### PR TITLE
Adding the reaction to an uncached message

### DIFF
--- a/code-samples/popular-topics/reactions/raw-event.js
+++ b/code-samples/popular-topics/reactions/raw-event.js
@@ -28,6 +28,8 @@ client.on('raw', async event => {
 		reaction = new Discord.MessageReaction(message, emoji, 1, data.user_id === client.user.id);
 	}
 
+	if (event.t === 'MESSAGE_REACTION_ADD') message._addReaction(reaction.emoji, user);
+
 	client.emit(events[event.t], reaction, user);
 });
 


### PR DESCRIPTION
Reacting to an uncached message would cache the message via:
https://github.com/discordjs/guide/blob/9fa60ac09b75d479e64cc1b89c5676fca558a7a6/code-samples/popular-topics/reactions/raw-event.js#L22

Then, when you unreact to that same message, it will not fire the `messageReactionRemove` event through the `raw` as it has been cached. It will also not be fired normally as [`reaction`](https://github.com/discordjs/discord.js/blob/stable/src/client/actions/MessageReactionRemove.js#L23) is [`null`](https://github.com/discordjs/discord.js/blob/stable/src/structures/Message.js#L596), because the reaction hasn't actually been added to the message.

A workaround to this issue would be to call [`Message#_addReaction(emoji, user)`](https://github.com/discordjs/discord.js/blob/stable/src/structures/Message.js#L567-L582) when an uncached message has been reacted to, which is done in this PR.