### PR TITLE
fixing a typo and explaining possible errors in the music bot example

### DIFF
--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -21,13 +21,15 @@ npm install --save node-opus
 If you get an error that says 'FFMPEG not found', this can be resolved by installing ffmpeg.
 
 On Debian / Ubuntu:
+
 ```
 sudo apt-get install ffmpeg
 ```
 
 On Windows:
+
 ```
-npm install ffmpeg-binaries
+npm install ffmpeg-binaries --save
 ```
 
 Additionally, there have been reports that playing audio in this way from the Ubuntu subsystem offered by Windows 10 does not work.

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -18,8 +18,14 @@ If you get an error that says 'OPUS_ENGINE_MISSING', you'll need to install one 
 npm install --save node-opus
 ```
 
-If you get an error that says 'FFMPEG not found', this can be resolved by installing the `ffmpeg-binaries` package.
+If you get an error that says 'FFMPEG not found', this can be resolved by installing ffmpeg.
 
+On Debian / Ubuntu:
+```
+sudo apt-get install ffmpeg
+```
+
+On Windows:
 ```
 npm install ffmpeg-binaries
 ```

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -4,11 +4,27 @@
 
 ## Play music from YouTube
 
-Here's a short example of a command that connects to a voice channel, plays a song, and exits when it's done. You'll need to install the `ytdl-code` package in order to run this.
+Here's a short example of a command that connects to a voice channel, plays a song, and exits when it's done.
+
+In order to run this, you'll need to have `ytdl-core` installed.
 
 ```
 npm install --save ytdl-core
 ```
+
+If you get an error that says 'OPUS_ENGINE_MISSING', you'll need to install one of the opus packages discord.js recommends.
+
+```
+npm install --save node-opus
+```
+
+If you get an error that says 'FFMPEG not found', this can be resolved by installing the `ffmpeg-binaries` package.
+
+```
+npm install ffmpeg-binaries
+```
+
+Additionally, there have been reports that playing audio in this way from the Ubuntu subsystem offered by Windows 10 does not work.
 
 ```js
 const Discord = require('discord.js');


### PR DESCRIPTION
I saw some people talking about having trouble with the music bot example, and tried it out for myself on a fresh install.  I ran into a few issues when following the exact words of the tutorial, and tried to clear up the 2 errors that will probably pop up if someone's just copy-pasting the code and hasn't worked with discord.js before.  

The other thing I've seen firsthand from my own experience, as well as in conversations I lurked through in the discord server, is that this does not work in the Ubuntu subsystem for Windows 10. I'd like to put a clearer reason / explanation for why this doesn't work, but I don't have one.  I just know that playing audio this way even with a totally clean environment in the Ubuntu subsystem and following all the steps perfectly does not work.

Oh, and `ytdl-core` was called `ytdl-code`.