### PR TITLE
Reactions: Listenting on old Messages: account for MESSAGE_REACTION_REMOVE with empty usercache

### DIFF
--- a/code-samples/popular-topics/reactions/raw-event.js
+++ b/code-samples/popular-topics/reactions/raw-event.js
@@ -16,11 +16,16 @@ client.on('raw', async event => {
 	const { d: data } = event;
 	const user = client.users.get(data.user_id);
 	const channel = client.channels.get(data.channel_id) || await user.createDM();
+	let message = channel.messages.get(data.message_id);
 
-	if (channel.messages.has(data.message_id)) return;
-
-	const message = await channel.fetchMessage(data.message_id);
 	const emojiKey = (data.emoji.id) ? `${data.emoji.name}:${data.emoji.id}` : data.emoji.name;
+
+	if (event.t === 'MESSAGE_REACTION_REMOVE' && message && message.reactions.get(emojiKey) && message.reactions.get(emojiKey).users.size) return;
+	if (event.t === 'MESSAGE_REACTION_ADD' && message) return;
+
+	if (!message) {
+		message = await channel.fetchMessage(data.message_id);
+	}
 	let reaction = message.reactions.get(emojiKey);
 
 	if (!reaction) {

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -276,7 +276,7 @@ Now we fetch the message if it isn't cached and the actual reaction from the mes
 if(!message) {
 	message = await channel.fetchMessage(data.message_id);
 }
-let const = message.reactions.get(emojiKey);
+const reaction = message.reactions.get(emojiKey);
 ```
 
 <tip>In the master branch/v12, reactions are keyed by their ID or name only, not in a `name:ID` format.</tip>

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -248,26 +248,35 @@ This will prevent your code from trying to build data that isn't relevant to tha
 const { d: data } = event;
 const user = client.users.get(data.user_id);
 const channel = client.channels.get(data.channel_id) || await user.createDM();
-
-if (channel.messages.has(data.message_id)) return;
-
-const message = await channel.fetchMessage(data.message_id);
+let message = channel.messages.get(data.message_id);
 ```
-
-The if statement in the middle plays an important role; it prevents us from re-emitting the event for both uncached *and* cached messages. Without this, your reaction events would execute twice for a single reaction if the message was already cached.
-
 A custom emoji contains both a name and an ID, while a unicode emoji contains just a name. Since custom emoji reactions are keyed in a `name:ID` format and unicode emoji reactions are keyed by their name, you'll have to do something like this to set the right emoji for this event:
 
 ```js
 const emojiKey = (data.emoji.id) ? `${data.emoji.name}:${data.emoji.id}` : data.emoji.name;
 ```
-
 We are checking for `emoji.id` because a unicode emoji won't have an ID inside the emoji object. Next we are using template literals to combine the name and the ID to construct the proper key format `name:ID` we need to get the custom emoji reaction.
 
-All that's left is to fetch the actual reaction from the message and emit the event.
+With the following if statements we make sure to return if the library already emits those events properly.
+In the case of `MESSAGE_REACTION_REMOVE` this is a cached message with a populated usercache.
+In the case of `MESSAGE_REACTION_ADD` this is a cached message.
+
+WIthout this your reaction events would execute twice for a single reaction or not at all, depending on the combination of met conditions.
 
 ```js
-const reaction = message.reactions.get(emojiKey);
+if (event.t === 'MESSAGE_REACTION_REMOVE' && message && message.reactions.get(emojiKey) && message.reactions.get(emojiKey).users.size) return;
+if (event.t === 'MESSAGE_REACTION_ADD' && message) return;
+
+```
+Now we fetch the message if it isn't cached and the actual reaction from the message.
+
+<!-- eslint-skip -->
+
+```js
+if(!message) {
+	message = await channel.fetchMessage(data.message_id);
+}
+let const = message.reactions.get(emojiKey);
 ```
 
 <tip>In the master branch/v12, reactions are keyed by their ID or name only, not in a `name:ID` format.</tip>

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -261,7 +261,7 @@ With the following if statements we make sure to return if the library already e
 In the case of `MESSAGE_REACTION_REMOVE` this is a cached message with a populated usercache.
 In the case of `MESSAGE_REACTION_ADD` this is a cached message.
 
-WIthout this your reaction events would execute twice for a single reaction or not at all, depending on the combination of met conditions.
+Without this your reaction events would execute twice for a single reaction or not at all, depending on the combination of met conditions.
 
 ```js
 if (event.t === 'MESSAGE_REACTION_REMOVE' && message && message.reactions.get(emojiKey) && message.reactions.get(emojiKey).users.size) return;


### PR DESCRIPTION
The current version of the guide simply returns if the message is cached.
If the message is cached but the usercache on the specified MessageReaction is not populated, the lib will not emmit the event, meaning we are left with a not emitted `MESSAGE_REACTION_REMOVE`.

This is is the case if the message gets cached by the guides raw event script.
Meaning on an uncached message the first reaction will properly emit,  but any following removal of uncached Reactions will not.
Accomplishing this required a bit of shifting in the guide

This PR attempts to fix this issue by letting the guides raw event script handle those cases.
Caveats: The only case breaking this approach is MESSAGE_REACTION_REMOVE on an uncached message inside DM

Which can not be handled due to guide/code-samples/popular-topics/reactions/raw-event.js 
requiring a guild in its constructor.

- [ ] Review for cleaner syntax