### PR TITLE
Updating rest-api page to use Node-fetch instead of snekfetch

### DIFF
--- a/code-samples/additional-info/rest-api/index.js
+++ b/code-samples/additional-info/rest-api/index.js
@@ -1,5 +1,6 @@
 const Discord = require('discord.js');
-const snekfetch = require('snekfetch');
+const fetch = require('node-fetch');
+const querystring = require('querystring');
 
 const client = new Discord.Client();
 const prefix = '!';
@@ -17,7 +18,7 @@ client.on('message', async message => {
 	const command = args.shift().toLowerCase();
 
 	if (command === 'cat') {
-		const { body } = await snekfetch.get('https://aws.random.cat/meow');
+		const { body } = await fetch('https://aws.random.cat/meow').then(response => response.json());
 
 		message.channel.send(body.file);
 	}
@@ -26,7 +27,9 @@ client.on('message', async message => {
 			return message.channel.send('You need to supply a search term!');
 		}
 
-		const { body } = await snekfetch.get('https://api.urbandictionary.com/v0/define').query({ term: args.join(' ') });
+		const query = querystring.stringify({ term: args.join(' ') });
+
+		const { body } = await fetch.get(`https://api.urbandictionary.com/v0/define${query}`).then(response => response.json());
 
 		if (!body.list.length) {
 			return message.channel.send(`No results found for **${args.join(' ')}**.`);


### PR DESCRIPTION
As mentioned on the [snekfetch](https://www.npmjs.com/package/snekfetch) npm package, it has been deprecated and suggests to use node-fetch instead.

I have updated the rest-api article to use node-fetch instead of snekfetch.