### PR TITLE
Fix the Mention prefix example

### DIFF
--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -84,8 +84,10 @@ const Discord = require('discord.js');
 const client = new Discord.Client();
 const prefix = '!';
 
+const escapeRegex = require('escape-string-regexp');
+
 client.on('message', message => {
-	const prefixRegex = new RegExp(`^(<@!?${client.user.id}>|\\${prefix})\\s*`);
+	const prefixRegex = new RegExp(`^(<@!?${client.user.id}>|${escapeRegex(prefix)})\\s*`);
 	if (!prefixRegex.test(message.content)) return;
 
 	const [, matchedPrefix] = message.content.match(prefixRegex);

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -76,6 +76,10 @@ process.on('unhandledRejection', error => console.error('Uncaught Promise Reject
 
 ## Mention prefix
 
+::: tip
+The `escapeRegex` function is used to convert special characters into literal characters by escaping them, so that they don't terminate the pattern within the [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
+:::
+
 When a user adds your bot to their server, they may not immediately know what the prefix is. This is why it's a good idea to allow your bot to be triggered by either a set prefix, or by pinging them. In addition, it's also a good idea to have a command that displays the available prefixes.
 
 ```js
@@ -103,9 +107,6 @@ client.on('message', message => {
 
 client.login('your-token-goes-here');
 ```
-
-::: tip
-The `escapeRegex` function is used to convert special characters into literal characters by escaping them, so that they don't terminate the pattern within the [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
 
 ::: tip
 If you aren't familiar with the syntax used on the `const [, matchedPrefix] = ...` line, that's called "array destructuring". Feel free to read more about it in the [ES6 syntax](/additional-info/es6-syntax.md#array-destructuring) guide!

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -84,7 +84,7 @@ const Discord = require('discord.js');
 const client = new Discord.Client();
 const prefix = '!';
 
-const escapeRegex = require('escape-string-regexp');
+const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 client.on('message', message => {
 	const prefixRegex = new RegExp(`^(<@!?${client.user.id}>|${escapeRegex(prefix)})\\s*`);
@@ -103,6 +103,9 @@ client.on('message', message => {
 
 client.login('your-token-goes-here');
 ```
+
+::: tip
+The `escapeRegex` arrow function is a simple function used to remove special characters, that would normally result in an error, from a [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
 
 ::: tip
 If you aren't familiar with the syntax used on the `const [, matchedPrefix] = ...` line, that's called "array destructuring". Feel free to read more about it in the [ES6 syntax](/additional-info/es6-syntax.md#array-destructuring) guide!

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -84,7 +84,7 @@ const Discord = require('discord.js');
 const client = new Discord.Client();
 const prefix = '!';
 
-const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const escapeRegex = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 client.on('message', message => {
 	const prefixRegex = new RegExp(`^(<@!?${client.user.id}>|${escapeRegex(prefix)})\\s*`);

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -105,7 +105,7 @@ client.login('your-token-goes-here');
 ```
 
 ::: tip
-The `escapeRegex` arrow function is a simple function used to remove special characters, that would normally result in an error, from a [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
+The `escapeRegex` function is used to convert special characters into literal characters by escaping them, so that they don't terminate the pattern within the [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
 
 ::: tip
 If you aren't familiar with the syntax used on the `const [, matchedPrefix] = ...` line, that's called "array destructuring". Feel free to read more about it in the [ES6 syntax](/additional-info/es6-syntax.md#array-destructuring) guide!

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -76,10 +76,6 @@ process.on('unhandledRejection', error => console.error('Uncaught Promise Reject
 
 ## Mention prefix
 
-::: tip
-The `escapeRegex` function is used to convert special characters into literal characters by escaping them, so that they don't terminate the pattern within the [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
-:::
-
 When a user adds your bot to their server, they may not immediately know what the prefix is. This is why it's a good idea to allow your bot to be triggered by either a set prefix, or by pinging them. In addition, it's also a good idea to have a command that displays the available prefixes.
 
 ```js
@@ -107,6 +103,10 @@ client.on('message', message => {
 
 client.login('your-token-goes-here');
 ```
+
+::: tip
+The `escapeRegex` function is used to convert special characters into literal characters by escaping them, so that they don't terminate the pattern within the [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)!
+:::
 
 ::: tip
 If you aren't familiar with the syntax used on the `const [, matchedPrefix] = ...` line, that's called "array destructuring". Feel free to read more about it in the [ES6 syntax](/additional-info/es6-syntax.md#array-destructuring) guide!


### PR DESCRIPTION
Hello, 

Since I am not the biggest fan of Regex I never got to make a "prefix mention" myself, so after a quick Google search I stumbled upon the Discord Guide example and started using it. After a while, I was testing something inside of my Command Handler and changed the prefix of the bot to `r!`, in which, the given example on the Guide `r` gets escaped, completely breaking usage and forcing you to mention the bot. The escapes are obviously there so characters like `?` don't break it. After discussing with Space in the other-js-questions channel he recommended me to use the [`escape-string-regexp`](https://www.npmjs.com/package/escape-string-regexp) package.

So that is pretty much what this PR fixes, though I am unsure how to word a tip specifying what the used package does & specifying installation, let me know if I can add anything else.