### PR TITLE
Changed MDN link.

### DIFF
--- a/guide/popular-topics/canvas.md
+++ b/guide/popular-topics/canvas.md
@@ -70,7 +70,7 @@ What this will do is trigger the `guildMemberAdd` event while passing in the mes
 The end goal will be to display the user's avatar, username, and a simple "Welcome!" message when they join. After importing the Canvas module and initializing it, you should load the images. With Canvas, you have to specify where the image comes from first, naturally, and then specify how it gets loaded into the actual Canvas using `ctx`, which is what you will use to interact with Canvas.
 
 ::: tip
-`node-canvas` works almost identical to HTML5 Canvas. You can read the HTML5 Canvas tutorials on [w3Schools](https://www.w3schools.com/html/html5_canvas.asp) and [MDN](https://developer.mozilla.org/kab/docs/Web/API/Canvas_API) for more information later!
+`node-canvas` works almost identical to HTML5 Canvas. You can read the HTML5 Canvas tutorials on [w3Schools](https://www.w3schools.com/html/html5_canvas.asp) and [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) for more information later!
 :::
 
 <!-- eslint-disable require-await -->


### PR DESCRIPTION
The link to the Canvas API (on MDN) is in a different language that does not match the default language of the guide, English.

The link directs the user to MDN's website under this language: https://developer.mozilla.org/kab/docs/Web/API/Canvas_API