### PR TITLE
Update Permissions: Add missing permissions cause

### DIFF
--- a/guide/popular-topics/permissions-extended.md
+++ b/guide/popular-topics/permissions-extended.md
@@ -65,6 +65,7 @@ For voice channels this same principle applies to the permission `CONNECT` as we
 During your development you will likely run into `DiscordAPIError: Missing Permissions` at some point. This error can be caused by one of the following:
 
 - Your bot is missing the needed permission to execute this action in it's calculated base or final permissions (requirement changes based on the type of action you are trying to execute).
+- You provided an invalid permission number while trying to create overwrites. (The calculator on the apps page returns decimal values while the developer documentation lists the flags in hex. Make sure you are not mixing the two and don't use the hex prefix `0x` where not applicable)
 - It is trying to execute an action on a guild member with a role higher than or equal to your bots highest role.
 - It is trying to modify or assign a role that is higher than or equal to its highest role.
 - It is trying to execute a forbidden action on the server owner.


### PR DESCRIPTION
The added cause was found on the discord server during support and not a thing we previously thought about.
Somehow the prefixing of a decimal with the hex indicator `0x` causes the API to reject the patch request for the overwrite update.  
  
Note: I'm not too familiar with the internal workings at this point and can just assume that the bots permissions are checked against the invalid permission number resulting in a rejected request. Since invalid permission values are usually accepted and used as-is and as applicable I'm not entirely sure of the underlying circumstances causing an error instead.