### PR TITLE
Change color of .inserted 

### DIFF
--- a/guide/assets/css/main.css
+++ b/guide/assets/css/main.css
@@ -150,7 +150,7 @@ body.close #theme-toggle-button {
 }
 
 .token.inserted {
-	color: #42b983;
+	color: #00ab58;
 	border-width: 0;
 	transition: color 0.2s ease-in-out;
 }

--- a/guide/assets/css/main.css
+++ b/guide/assets/css/main.css
@@ -150,7 +150,7 @@ body.close #theme-toggle-button {
 }
 
 .token.inserted {
-	color: #00ab58;
+	color: #00b311;
 	border-width: 0;
 	transition: color 0.2s ease-in-out;
 }


### PR DESCRIPTION
The old color (in my opinion) was a bit too light, giving it the feel of a comment; a darker color would help improve its clarity.

Old:
![image](https://user-images.githubusercontent.com/16544254/35864185-08c831c6-0b1f-11e8-86d0-a53c97c8f8aa.png)

New:
![image](https://user-images.githubusercontent.com/16544254/35864174-ff585a80-0b1e-11e8-93d3-5c281ca17b2a.png)
