### PR TITLE
Add bot restart and user tagging examples

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,6 @@ Feel free to add on to this list as you see fit. Make sure to cross things off a
 
 * Frequently requested topic guides
 	* How to navigate the d.js docs (hoo boi)
-	* Bot restart command (examples page)
 	* Reaction menu example
 	* Embeds
 	* Permission overwrites (roles, members, adding, deleting, etc.)

--- a/guide/popular-topics/common-questions.md
+++ b/guide/popular-topics/common-questions.md
@@ -101,8 +101,9 @@ user.send('<content>');
 ### How do I tag a certain user in a message?
 
 ```js
-const user = <client>.users.get('<id>');
+const user = <message>.mentions.users.first();
 <message>.channel.send(`Hi, ${user}.`);
+<message>.channel.send('Hi, <@user id>.');
 ```
 
 <p class="tip">If you want to tag the user who sent the message, you can use `<message>.reply()`. For example: `<message>.reply('hi.')` would result in `@User, hi.`. If you want to insert the tag elsewhere, you can store `<message>.author` as your `user` variable and use the original example.</p>
@@ -150,4 +151,4 @@ process.exit();
 
 ### What is the difference between a User and a GuildMember?
 
-A lot of users get confused as to what the difference between Users and GuildMembers is. The simple answer is that a User represent a global Discord user and a GuildMember represents a Discord user on a specific server. That means only GuildMembers can have permissions, roles, and nicknames, for example, because all these things are server-bound information that could be different on every server that user is in.
+A lot of users get confused as to what the difference between Users and GuildMembers is. The simple answer is that a User represents a global Discord user and a GuildMember represents a Discord user on a specific server. That means only GuildMembers can have permissions, roles, and nicknames, for example, because all of these things are server-bound information that could be different on each server that user is in.

--- a/guide/popular-topics/common-questions.md
+++ b/guide/popular-topics/common-questions.md
@@ -98,6 +98,17 @@ user.send('<content>');
 
 <p class="tip">If you want to DM the user who sent the message, you can use `<message>.author.send()`.</p>
 
+### How do I tag a certain user in a message?
+
+```js
+const user = <client>.users.get('<id>');
+<message>.channel.send(`Hi, ${user}.`);
+```
+
+<p class="tip">If you want to tag the user who sent the message, you can use `<message>.reply()`. For example: `<message>.reply('hi.')` would result in `@User, hi.`. If you want to insert the tag elsewhere, you can store `<message>.author` as your `user` variable and use the original example.</p>
+
+<p class="tip">Tags inside certain areas of an embed may display correctly, but will not actually ping the user. Tags inside other certain areas of an embed will display the raw string instead (e.g. `<@123456789012345678>`).</p>
+
 ### How do I prompt the user for additional input?
 
 ```js
@@ -121,11 +132,21 @@ user.send('<content>');
 ```js
 <message>.channel.send('My message to react to.').then(sentMessage => {
 	sentMessage.react('👍');
-	sentMessage.react(<client>.emojis.get('<id>'));
+	sentMessage.react('<emoji id>');
 });
 ```
 
 <p class="tip">If you want to learn more about reactions, check out [this dedicated guide on reactions](/popular-topics/reactions)!</p>
+
+### How do I create a restart command?
+
+```js
+process.exit();
+```
+
+<p class="tip">`process.exit()` will only kill your Node process, but when using [PM2](http://pm2.keymetrics.io/), it will restart the process whenever it gets killed. You can read our guide on PM2 [here](/improving-dev-environment/pm2).</p>
+
+<p class="warning">Be sure to [limit this to your own ID](/popular-topics/common-questions?id=how-do-i-limit-a-command-to-a-single-user) so that other users can't restart your bot!</p>
 
 ### What is the difference between a User and a GuildMember?
 


### PR DESCRIPTION
2 simple examples that are asked almost daily in the support channels, as well as some `<p class="tip">` tags to accompany them with relevant, useful info. Also updated the reaction adding example, since you can just directly insert an emoji ID if you have that, instead of using `client.emojis.get('<id>')`.