### PR TITLE
Avoid using abbreviated NPM commands

### DIFF
--- a/guide/commando/README.md
+++ b/guide/commando/README.md
@@ -2,8 +2,8 @@
 
 When you got your first bot up and running with Discord.js, you should've installed Discord.js using npm, Node.js' Package Manager. The same applies to Commando, which must be separately installed. You can do this in one of two ways:
 
-Stable (v11): `npm i discord.js-commando`  
-Master (v12): `npm i discordjs/Commando`
+Stable (v11): `npm install discord.js-commando`  
+Master (v12): `npm install discordjs/Commando`
 
 <warning>You need at least Node.js version 8.0.0 to use Commando. Master branch will also require you to install [Git](https://git-scm.com/downloads).</warning>
 

--- a/guide/improving-dev-environment/pm2.md
+++ b/guide/improving-dev-environment/pm2.md
@@ -9,7 +9,7 @@ PM2 is a process manager. It manages your applications' states, so you can start
 You can install PM2 via npm:
 
 ```bash
-npm i -g pm2
+npm install --global pm2
 ```
 
 Or, if you use Yarn:
@@ -57,7 +57,7 @@ The initial steps to run differ per OS. In this guide, we'll cover those for Win
 **Install the [pm2-windows-service](https://www.npmjs.com/package/pm2-windows-service) package from npm:**
 
 ```bash
-npm i -g pm2-windows-service
+npm install --global pm2-windows-service
 ```
 
 **After installation has finished, install the service by running the following command:**

--- a/guide/preparations/setting-up-a-linter.md
+++ b/guide/preparations/setting-up-a-linter.md
@@ -18,10 +18,10 @@ First, be sure to install the [ESLint package](https://www.npmjs.com/package/esl
 
 ```bash
 # locally
-npm i eslint
+npm install eslint
 
 # globally
-npm i -g eslint
+npm install --global eslint
 ```
 
 Afterwards, install the appropriate plugin(s) for your editor of choice.


### PR DESCRIPTION
In a guide such as this, it's best to avoid using abbreviated commands whenever possible, since it's likely to be used by people who are new to the ecosystem or currently learning it. This PR just replaces the NPM install commands to use the non-abbreviated commands/params.