### PR TITLE
refactor: change all instances of .on('ready') to .once('ready')

### DIFF
--- a/code-samples/additional-info/rest-api/index.js
+++ b/code-samples/additional-info/rest-api/index.js
@@ -6,7 +6,7 @@ const prefix = '!';
 
 const trim = (str, max) => (str.length > max) ? `${str.slice(0, max - 3)}...` : str;
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/command-handling/adding-features/index.js
+++ b/code-samples/command-handling/adding-features/index.js
@@ -14,7 +14,7 @@ for (const file of commandFiles) {
 
 const cooldowns = new Discord.Collection();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/command-handling/dynamic-commands/index.js
+++ b/code-samples/command-handling/dynamic-commands/index.js
@@ -12,7 +12,7 @@ for (const file of commandFiles) {
 	client.commands.set(command.name, command);
 }
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/command-handling/file-setup/index.js
+++ b/code-samples/command-handling/file-setup/index.js
@@ -12,7 +12,7 @@ for (const file of commandFiles) {
 	client.commands.set(command.name, command);
 }
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/commando/getting-started/index.js
+++ b/code-samples/commando/getting-started/index.js
@@ -16,7 +16,7 @@ client.registry
 	.registerDefaultCommands()
 	.registerCommandsIn(path.join(__dirname, 'commands'));
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log(`Logged in as ${client.user.tag}! (${client.user.id})`);
 	client.user.setActivity('with Commando');
 });

--- a/code-samples/creating-your-bot/adding-more-commands/index.js
+++ b/code-samples/creating-your-bot/adding-more-commands/index.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const { prefix, token } = require('./config.json');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/creating-your-bot/commands-with-user-input/index.js
+++ b/code-samples/creating-your-bot/commands-with-user-input/index.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const { prefix, token } = require('./config.json');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/creating-your-bot/configuration-files/index.js
+++ b/code-samples/creating-your-bot/configuration-files/index.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const config = require('./config.json');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/creating-your-bot/up-and-running/index.js
+++ b/code-samples/creating-your-bot/up-and-running/index.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/popular-topics/canvas/index.js
+++ b/code-samples/popular-topics/canvas/index.js
@@ -4,7 +4,7 @@ const snekfetch = require('snekfetch');
 
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/popular-topics/permissions/index.js
+++ b/code-samples/popular-topics/permissions/index.js
@@ -2,7 +2,7 @@ const util = require('util');
 const { Client, Permissions } = require('discord.js');
 const client = new Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/popular-topics/reactions/awaiting-reactions.js
+++ b/code-samples/popular-topics/reactions/awaiting-reactions.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/popular-topics/reactions/basic-reacting.js
+++ b/code-samples/popular-topics/reactions/basic-reacting.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/code-samples/popular-topics/reactions/raw-event.js
+++ b/code-samples/popular-topics/reactions/raw-event.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/guide/additional-info/async-await.md
+++ b/guide/additional-info/async-await.md
@@ -79,7 +79,7 @@ const client = new Discord.Client();
 
 const prefix = '?';
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('I am ready!');
 });
 

--- a/guide/additional-info/es6-syntax.md
+++ b/guide/additional-info/es6-syntax.md
@@ -9,7 +9,7 @@ const Discord = require('discord.js');
 const client = new Discord.Client();
 const config = require('./config.json');
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 
@@ -130,7 +130,7 @@ Here are some examples of ways you can benefit from arrow functions over regular
 
 ```js
 // regular functions, full ES5
-client.on('ready', function() {
+client.once('ready', function() {
 	console.log('Ready!');
 });
 
@@ -156,7 +156,7 @@ var collector = message.createReactionCollector(filter, { time: 15000 });
 
 ```js
 // arrow functions, full ES6
-client.on('ready', () => console.log('Ready!'));
+client.once('ready', () => console.log('Ready!'));
 
 client.on('typingStart', (channel, user) => console.log(`${user} started typing in ${channel}`));
 

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -24,7 +24,7 @@ const Discord = require('discord.js');
 const client = new Discord.Client();
 const prefix = '!';
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -10,7 +10,7 @@ const { prefix, token } = require('./config.json');
 
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/guide/commando/README.md
+++ b/guide/commando/README.md
@@ -81,7 +81,7 @@ Should you want to disable a default command, such as if you wanted to make your
 Next, you're going to need to create a ready event and an error event, as usual.
 
 ```js
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log(`Logged in as ${client.user.tag}! (${client.user.id})`);
 	client.user.setActivity('with Commando');
 });

--- a/guide/creating-your-bot/README.md
+++ b/guide/creating-your-bot/README.md
@@ -40,9 +40,7 @@ const Discord = require('discord.js');
 const client = new Discord.Client();
 
 // when the client is ready, run this code
-// this event will trigger whenever your bot:
-// - finishes logging in
-// - reconnects after disconnecting
+// this event will only trigger one time after logging in
 client.once('ready', () => {
 	console.log('Ready!');
 });
@@ -63,7 +61,7 @@ client.on('message', message => {
 });
 ```
 
-Save the file, go back to your console, and start the process up again. Whenever a message is sent inside a channel your bot has access to, the message's content will be logged to your console. Go ahead and test it out!
+Notice how the code uses `.on` rather than `.once` like in the ready event. This means that it can trigger multiple times. Save the file, go back to your console, and start the process up again. Whenever a message is sent inside a channel your bot has access to, the message's content will be logged to your console. Go ahead and test it out!
 
 <tip>Inside your console, you can press the up arrow on your keyboard to bring up the latest commands you've run. Pressing `Up` and then `Enter` after closing the process is a nice, quick way to start it up again (as opposed to typing out the name each time).</tip>
 

--- a/guide/creating-your-bot/README.md
+++ b/guide/creating-your-bot/README.md
@@ -18,7 +18,7 @@ Once you've created a new file, do a quick check to see if you have everything s
 const Discord = require('discord.js');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 
@@ -43,7 +43,7 @@ const client = new Discord.Client();
 // this event will trigger whenever your bot:
 // - finishes logging in
 // - reconnects after disconnecting
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/guide/popular-topics/canvas.md
+++ b/guide/popular-topics/canvas.md
@@ -33,7 +33,7 @@ const snekfetch = require('snekfetch');
 
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -8,7 +8,7 @@ Here's the base code we'll be using:
 const Discord = require('discord.js');
 const client = new Discord.Client();
 
-client.on('ready', () => {
+client.once('ready', () => {
 	console.log('Ready!');
 });
 


### PR DESCRIPTION
There were some recent issues that were brought up in the main discord.js repo about how ready event fires more than once. If people that follow the guide begin to use `.once()` for ready, then it could prevent issues like that in the future. 