### PR TITLE
Changes to v11 -> v12 Update Guide

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ Feel free to add on to this list as you see fit. Make sure to cross things off a
 * Frequently requested topic guides
 	* How to navigate the d.js docs (hoo boi)
 	* How to use APIs (general snekfetch/HTTP request guide and how to use that data)
+	* How to use permission overwrites (upon channel creation, setting/unsetting them, reading them, etc.)
 
 * Long-term plans
 	* OAuth guide

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@ Feel free to add on to this list as you see fit. Make sure to cross things off a
 	* Keyboard shortcuts for VSC/Atom/Sublime
 	* Useful packages for VSC/Atom/Sublime
 	* pm2
-	* GitKraken
 	* cmder/hyper/etc.
 	* package.json scripts
 
@@ -24,11 +23,17 @@ Feel free to add on to this list as you see fit. Make sure to cross things off a
 * Frequently asked questions section
 	* Difference between User and GuildMember
 	* Incoming breaking changes in v12 from v11
+	* Bot restart command
 
 * Frequently requested topic guides
 	* How to navigate the d.js docs (hoo boi)
-	* Bot restart command (common questions page)
+	* How to use APIs (general snekfetch/HTTP request guide and how to use that data)
 
 * Long-term plans
 	* OAuth guide
 	* Figure out how to make an OAuth dashboard (node, express, passport, vue maybe)
+
+* Misc.
+	* Set up Travis to lint the `code_samples` folder
+	* Test out docsify SSR on an alternate domain to check out how it works/if it's an improvement
+	* Dark theme? (insert lenny here)

--- a/guide/_sidebar.md
+++ b/guide/_sidebar.md
@@ -31,5 +31,6 @@
 	* [Additional information](/sharding/additional-information)
 	
 	* **Miscellaneous**
+	* [Changes in v12](/additional-info/changes-in-v12)
 	* [Collectors](/creating-your-bot/collectors)
 	* [ES6 syntax examples](/additional-info/es6-syntax)

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -4,13 +4,22 @@ If you weren't already aware, v12 is constantly in development, and you can even
 
 The section headers will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
 
+## Legend
+
+* All headers are named as `Class#propertyOrMethod`
+* The use of parenthesis designates optional inclusion. For example, `Channel#fetch(Pinned)Message(s)` means that this section will include changes for `Channel#fetchPinnedMessages`, `Channel#fetchMessages`, and `Channel#fetchMessage`.
+* The user of asterisks designates a wildcard. For example, `Channel#send***` means that this section will include changes for `Channel#sendMessage`, `Channel#sendFile`, `Channel#sendEmbed`, and so forth.
+
+## Breaking changes
+
 <p class="danger">This next bit is for me (Sanc) to keep track of the classes I've gone through and checked for breaking changes. Remove before making the PR.</p>
 
 * ClientUser
+* DiscordAPIError
+* DMChannel
 * Guild
 * Invite
-
-## Breaking changes
+* OAuth2Application
 
 <p class="danger">Before anything, it is important to note that discord.js v12 (and so forth) requires a **minimum** Node version of v8. If you aren't sure what Node version you're on, run `node -v` in your console and update if necessary.</p>
 
@@ -162,6 +171,10 @@ The second parameter in `clientUser.setPassword()` has been changed. The `oldPas
 ### ClientUser#unblock
 
 `clientUser.unblock()` has been removed entirely.
+
+### Collector#cleanup
+
+`collector.cleanup()` has been removed entirely.
 
 ### Guild#createChannel
 
@@ -344,7 +357,7 @@ The `OAuth2Application` class has been renamed to `ClientApplication`.
 
 ### OAuth2Application#reset
 
-`application.reset()` has been renamed to `application.resetSecret()`.
+`application.reset()` has been split up into `application.resetSecret()` and `application.resetToken()`.
 
 ### OAuth2Application#iconURL
 
@@ -453,3 +466,11 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 
 Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
+---
+
+## Additions
+
+<p class="danger">This next bit is for me (Sanc) to keep track of the classes I've gone through and checked for additions. Remove before making the PR.</p>
+
+* DiscordAPIError
+* DMChannel

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -40,7 +40,7 @@ TODO LATER CUZ I DON'T WANNA TOUCH THAT SHIT RN:
 * MessageCollector
 * MessageEmbed***
 
-<p class="danger">Before anything, it is important to note that discord.js v12 (and so forth) requires a **minimum** Node version of v8. If you aren't sure what Node version you're on, run `node -v` in your console and update if necessary.</p>
+<p class="danger">Before anything, it is important to note that discord.js v12 (and so forth) requires a **minimum** Node version of v10. If you aren't sure what Node version you're on, run `node -v` in your console and update if necessary.</p>
 
 ### Attachment
 
@@ -120,6 +120,43 @@ All the `.send***()` methods have been removed in favor of one general `.send()`
 - client.fetchUser('123456789012345678');
 + client.users.fetch('123456789012345678');
 ```
+
+#### Client#browser
+
+`client.browser` has been removed entirely.
+
+#### Client#channels
+
+`client.channels` has been changed from a Collection to a DataStore.
+
+#### Client#emojis
+
+`client.emojis` has been changed from a Collection to a DataStore.
+
+#### Client#guilds
+
+`client.guilds` has been changed from a Collection to a DataStore.
+
+#### Client#ping
+
+`client.ping` has been moved to the WebSocketManager under `client.ws.ping`
+
+```diff
+- client.ping
++ client.ws.ping
+```
+
+#### Client#pings
+
+`client.pings` has been removed entirely.
+
+#### Client#presences
+
+`client.presences` has been removed entirely.
+
+#### Client#users
+
+`client.users` has been changed from a Collection to a DataStore.
 
 ### ClientUser
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -4,6 +4,8 @@ If you weren't already aware, v12 is constantly in development, and you can even
 
 The section headers will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
 
+<p class="danger">While this list has been carefully crafted, it may be incomplete! If you notice a pieces of missing or inaccurate data, we encourage you to [submit a pull request](https://github.com/Danktuary/Making-Bots-with-Discord.js)!</p>
+
 ## Legend
 
 * All headers are named as `Class#propertyOrMethod`
@@ -19,6 +21,9 @@ The section headers will be named after the v11 classes/methods/properties and w
 * DMChannel
 * GroupDMChannel
 * Guild
+* GuildAuditLogs
+* GuildAuditLogsEntry
+* GuildChannel
 * Invite
 * OAuth2Application
 
@@ -28,7 +33,9 @@ The section headers will be named after the v11 classes/methods/properties and w
 
 The `Attachment` class has been removed in favor of the `MessageAttachment` class.
 
-### Channel#send\*\*\*
+### Channel
+
+#### Channel#send\*\*\*
 
 All the `.send***()` methods were removed in favor of one general `.send()` method.
 
@@ -71,7 +78,7 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 + channel.send({ files: [new MessageAttachment('./file-one.png'), new MessageAttachment('./file-two.png')] });
 ```
 
-### Channel#fetch(Pinned)Message(s)
+#### Channel#fetch(Pinned)Message(s)
 
 `channel.fetchMessage()`, `channel.fetchMessages()`, and `channel.fetchPinnedMessages()` were all removed and transformed in the shape of DataStores.
 
@@ -90,7 +97,9 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 + channel.messages.fetchPinned();
 ```
 
-### Client#fetchUser
+### Client
+
+#### Client#fetchUser
 
 `client.fetchUser()` has been removed and transformed in the shape of a DataStore.
 
@@ -99,19 +108,21 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 + client.users.fetch('123456789012345678');
 ```
 
-### ClientUser#acceptInvite
+### ClientUser
+
+#### ClientUser#acceptInvite
 
 `clientUser.acceptInvite()` has been removed entirely.
 
-### ClientUser#addFriend
+#### ClientUser#addFriend
 
 `clientUser.addFriend()` has been removed entirely.
 
-### ClientUser#block
+#### ClientUser#block
 
 `clientUser.block()` has been removed entirely.
 
-### ClientUser#avatarURL
+#### ClientUser#avatarURL
 
 `clientUser.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -121,7 +132,7 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 + clientUser.avatarURL({ format: 'png', size: 1024 });
 ```
 
-### ClientUser#createGuild
+#### ClientUser#createGuild
 
 The second and third parameters in `clienrUser.createGuild()` have been changed/removed, leaving it with a total of two parameters. The `region` and `icon` parameters from v11 have been merged into an object as the second parameter.
 
@@ -130,7 +141,7 @@ The second and third parameters in `clienrUser.createGuild()` have been changed/
 + clientUser.createGuild('New server', { region: 'us-east', icon: './path/to/file.png' });
 ```
 
-### ClientUser#displayAvatarURL
+#### ClientUser#displayAvatarURL
 
 `clientUser.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -140,15 +151,15 @@ The second and third parameters in `clienrUser.createGuild()` have been changed/
 + clientUser.displayAvatarURL({ format: 'png', size: 1024 });
 ```
 
-### ClientUser#removeFriend
+#### ClientUser#removeFriend
 
 `clientUser.removeFriend()` has been removed entirely.
 
-### ClientUser#send\*\*\*
+#### ClientUser#send\*\*\*
 
 Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
-### ClientUser#setGame
+#### ClientUser#setGame
 
 `clientUser.setGame()` has been changed to `clientUser.setActivity()`. The second parameter is no longer for providing a streaming URL, but rather an object that allows you to provide the URL and activity type.
 
@@ -160,7 +171,7 @@ Just like the `Channel#send***` methods, all the `.send***()` methods were remov
 + clientUser.setActivity('with my bot friends!', { url: 'https://twitch.tv/your/stream/here', type: 'STREAMING' });
 ```
 
-### ClientUser#setPassword
+#### ClientUser#setPassword
 
 The second parameter in `clientUser.setPassword()` has been changed. The `oldPassword` parameter from v11 has been changed into an object as the second parameter.
 
@@ -169,15 +180,19 @@ The second parameter in `clientUser.setPassword()` has been changed. The `oldPas
 + clientUser.setPassword('newpassword', { oldPassword: 'oldpassword', mfaCode: '123456' });
 ```
 
-### ClientUser#unblock
+#### ClientUser#unblock
 
 `clientUser.unblock()` has been removed entirely.
 
-### Collector#cleanup
+### Collector
+
+#### Collector#cleanup
 
 `collector.cleanup()` has been removed entirely.
 
-### GroupDMChannel#iconURL
+### GroupDMChannel
+
+#### GroupDMChannel#iconURL
 
 `groupDM.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -187,8 +202,7 @@ The second parameter in `clientUser.setPassword()` has been changed. The `oldPas
 + groupDM.iconURL({ format: 'png', size: 1024 });
 ```
 
-### GroupDMChannel#addUser
-
+#### GroupDMChannel#addUser
 
 The first and second parameters in `groupDM.addUser()` have been changed/removed, leaving it with a total of one parameter. The `accessTokenOrID` and `reason` parameters from v11 have been merged into an object as the first parameter.
 
@@ -198,7 +212,9 @@ The first and second parameters in `groupDM.addUser()` have been changed/removed
 + groupDM.addUser({ user: '123456789012345678', accessToken: 'access-token', nick: 'My Best Friend!' });
 ```
 
-### Guild#ban
+### Guild
+
+#### Guild#ban
 
 The second parameter in `guild.ban()` has been changed. The `options` parameter no longer accepts a number, nor a string.
 
@@ -210,7 +226,7 @@ The second parameter in `guild.ban()` has been changed. The `options` parameter 
 + guild.ban(user, { reason: 'Too much trolling' });
 ```
 
-### Guild#createChannel
+#### Guild#createChannel
 
 The third and fourth parameters in `guild.createChannel()` have been changed/removed, leaving it with a total of three parameters. The `overwrites` and `reason` parameters from v11 have been merged into an object as the third parameter.
 
@@ -219,7 +235,7 @@ The third and fourth parameters in `guild.createChannel()` have been changed/rem
 + guild.createChannel('new-channel', 'text', { overwrites: permissionOverwriteArray, reason: 'New channel added for fun!' });
 ```
 
-### Guild#createEmoji
+#### Guild#createEmoji
 
 The third and fourth parameters in `guild.createEmoji()` have been changed/removed, leaving it with a total of three parameters. The `roles` and `reason` parameters from v11 have been merged into an object as the third parameter.
 
@@ -228,7 +244,7 @@ The third and fourth parameters in `guild.createEmoji()` have been changed/remov
 + guild.createEmoji('./path/to/file.png', 'NewEmoji', { roles: collectionOfRoles, reason: 'New emoji added for fun!' });
 ```
 
-### Guild#createRole
+#### Guild#createRole
 
 The first and second parameters in `guild.createRole()` have been changed/removed, leaving it with a total of one parameter. The `data` and `reason` parameters from v11 have been moved into an object as the first parameter.
 
@@ -237,7 +253,7 @@ The first and second parameters in `guild.createRole()` have been changed/remove
 + guild.createRole({ data: roleData, reason: 'New staff role!' });
 ```
 
-### Guild#deleteEmoji
+#### Guild#deleteEmoji
 
 `Guild.deleteEmoji()` has been removed and transformed in the shape of a DataStore.
 
@@ -246,7 +262,7 @@ The first and second parameters in `guild.createRole()` have been changed/remove
 + guild.emojis.resolve('123456789012345678').delete();
 ```
 
-### Guild#defaultChannel
+#### Guild#defaultChannel
 
 Unfortunately, "default" channels don't exist in Discord anymore, and as such, the `guild.defaultChannel` property has been removed with no alternative.
 
@@ -259,7 +275,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 <p class="tip">Not sure how to set up a database? Check out [this page](/sequelize/)!</p>
 
-### Guild#fetchBans
+#### Guild#fetchBans
 
 `guild.fetchBans()` will return a `Collection` of objects in v12, whereas v11 would return a `Collection` of `User` objects.
 
@@ -268,7 +284,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 + guild.fetchBans().then(bans => console.log(`${bans.first().user.tag} was banned because "${bans.first().reason}"`));
 ```
 
-### Guild#fetchMember(s)
+#### Guild#fetchMember(s)
 
 `guild.fetchMember()` and `guild.fetchMembers()` were both removed and transformed in the shape of DataStores. In addition, `guild.members.fetch()` will return a `Collection` of `GuildMember` objects in v12, whereas v11 would return a `Guild` object.
 
@@ -282,7 +298,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 + guild.members.fetch();
 ```
 
-### Guild#fetchWebhooks
+#### Guild#fetchWebhooks
 
 `guild.fetchWebhooks()` is now a Promise that returns a `Collection` of `Webhook`s.
 
@@ -291,7 +307,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 + guild.fetchWebhooks().then(webhooks => webhooks.first());
 ```
 
-### Guild#iconURL
+#### Guild#iconURL
 
 `guild.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -301,7 +317,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 + guild.iconURL({ format: 'png', size: 1024 });
 ```
 
-### Guild#pruneMembers
+#### Guild#pruneMembers
 
 The first, second, and third parameters in `guild.createEmoji()` have been changed/removed, leaving it with a total of one parameter. The `days`, `dry`, and `reason` parameters from v11 have been merged into an object as the first parameter.
 
@@ -310,15 +326,15 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 + guild.pruneMembers({ days: 7, dry: true, reason: 'Scheduled pruning' });
 ```
 
-### Guild#setChannelPosition
+#### Guild#setChannelPosition
 
 `guild.setChannelPosition()` has been removed entirely. As an alternative, you can use `channel.setPosition()`, or `guild.setChannelPositions()`, which accepts accepts the same form of data as `guild.setChannelPosition` but inside an array.
 
-### Guild#setRolePosition
+#### Guild#setRolePosition
 
 `guild.setRolePosition()` has been removed entirely. As an alternative, you can use `role.setPosition()`.
 
-### Guild#splashURL
+#### Guild#splashURL
 
 `guild.splashURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -328,16 +344,41 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 + guild.splashURL({ format: 'png', size: 1024 });
 ```
 
-### GuildChannel#createInvite
+### GuildChannel
 
-The second parameter in `guild.createEmoji()` has been removed, leaving it with a total of one parameter. The `reason` parameter from v11 have been merged into an object as the first parameter.
+#### GuildChannel#calculatedPosition
+
+`channel.calculatedPosition` has been renamed to `channel.position`.
+
+#### GuildChannel#clone
+
+The first, second, third, and fourth parameters in `channel.clone()` have been changed/removed, leaving it with a total of one parameter. The `name`, `withPermissions`, `withTopic`, and `reason` parameters from v11 have been merged into an object as the first parameter. 
+
+#### GuildChannel#createInvite
+
+The second parameter in `channel.createInvite()` has been removed, leaving it with a total of one parameter. The `reason` parameter from v11 have been merged into an object as the first parameter.
 
 ```diff
 - channel.createInvite({ temporary: true }, 'Just testing');
 + channel.createInvite({ temporary: true, reason: 'Just testing' });
 ```
 
-### GuildMember#hasPermissions
+#### GuildChannel#position
+
+`channel.position` has been renamed to `channel.rawPosition`.
+
+#### GuildChannel#setPosition
+
+The second parameter in `channel.setPosition()` has been changed. The `relative` parameter from v11 has been merged into an object.
+
+```diff
+- channel.setPosition(10, true);
++ channel.setPosition(10, { relative: true, reason: 'Basic organization' });
+```
+
+### GuildMember
+
+#### GuildMember#hasPermissions
 
 `member.hasPermissions()` has been removed in favor of `member.hasPermission()`.
 
@@ -346,7 +387,9 @@ The second parameter in `guild.createEmoji()` has been removed, leaving it with 
 + member.hasPermission(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
 ```
 
-### Message#delete
+### Message
+
+#### Message#delete
 
 The first parameter in `message.delete()` has been changed. The `timeout` parameter from v11 have been merged into an object as the first parameter.
 
@@ -355,7 +398,7 @@ The first parameter in `message.delete()` has been changed. The `timeout` parame
 + message.delete({ timeout: 5000 });
 ```
 
-### Message#editCode
+#### Message#editCode
 
 In the same sense that the `channel.sendCode()` method was removed, `message.editCode()` has also been removed entirely.
 
@@ -364,7 +407,7 @@ In the same sense that the `channel.sendCode()` method was removed, `message.edi
 + message.edit('const version = 12;', { code: 'js' });
 ```
 
-### Message#is(Member)Mentioned
+#### Message#is(Member)Mentioned
 
 `message.isMentioned()` and `message.isMemberMentioned()` have been removed in favor of `message.mentions.has()`.
 
@@ -374,7 +417,9 @@ In the same sense that the `channel.sendCode()` method was removed, `message.edi
 + message.mentions.has('123456789012345678');
 ```
 
-### MessageCollector#max(Matches)
+### MessageCollector
+
+#### MessageCollector#max(Matches)
 
 The `max` and `maxMatches` properties of the `MessageCollector` class have been renamed and repurposed.
 
@@ -386,11 +431,13 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 + `max`: The maximum amount of messages to collect.
 ```
 
-### MessageEmbed#client
+### MessageEmbed
+
+#### MessageEmbed#client
 
 `messageEmbed.client` has been removed entirely.
 
-### MessageEmbed#message
+#### MessageEmbed#message
 
 `messageEmbed.message` has been removed entirely.
 
@@ -398,11 +445,11 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 
 The `OAuth2Application` class has been renamed to `ClientApplication`.
 
-### OAuth2Application#reset
+#### OAuth2Application#reset
 
 `application.reset()` has been split up into `application.resetSecret()` and `application.resetToken()`.
 
-### OAuth2Application#iconURL
+#### OAuth2Application#iconURL
 
 `application.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -412,7 +459,9 @@ The `OAuth2Application` class has been renamed to `ClientApplication`.
 + user.iconURL({ format: 'png', size: 1024 });
 ```
 
-### Permissions#flags
+### Permissions
+
+#### Permissions#flags
 
 The following permission flags have been renamed:
 
@@ -420,11 +469,11 @@ The following permission flags have been renamed:
 * `EXTERNAL_EMOJIS` -> `USE_EXTERNAL_EMOJIS`
 * `MANAGE_ROLES_OR_PERMISSIONS` -> `MANAGE_ROLES`
 
-### Permissions#member
+#### Permissions#member
 
 `permissions.member` has been removed entirely.
 
-### Permissions#missingPermissions
+#### Permissions#missingPermissions
 
 `permissions.missingPermissions()` has been renamed to `permissions.missing()` and also refactored. The second parameter in v11 was named `explicit`, described as "Whether to require the user to explicitly have the exact permissions", defaulting to `false`. However, the second parameter in v11 is named `checkAdmin`, described as "Whether to allow the administrator permission to override", defaulting to `true`.
 
@@ -433,7 +482,7 @@ The following permission flags have been renamed:
 + permissions.missing(['MANAGE_SERVER']);
 ```
 
-### Permissions#raw
+#### Permissions#raw
 
 `permissions.raw` has been removed in favor of `permissions.bitfield`.
 
@@ -446,7 +495,7 @@ The following permission flags have been renamed:
 
 The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 
-### RichEmbed#attachFile
+#### RichEmbed#attachFile
 
 `richEmbed.attachFile()` has been removed in favor of `messageEmbed.attachFiles()`.
 
@@ -461,7 +510,9 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 + new MessageEmbed().attachFiles([new MessageAttachment('./file-name.png')]);
 ```
 
-### Role#hasPermission(s)
+### Role
+
+#### Role#hasPermission(s)
 
 `role.hasPermission()` and `role.hasPermissions()` have been removed in favor of `permissions.has()`.
 
@@ -475,7 +526,9 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 + role.permissions.has(['MANAGE_MESSAGES', 'MANAGE_SERVER']);
 ```
 
-### TextChannel#createCollector
+### TextChannel
+
+#### TextChannel#createCollector
 
 `channel.createCollector()` has now been removed in favor of `channel.createMessageCollector()` (which was already available in v11.1). In addition, the `max` and `maxMatches` properties were renamed and repurposed. You can read more about that [here](/additional-info/changes-in-v12?id=messagecollectormaxmatches).
 
@@ -484,7 +537,9 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 + channel.createMessageCollector(filterFunction, { max: 2, maxProcessed: 10, time: 15000 });
 ```
 
-### User#avatarURL
+### User
+
+#### User#avatarURL
 
 `user.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -494,7 +549,7 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 + user.avatarURL({ format: 'png', size: 1024 });
 ```
 
-### User#displayAvatarURL
+#### User#displayAvatarURL
 
 `user.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
@@ -504,7 +559,9 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 + user.displayAvatarURL({ format: 'png', size: 1024 });
 ```
 
-### Webhook#send\*\*\*
+### Webhook
+
+#### Webhook#send\*\*\*
 
 Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
@@ -518,24 +575,40 @@ Just like the `Channel#send***` methods, all the `.send***()` methods were remov
 * DMChannel
 * Emoji
 * GroupDMChannel
+* Guild
+* GuildAuditLogs
+* GuildAuditLogsEntry
+* GuildChannel
 
-### Emoji#addRestrictedRoles
+### Channel
+
+#### Channel#type
+
+`channel.type` now may also return `category` or `unknown`.
+
+### Emoji
+
+#### Emoji#addRestrictedRoles
 
 `emoji.addRestrictedRoles()` now also accepts a `Collection` of `Role` objects,, as opposed to only an array of `RoleResolvable`s.
 
-### Emoji#delete
+#### Emoji#delete
 
 `emoji.delete()` has been added and (optionally) accepts a `reason` string as the first parameter.
 
-### Emoji#removeRestrictedRoles
+#### Emoji#removeRestrictedRoles
 
 `emoji.removeRestrictedRoles()` now also accepts a `Collection` of `Role` objects,, as opposed to only an array of `RoleResolvable`s.
 
-### GroupDMChannel#edit
+### GroupDMChannel
+
+#### GroupDMChannel#edit
 
 `groupDM.edit()` has been added, accepts a `data` object as the first parameter, and (optionally) a `reason` string as the second parameter.
 
-### Guild#createChannel
+### Guild
+
+#### Guild#createChannel
 
 The third parameter in `guild.createChannel()` has been refactored in the following manner:
 
@@ -567,6 +640,30 @@ guild.createChannel('Secret Voice Channel', 'voice', {
 });
 ```
 
-### Guild#verified
+#### Guild#verified
 
-`Guild.verified` has been added.
+`guild.verified` has been added.
+
+### GuildAuditLogs
+
+#### GuildAuditLogs#Actions
+
+`auditLogs.Actions()` has been added (static method).
+
+#### GuildAuditLogs#Targets
+
+`auditLogs.Targets()` has been added (static method).
+
+### GuildChannel
+
+#### GuildChannel#lockPermissions
+
+`channel.lockPermimssions()` has been added.
+
+#### GuildChannel#parent(ID)
+
+`channel.parent` and `channel.parentID` have been added.
+
+#### GuildChannel#setParent
+
+`channel.setParent()` has been added.

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -137,11 +137,11 @@ The RichEmbed constructor has been removed and is now called `MessageEmbed`.  It
 
 ### String Concatenation
 
-v12 has changed how string concatenation works with stringifying objects.  The `valueOf` any data structure will return its id, which affects how it behaves in strings, eg. using an object for a mention.  In v11, you used to be able to use `channel.send('Hello ' + userObject)` and it would automatically stringify the object and it would become the mention, but in v12, it will now send a message that says `Hello 123456789012345678` instead.  Using template literals (\`\`) will still return the mention, however.
+v12 has changed how string concatenation works with stringifying objects.  The `valueOf` any data structure will return its id, which affects how it behaves in strings, eg. using an object for a mention.  In v11, you used to be able to use `channel.send(userObject + ' has joined!')` and it would automatically stringify the object and it would become the mention (`@user has joined!`), but in v12, it will now send a message that says `123456789012345678 has joined` instead.  Using template literals (\`\`) will still return the mention, however.
 
 ```diff
-- channel.send('Hello ' + userObject)
-+ channel.send(`Hello ${userObject}`)
+- channel.send(userObject + ' has joined!')
++ channel.send(`${userObject} has joined!`)
 ```
 
 ### User Account-Only Methods

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1,6 +1,14 @@
-# Changes in v12
+# A Brief Primer Updating from v11 to v12
 
-If you weren't already aware, v12 is constantly in development, and you can even start using it right now by running `npm install discordjs/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll more than likely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
+After a long time in development, Discord.js v12 is nearing a stable release, meaning it's time to update from v11 to get new features for your bots!  However, with those new features comes a lot of changes to the library that will break code written for v11.  This guide will serve as a handy reference for updating your code, covering the most commonly-used methods that have been changed, new topics such as partials and internal sharding, and will also include a comprehensive list of the method and property changes at the end.
+
+## Before You Start
+
+v12 requires Node 10.x or higher to  use, so make sure you're up-to-date.  To check your Node version, use `node -v` in your terminal or command prompt, and if it's not high enough, update it!  There are many resources online to help you get up-to-date.
+
+For now, you do need Git installed and added to your PATH environment, so ensure that's done as well - again, guides are available online for a wide variety of operating systems.  Once you have Node up-to-date and Git installed, you can install v12 by running `npm install discordjs/discord.js` in your terminal or command prompt for text-only use, or `npm install discordjs/discord.js node-opus` for voice support.  
+
+<p class="danger">This stuff should keep getting shoved to the bottom, with the commonly-used methods that are changed, as well as topic overviews added before it.</p>
 
 The section headers for breaking changes will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. The section headers for additions will be named after the v12 classes/methods/properties, to reflect their current syntax appropriately.
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -2,7 +2,9 @@
 
 If you weren't already aware, v12 is constantly in development, and you can even start using it right now by running `npm install hydrabolt/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll more than likely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
 
-The section headers will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
+The section headers for breaking changes will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. The section headers for additions will be named after the v12 classes/methods/properties, to reflect their current syntax appropriately.
+
+"Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
 
 <p class="danger">While this list has been carefully crafted, it may be incomplete! If you notice a pieces of missing or inaccurate data, we encourage you to [submit a pull request](https://github.com/Danktuary/Making-Bots-with-Discord.js)!</p>
 
@@ -10,7 +12,7 @@ The section headers will be named after the v11 classes/methods/properties and w
 
 * All headers are named as `Class#propertyOrMethod`
 * The use of parenthesis designates optional inclusion. For example, `Channel#fetch(Pinned)Message(s)` means that this section will include changes for `Channel#fetchPinnedMessages`, `Channel#fetchMessages`, and `Channel#fetchMessage`.
-* The user of asterisks designates a wildcard. For example, `Channel#send***` means that this section will include changes for `Channel#sendMessage`, `Channel#sendFile`, `Channel#sendEmbed`, and so forth.
+* The use of asterisks designates a wildcard. For example, `Channel#send***` means that this section will include changes for `Channel#sendMessage`, `Channel#sendFile`, `Channel#sendEmbed`, and so forth.
 
 ## Breaking changes
 
@@ -24,8 +26,17 @@ The section headers will be named after the v11 classes/methods/properties and w
 * GuildAuditLogs
 * GuildAuditLogsEntry
 * GuildChannel
+* GuildMember
 * Invite
+* Message
+* MessageAttachment
+* MessageMentions
 * OAuth2Application
+
+TODO LATER CUZ I DON'T WANNA TOUCH THAT SHIT RN:
+
+* MessageCollector
+* MessageEmbed***
 
 <p class="danger">Before anything, it is important to note that discord.js v12 (and so forth) requires a **minimum** Node version of v8. If you aren't sure what Node version you're on, run `node -v` in your console and update if necessary.</p>
 
@@ -74,7 +85,7 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 
 ```diff
 - channel.sendFiles(['./file-one.png', './file-two.png']);
-+ channel.send({ files: [{ attachment: './file-one.png' }, { attachment: './file-one.png' }] });
++ channel.send({ files: [{ attachment: './file-one.png' }, { attachment: './file-two.png' }] });
 + channel.send({ files: [new MessageAttachment('./file-one.png'), new MessageAttachment('./file-two.png')] });
 ```
 
@@ -134,7 +145,7 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 
 #### ClientUser#createGuild
 
-The second and third parameters in `clienrUser.createGuild()` have been changed/removed, leaving it with a total of two parameters. The `region` and `icon` parameters from v11 have been merged into an object as the second parameter.
+The second and third parameters in `clientUser.createGuild()` have been changed/removed, leaving it with a total of two parameters. The `region` and `icon` parameters from v11 have been merged into an object as the second parameter.
 
 ```diff
 - clientUser.createGuild('New server', 'us-east', './path/to/file.png');
@@ -373,10 +384,31 @@ The second parameter in `channel.setPosition()` has been changed. The `relative`
 
 ```diff
 - channel.setPosition(10, true);
-+ channel.setPosition(10, { relative: true, reason: 'Basic organization' });
++ channel.setPosition(10, { relative: true });
 ```
 
 ### GuildMember
+
+#### GuildMember#ban
+
+The second parameter in `member.ban()` has been changed. The `options` parameter no longer accepts a number, nor a string.
+
+```diff
+- member.ban(user, 7);
++ member.ban(user, { days: 7 });
+
+- member.ban(user, 'Too much trolling');
++ member.ban(user, { reason: 'Too much trolling' });
+```
+
+#### GuildMember#hasPermission
+
+The second, third, and fourth parameters in `member.hasPermission()` have been changed/removed, leaving it with a total of three parameters. The `explicit` parammeter from v11 has been removed.
+
+```diff
+- member.hasPermission('MANAGE_MESSAGES', true, false, false);
++ member.hasPermission('MANAGE_MESSAGES', false, false);
+```
 
 #### GuildMember#hasPermissions
 
@@ -386,6 +418,10 @@ The second parameter in `channel.setPosition()` has been changed. The `relative`
 - member.hasPermissions(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
 + member.hasPermission(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
 ```
+
+#### GuildMember#send\*\*\*
+
+Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
 ### Message
 
@@ -400,7 +436,7 @@ The first parameter in `message.delete()` has been changed. The `timeout` parame
 
 #### Message#editCode
 
-In the same sense that the `channel.sendCode()` method was removed, `message.editCode()` has also been removed entirely.
+`message.editCode()` has been removed entirely.
 
 ```diff
 - message.editCode('js', 'const version = 11;');
@@ -416,6 +452,22 @@ In the same sense that the `channel.sendCode()` method was removed, `message.edi
 - message.isMemberMentioned('123456789012345678');
 + message.mentions.has('123456789012345678');
 ```
+
+### MessageAttachment
+
+The `MessageAttachment` class' constructor parameters have changed
+
+#### MessageAttachment#client
+
+`attachment.client` has been removed entirely.
+
+#### MessageAttachment#filename
+
+`attachment.filename` has been renamed to `attachment.name`.
+
+#### MessageAttachment#filesize
+
+`attachment.filesize` has been renamed to `attachment.size`.
 
 ### MessageCollector
 
@@ -440,6 +492,17 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 #### MessageEmbed#message
 
 `messageEmbed.message` has been removed entirely.
+
+### MessageReaction
+
+#### MessageReaction#fetchUsers
+
+The first parameter in `reaction.fetchUsers()` has been changed. The `limit` parameter from v11 has been merged into an object as the first parameter.
+
+```diff
+- reaction.fetchUsers(50);
++ reaction.fetchUsers({ limit: 50 });
+```
 
 ### OAuth2Application
 
@@ -579,6 +642,11 @@ Just like the `Channel#send***` methods, all the `.send***()` methods were remov
 * GuildAuditLogs
 * GuildAuditLogsEntry
 * GuildChannel
+* GuildMember
+* Invite
+* Message
+* MessageAttachment
+* MessageMentions
 
 ### Channel
 
@@ -667,3 +735,51 @@ guild.createChannel('Secret Voice Channel', 'voice', {
 #### GuildChannel#setParent
 
 `channel.setParent()` has been added.
+
+### Message
+
+#### Message#activity
+
+`message.activity` has been added.
+
+#### Message#application
+
+`message.application` has been added.
+
+### MessageAttachment
+
+#### MessageAttachment#setAttachment
+
+`attachment.setAttachment()` has been added.
+
+#### MessageAttachment#setFile
+
+`attachment.setFile()` has been added.
+
+#### MessageAttachment#setName
+
+`attachment.setName()` has been added.
+
+### MessageMentions
+
+#### MessageMentions#has
+
+`mentions.has()` has been added.
+
+### ClientApplication
+
+#### ClientApplication#cover
+
+`application.cover` has been added.
+
+#### ClientApplication#coverImage
+
+`application.coverImage()` has been added.
+
+#### ClientApplication#createAsset
+
+`application.createAsset()` has been added.
+
+#### ClientApplication#fetchAssets
+
+`application.fetchAssets()` has been added.

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -31,7 +31,9 @@ The section headers for breaking changes will be named after the v11 classes/met
 * Message
 * MessageAttachment
 * MessageMentions
+* MessageReaction
 * OAuth2Application
+* PermissionOverwrites
 
 TODO LATER CUZ I DON'T WANNA TOUCH THAT SHIT RN:
 
@@ -632,21 +634,7 @@ Just like the `Channel#send***` methods, all the `.send***()` methods were remov
 
 ## Additions
 
-<p class="danger">This next bit is for me (Sanc) to keep track of the classes I've gone through and checked for additions. Remove before making the PR.</p>
-
-* DiscordAPIError
-* DMChannel
-* Emoji
-* GroupDMChannel
-* Guild
-* GuildAuditLogs
-* GuildAuditLogsEntry
-* GuildChannel
-* GuildMember
-* Invite
-* Message
-* MessageAttachment
-* MessageMentions
+<p class="warning">Remember to add examples for the additions.</p>
 
 ### Channel
 
@@ -783,3 +771,14 @@ guild.createChannel('Secret Voice Channel', 'voice', {
 #### ClientApplication#fetchAssets
 
 `application.fetchAssets()` has been added.
+
+### PermissionOverwrites
+
+#### PermissionOverwrites#allowed
+
+`permissionOverwrites.allowed` has been added.
+
+#### PermissionOverwrites#denied
+
+`permissionOverwrites.denied` has been added.
+

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -8,6 +8,10 @@ The section headers will be named after the v11 classes/methods/properties so th
 
 <p class="danger">Before anything, it is important to note that discord.js v12 (and so forth) requires a **minimum** Node version of v8. If you aren't sure what Node version you're on, run `node -v` in your console and update if necessary.</p>
 
+### Attachment
+
+The `Attachment` class has been renamed to `MessageAttachment`.
+
 ### Channel#send\*\*\*
 
 All the `.send***()` methods were removed in favor of one general `.send()` method.
@@ -49,7 +53,7 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 
 ### Channel#fetchMessage(s)
 
-`channel.fetchMessage()` and `channel.fetchMessages()` were both removed in favor of DataStores.
+`channel.fetchMessage()` and `channel.fetchMessages()` were both removed and transformed in the shape of DataStores.
 
 ```diff
 - channel.fetchMessage('123456789012345678');
@@ -63,11 +67,23 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 
 ### Client#fetchUser
 
-`client.fetchUser` has been removed in favor of DataStores.
+`client.fetchUser()` has been removed and transformed in the shape of DataStores.
 
 ```diff
 - client.fetchUser('123456789012345678');
 + client.users.fetch('123456789012345678');
+```
+
+### ClientUser#setGame
+
+`client.user.setGame()` has been changed to `client.user.setActivity()`. The second parameter is no longer for providing a streaming URL, but rather an object that allows you to provide the URL and activity type.
+
+```diff
+- client.user.setGame('with my bot friends!');
++ client.user.setActivity('with my bot friends!');
+
+- client.user.setGame('with my bot friends!', 'https://twitch.tv/your/stream/here');
++ client.user.setActivity('with my bot friends!', { url: 'https://twitch.tv/your/stream/here', type: 'STREAMING' });
 ```
 
 ### Guild#defaultChannel
@@ -76,7 +92,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 **Q:** "I previously had a welcome message system (or something similar) set up using that property. What can I do now?"
 
-**A:** There are a few ways to tackle this. Inside the `guildMemberAdd` event, you can:
+**A:** There are a few ways to tackle this. Using the example of a welcome message system, inside the `guildMemberAdd` event, you can:
 
 1. Make a new command that creates a `welcome-messages` channel, set up a database, store the channel ID in a column, and use `client.channels.get('id')` to send to that channel. This is the most reliable method and gives server staff freedom to rename the channel as they please.
 2. Make a new command that creates a `welcome-messages` channel and use `guild.channels.find('name', 'welcome-messages')`. This method will work nearly the same as the one above, but will break if someone on that server decides to rename the channel. This may also give you unexpected results, due to Discord allowing multiple channels to have the same name.
@@ -85,7 +101,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 ### Guild#fetchMember(s)
 
-`guild.fetchMember()` and `guild.fetchMembers()` were both removed in favor of DataStores. In addition, `guild.members.fetch()` will return a `Collection` of `GuildMember`s in v12, where as v11 would return a `Guild` object.
+`guild.fetchMember()` and `guild.fetchMembers()` were both removed and transformed in the shape of DataStores. In addition, `guild.members.fetch()` will return a `Collection` of `GuildMember`s in v12, where as v11 would return a `Guild` object.
 
 ```diff
 - guild.fetchMember('123456789012345678');
@@ -104,7 +120,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 ```diff
 - guild.iconURL;
 + guild.iconURL();
-+ guild.iconURL({ format: 'png', size: '1024' })
++ guild.iconURL({ format: 'png', size: 1024 });
 ```
 
 ### GuildChannel#createInvite
@@ -179,7 +195,7 @@ The `OAuth2Application` class has been renamed to `ClientApplication`.
 ```diff
 - user.iconURL;
 + user.iconURL();
-+ user.iconURL({ format: 'png', size: '1024' })
++ user.iconURL({ format: 'png', size: 1024 });
 ```
 
 ### Permissions#flags
@@ -252,7 +268,7 @@ The `MessageEmbed` class is the new and improved `RichEmbed`. In most cases, all
 ```diff
 - user.avatarURL;
 + user.avatarURL();
-+ user.avatarURL({ format: 'png', size: '1024' })
++ user.avatarURL({ format: 'png', size: 1024 });
 ```
 
 ### User#displayAvatarURL
@@ -262,7 +278,7 @@ The `MessageEmbed` class is the new and improved `RichEmbed`. In most cases, all
 ```diff
 - user.displayAvatarURL;
 + user.displayAvatarURL();
-+ user.displayAvatarURL({ format: 'png', size: '1024' })
++ user.displayAvatarURL({ format: 'png', size: 1024 });
 ```
 
 ### Webhook#send\*\*\*

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -4,13 +4,13 @@ If you weren't already aware, v12 is constantly in development, and you can even
 
 The section headers for breaking changes will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. The section headers for additions will be named after the v12 classes/methods/properties, to reflect their current syntax appropriately.
 
-"Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
+"Difference" codeblocks will be used to display the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled. Regular JavaScript syntax codeblocks will be used to display the additions. 
 
-<p class="danger">While this list has been carefully crafted, it may be incomplete! If you notice a pieces of missing or inaccurate data, we encourage you to [submit a pull request](https://github.com/Danktuary/Making-Bots-with-Discord.js)!</p>
+<p class="danger">While this list has been carefully crafted, it may be incomplete! If you notice pieces of missing or inaccurate data, we encourage you to [submit a pull request](https://github.com/Danktuary/Making-Bots-with-Discord.js)!</p>
 
 ## Legend
 
-* All headers are named as `Class#propertyOrMethod`
+* All section headers are named in the following convention: `Class#methodOrProperty`.
 * The use of parenthesis designates optional inclusion. For example, `Channel#fetch(Pinned)Message(s)` means that this section will include changes for `Channel#fetchPinnedMessages`, `Channel#fetchMessages`, and `Channel#fetchMessage`.
 * The use of asterisks designates a wildcard. For example, `Channel#send***` means that this section will include changes for `Channel#sendMessage`, `Channel#sendFile`, `Channel#sendEmbed`, and so forth.
 
@@ -50,7 +50,7 @@ The `Attachment` class has been removed in favor of the `MessageAttachment` clas
 
 #### Channel#send\*\*\*
 
-All the `.send***()` methods were removed in favor of one general `.send()` method.
+All the `.send***()` methods have been removed in favor of one general `.send()` method.
 
 ```diff
 - channel.sendMessage('Hey!');
@@ -170,7 +170,7 @@ The second and third parameters in `clientUser.createGuild()` have been changed/
 
 #### ClientUser#send\*\*\*
 
-Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
+Just like the `Channel#send***` methods, all the `.send***()` methods have been removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
 #### ClientUser#setGame
 
@@ -423,7 +423,7 @@ The second, third, and fourth parameters in `member.hasPermission()` have been c
 
 #### GuildMember#send\*\*\*
 
-Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
+Just like the `Channel#send***` methods, all the `.send***()` methods have been removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
 ### Message
 
@@ -595,7 +595,7 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 
 #### TextChannel#createCollector
 
-`channel.createCollector()` has now been removed in favor of `channel.createMessageCollector()` (which was already available in v11.1). In addition, the `max` and `maxMatches` properties were renamed and repurposed. You can read more about that [here](/additional-info/changes-in-v12?id=messagecollectormaxmatches).
+`channel.createCollector()` has been removed in favor of `channel.createMessageCollector()`. In addition, the `max` and `maxMatches` properties were renamed and repurposed. You can read more about that [here](/additional-info/changes-in-v12?id=messagecollectormaxmatches).
 
 ```diff
 - channel.createCollector(filterFunction, { maxMatches: 2, max: 10, time: 15000 });
@@ -628,7 +628,7 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 
 #### Webhook#send\*\*\*
 
-Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
+Just like the `Channel#send***` methods, all the `.send***()` methods have been removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
 
 ---
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1,6 +1,6 @@
 # Changes in v12
 
-If you weren't already aware, v12 is constantly in development, and you can even start using it by running `npm install hydrabolt/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll almost definitely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
+If you weren't already aware, v12 is constantly in development, and you can even start using it right now by running `npm install hydrabolt/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll more than likely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
 
 The section headers will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
 
@@ -16,7 +16,7 @@ The section headers will be named after the v11 classes/methods/properties and w
 
 ### Attachment
 
-The `Attachment` class has been renamed to `MessageAttachment`.
+The `Attachment` class has been removed in favor of the `MessageAttachment` class.
 
 ### Channel#send\*\*\*
 
@@ -43,6 +43,10 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 <p class="tip">Assuming you have the `MessageAttachment` class required somewhere in your file, e.g. `const { MessageAttachment } = require('discord.js')`.</p>
 
 ```diff
+- channel.sendFile('./file.png');
++ channel.send({ files: [{ attachment: './file.png' }] });
++ channel.send(new MessageAttachment('./file.png'));
+
 - channel.sendFile('./file.png', 'file-name.png');
 + channel.send({ files: [{ attachment: './file.png', name: 'file-name.png' }] });
 + channel.send(new MessageAttachment('./file.png', 'file-name.png'));
@@ -57,9 +61,9 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 + channel.send({ files: [new MessageAttachment('./file-one.png'), new MessageAttachment('./file-two.png')] });
 ```
 
-### Channel#fetchMessage(s)
+### Channel#fetch(Pinned)Message(s)
 
-`channel.fetchMessage()` and `channel.fetchMessages()` were both removed and transformed in the shape of DataStores.
+`channel.fetchMessage()`, `channel.fetchMessages()`, and `channel.fetchPinnedMessages()` were all removed and transformed in the shape of DataStores.
 
 ```diff
 - channel.fetchMessage('123456789012345678');
@@ -69,6 +73,11 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 ```diff
 - channel.fetchMessages({ limit: 100 });
 + channel.messages.fetch({ limit: 100 });
+```
+
+```diff
+- channel.fetchPinnedMessages();
++ channel.messages.fetchPinned();
 ```
 
 ### Client#fetchUser
@@ -159,8 +168,8 @@ The second parameter in `clientUser.setPassword()` has been changed. The `oldPas
 The third and fourth parameters in `guild.createChannel()` have been changed/removed, leaving it with a total of three parameters. The `overwrites` and `reason` parameters from v11 have been merged into an object as the third parameter.
 
 ```diff
-- guild.createChannel('new-channel', 'text', permissionOverwriteArray, 'New channel');
-+ guild.createChannel('new-channel', 'text', { overwrites: permissionOverwriteArray, reason: 'New channel' });
+- guild.createChannel('new-channel', 'text', permissionOverwriteArray, 'New channel added for fun!');
++ guild.createChannel('new-channel', 'text', { overwrites: permissionOverwriteArray, reason: 'New channel added for fun!' });
 ```
 
 ### Guild#createEmoji
@@ -177,8 +186,8 @@ The third and fourth parameters in `guild.createEmoji()` have been changed/remov
 The first and second parameters in `guild.createRole()` have been changed/removed, leaving it with a total of one parameter. The `data` and `reason` parameters from v11 have been moved into an object as the first parameter.
 
 ```diff
-- guild.createRole(roleData, 'New staff role');
-+ guild.createRole({ data: roleData, reason: 'New staff role' });
+- guild.createRole(roleData, 'New staff role!');
++ guild.createRole({ data: roleData, reason: 'New staff role!' });
 ```
 
 ### Guild#deleteEmoji
@@ -196,10 +205,10 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 **Q:** "I previously had a welcome message system (or something similar) set up using that property. What can I do now?"
 
-**A:** There are a few ways to tackle this. Using the example of a welcome message system, inside the `guildMemberAdd` event, you can:
+**A:** There are a few ways to tackle this. Using the example of a welcome message system, you can:
 
-1. Make a new command that creates a `welcome-messages` channel, set up a database, store the channel ID in a column, and use `client.channels.get('id')` to send to that channel. This is the most reliable method and gives server staff freedom to rename the channel as they please.
-2. Make a new command that creates a `welcome-messages` channel and use `guild.channels.find('name', 'welcome-messages')`. This method will work nearly the same as the one above, but will break if someone on that server decides to rename the channel. This may also give you unexpected results, due to Discord allowing multiple channels to have the same name.
+1. Set up a database table to store the channel ID in a column when someone uses a `!welcome-channel #channel-name` command, for example. Then inside the `guildMemberAdd` event, use `client.channels.get('id')` and send a message to that channel. This is the most reliable method and gives server staff freedom to rename the channel as they please.
+2. Make a new command that creates a `welcome-messages` channel, use `guild.channels.find('name', 'welcome-messages')`, and send a message to that channel. This method will work fine in most cases, but will break if someone on that server decides to rename the channel. This may also give you unexpected results, due to Discord allowing multiple channels to have the same name.
 
 <p class="tip">Not sure how to set up a database? Check out [this page](/sequelize/)!</p>
 
@@ -214,7 +223,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 ### Guild#fetchMember(s)
 
-`guild.fetchMember()` and `guild.fetchMembers()` were both removed and transformed in the shape of DataStores. In addition, `guild.members.fetch()` will return a `Collection` of `GuildMember`s in v12, where as v11 would return a `Guild` object.
+`guild.fetchMember()` and `guild.fetchMembers()` were both removed and transformed in the shape of DataStores. In addition, `guild.members.fetch()` will return a `Collection` of `GuildMember` objects in v12, whereas v11 would return a `Guild` object.
 
 ```diff
 - guild.fetchMember('123456789012345678');
@@ -238,7 +247,7 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 ### Guild#pruneMembers
 
-The first, second, and third parameters in `guild.createEmoji()` have been changed/removed, leaving it with a total of one parameter. The `dry` and `reason` parameters from v11 have been merged into an object as the first parameter.
+The first, second, and third parameters in `guild.createEmoji()` have been changed/removed, leaving it with a total of one parameter. The `days`, `dry`, and `reason` parameters from v11 have been merged into an object as the first parameter.
 
 ```diff
 - guild.pruneMembers(7, true, 'Scheduled pruning');
@@ -265,7 +274,7 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 
 ### GuildChannel#createInvite
 
-`channel.createInvite()` no longer takes a second parameter. The `reason` parameter has been moved inside the first parameter's object as a `reason` property.
+The second parameter in `guild.createEmoji()` has been removed, leaving it with a total of one parameter. The `reason` parameter from v11 have been merged into an object as the first parameter.
 
 ```diff
 - channel.createInvite({ temporary: true }, 'Just testing');
@@ -274,7 +283,7 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 
 ### GuildMember#hasPermissions
 
-`member.hasPermissions()` has been removed, but `member.hasPermission()` now takes either a string or an array.
+`member.hasPermissions()` has been removed in favor of `member.hasPermission()`.
 
 ```diff
 - member.hasPermissions(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
@@ -283,17 +292,16 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 
 ### Message#delete
 
-The first parameter in `message.delete()` has been changed from a number to an object, also allowing you to set the reason for deleting that message.
+The first parameter in `message.delete()` has been changed. The `timeout` parameter from v11 have been merged into an object as the first parameter.
 
 ```diff
 - message.delete(5000);
 + message.delete({ timeout: 5000 });
-+ message.delete({ timeout: 5000, reason: 'Very bad message' });
 ```
 
 ### Message#editCode
 
-In the same sense that the `.send*()` methods were removed, `.editCode()` was also removed entirely.
+In the same sense that the `channel.sendCode()` method was removed, `message.editCode()` has also been removed entirely.
 
 ```diff
 - message.editCode('js', 'const version = 11;');
@@ -324,11 +332,11 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 
 ### MessageEmbed#client
 
-`embed.client` has been removed entirely.
+`messageEmbed.client` has been removed entirely.
 
 ### MessageEmbed#message
 
-`embed.message` has been removed entirely.
+`messageEmbed.message` has been removed entirely.
 
 ### OAuth2Application
 
@@ -350,7 +358,7 @@ The `OAuth2Application` class has been renamed to `ClientApplication`.
 
 ### Permissions#flags
 
-The following permission flag names have been renamed:
+The following permission flags have been renamed:
 
 * `READ_MESSAGES` -> `VIEW_CHANNEL`
 * `EXTERNAL_EMOJIS` -> `USE_EXTERNAL_EMOJIS`
@@ -358,11 +366,12 @@ The following permission flag names have been renamed:
 
 ### Permissions#member
 
-`permissions.member` has been removed entirely with no alternative.
+`permissions.member` has been removed entirely.
 
 ### Permissions#missingPermissions
 
-`permissions.missingPermissions()` has been renamed to `permissions.missing()` and refactored a bit. The second parameter in v11 was named `explicit`, described as "Whether to require the user to explicitly have the exact permissions", defaulting to `false`. However, the second parameter in v11 is named `checkAdmin`, described as "Whether to allow the administrator permission to override", and defaulting to `true`.
+
+`permissions.missingPermissions()` has been renamed to `permissions.missing()` and also refactored. The second parameter in v11 was named `explicit`, described as "Whether to require the user to explicitly have the exact permissions", defaulting to `false`. However, the second parameter in v11 is named `checkAdmin`, described as "Whether to allow the administrator permission to override", defaulting to `true`.
 
 ```diff
 - permissions.missingPermissions(['MANAGE_SERVER']);
@@ -371,11 +380,20 @@ The following permission flag names have been renamed:
 
 ### Permissions#raw
 
-`permissions.raw` has been removed. Should you need to use this, you can use `permissions.bitfield` instead.
+`permissions.raw` has been removed in favor of `permissions.bitfield`.
 
-### RichEmbeds
+```diff
+- permissions.raw;
++ permissions.bitfield;
+```
 
-The `MessageEmbed` class is the new and improved `RichEmbed`. In most cases, all you'll need to do is find & replace `RichEmbed` with `MessageEmbed` in your code. However, there are some small differences.
+### RichEmbed
+
+The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
+
+### RichEmbed#attachFile
+
+`richEmbed.attachFile()` has been removed in favor of `messageEmbed.attachFiles()`.
 
 ```diff
 - new RichEmbed().attachFile('attachment://file-namme.png');
@@ -390,7 +408,7 @@ The `MessageEmbed` class is the new and improved `RichEmbed`. In most cases, all
 
 ### Role#hasPermission(s)
 
-`role.hasPermission()` and `role.hasPermissions()` were both removed, but `Role` objects still have a `.permissions` property, in which you can use the `.has()` method on.
+`role.hasPermission()` and `role.hasPermissions()` have been removed in favor of `permissions.has()`.
 
 ```diff
 - role.hasPermission('MANAGE_MESSAGES');

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -17,23 +17,54 @@ Below is a list a of the most commonly-used or asked-about methods and propertie
 Some methods that retrieve uncached data have been changed, transformed in the shape of a DataStore.
 
 ```diff
-- client.fetchUser('123456789012345678')
-+ client.users.fetch('123456789012345678')
+- client.fetchUser('123456789012345678');
++ client.users.fetch('123456789012345678');
 
-- guild.fetchMember('123456789012345678')
-+ guild.members.fetch('123456789012345678')
+- guild.fetchMember('123456789012345678');
++ guild.members.fetch('123456789012345678');
 
-- guild.fetchMembers()
-+ guild.members.fetch()
+- guild.fetchMembers();
++ guild.members.fetch();
 
-- textChannel.fetchMessage('123456789012345678')
-+ textChannel.messages.fetch('123456789012345678')
+- textChannel.fetchMessage('123456789012345678');
++ textChannel.messages.fetch('123456789012345678');
 
-- textChannel.fetchMessages({limit: 10})
-+ textChannel.messages.fetch({limit: 10})
+- textChannel.fetchMessages({ limit: 10 });
++ textChannel.messages.fetch({ limit: 10 });
 
-- textChannel.fetcHPinnedMessages()
-+ textChannel.messages.fetchPinned()
+- textChannel.fetchPinnedMessages();
++ textChannel.messages.fetchPinned();
+```
+
+### Send
+
+All the `.send***()` methods have been removed in favor of one general `.send()` method.
+
+```diff
+- channel.sendMessage('Hey!');
++ channel.send('Hey!');
+
+- channel.sendEmbed(embedVariable);
++ channel.send(embedVariable);
++ channel.send({ embed: embedVariable });
+```
+
+<p class="warning">`channel.send(embedVariable)` will only work if that variable is an instance of the `MessageEmbed` class; object literals won't give you the expected result unless your embed data is inside an `embed` key.</p>
+
+```diff
+- channel.sendCode('js', 'const version = 11;');
++ channel.send('const version = 12;', { code: 'js' });
+
+- channel.sendFile('./file.png');
+- channel.sendFiles(['./file-one.png', './file-two.png']);
++ channel.send({
+  files: [{
+    attachment: 'entire/path/to/file.jpg',
+    name: 'file.jpg'
+  }]
++ channel.send({
+  files: ['https://cdn.discordapp.com/icons/222078108977594368/6e1019b3179d71046e463a75915e7244.png?size=2048']
+});
 ```
 
 ### Roles
@@ -41,31 +72,31 @@ Some methods that retrieve uncached data have been changed, transformed in the s
 The `GuildMember.roles` Collection has been changed to a DataStore in v12, so a lot of the associated methods for interacting with a member's roles have changed as well.  They're no longer on the GuildMember object itself, but instead now on the `GuildMemberRoleStore` Data Store.
 
 ```diff
-- guildMember.addRole('123456789012345678')
-- guildMember.addRoles(['123456789012345678', '098765432109876543'])
-+ guildMember.roles.add('123456789012345678')
-+ guildMember.roles.add(['123456789012345678', '098765432109876543'])
+- guildMember.addRole('123456789012345678');
+- guildMember.addRoles(['123456789012345678', '098765432109876543']);
++ guildMember.roles.add('123456789012345678');
++ guildMember.roles.add(['123456789012345678', '098765432109876543']);
 
-- guildMember.removeRole('123456789012345678')
-- guildMember.removeRoles(['123456789012345678', '098765432109876543'])
-+ guildMember.roles.remove('123456789012345678')
-+ guildMember.roles.remove(['123456789012345678', '098765432109876543'])
+- guildMember.removeRole('123456789012345678');
+- guildMember.removeRoles(['123456789012345678', '098765432109876543']);
++ guildMember.roles.remove('123456789012345678');
++ guildMember.roles.remove(['123456789012345678', '098765432109876543']);
 
-- guildMember.setRoles(['123456789012345678', '098765432109876543'])
-+ guildMember.roles.set(['123456789012345678', '098765432109876543'])
+- guildMember.setRoles(['123456789012345678', '098765432109876543']);
++ guildMember.roles.set(['123456789012345678', '098765432109876543']);
 ```
 
 In addition, the GuildMember properties related to roles have also been moved to the `GuildMemberRoleStore` Data Store.
 
 ```diff
-- guildMember.colorRole
-+ guildMember.roles.color
+- guildMember.colorRole;
++ guildMember.roles.color;
 
-- guildMember.highestRole
-+ guildMember.roles.highest
+- guildMember.highestRole;
++ guildMember.roles.highest;
 
-- guildMember.hoistRole
-+ guildMember.roles.hoist
+- guildMember.hoistRole;
++ guildMember.roles.hoist;
 ```
 
 ### Ban and Unban
@@ -73,12 +104,12 @@ In addition, the GuildMember properties related to roles have also been moved to
 The method to ban members and users have been moved to the `GuildMemberStore` Data Store.
 
 ```diff
-- guildMember.ban()
-- guild.ban('123456789012345678')
-+ guild.members.ban('123456789012345678')
+- guildMember.ban();
+- guild.ban('123456789012345678');
++ guild.members.ban('123456789012345678');
 
-- guild.unban('123456789012345678')
-+ guild.members.unban('123456789012345678')
+- guild.unban('123456789012345678');
++ guild.members.unban('123456789012345678');
 +
 ```
 
@@ -87,22 +118,31 @@ The method to ban members and users have been moved to the `GuildMemberStore` Da
 Some image-related properties like `user.avatarURL` are now a method in v12, so that you can apply some options to them, eg. to affect their display size.
 
 ```diff
-- user.avatarURL
-+ user.avatarURL()
+- user.avatarURL;
++ user.avatarURL();
 
-- user.displayAvatarURL
-+ user.displayAvatarURL()
+- user.displayAvatarURL;
++ user.displayAvatarURL();
 
-- guild.iconURL
-+ guild.iconURL()
+- guild.iconURL;
++ guild.iconURL();
 
-- guild.splashURL
-+ guild.splashURL()
+- guild.splashURL;
++ guild.splashURL();
 ```
 
 ### RichEmbed Constructor
 
 The RichEmbed constructor has been removed and is now called `MessageEmbed`.  It is largely the same to use, the only difference being the removal of `RichEmbed.attachFile()` - `MessageEmbed.attachFiles()` accepts a single file as a parameter as well.
+
+### String Concatenation
+
+v12 has changed how string concatenation works with stringifying objects.  The `valueOf` any data structure will return its id, which affects how it behaves in strings, eg. using an object for a mention.  In v11, you used to be able to use `channel.send('Hello ' + userObject)` and it would automatically stringify the object and it would become the mention, but in v12, it will now send a message that says `Hello 123456789012345678` instead.  Using template literals (\`\`) will still return the mention, however.
+
+```diff
+- channel.send('Hello ' + userObject)
++ channel.send(`Hello ${userObject}`)
+```
 
 ### User Account-Only Methods
 
@@ -159,46 +199,7 @@ The `Attachment` class has been removed in favor of the `MessageAttachment` clas
 
 #### Channel#send\*\*\*
 
-All the `.send***()` methods have been removed in favor of one general `.send()` method.
 
-```diff
-- channel.sendMessage('Hey!');
-+ channel.send('Hey!');
-```
-
-```diff
-- channel.sendEmbed(embedVariable);
-+ channel.send(embedVariable);
-+ channel.send({ embed: embedVariable });
-```
-
-<p class="warning">`channel.send(embedVariable)` will only work if that variable is an instance of the `MessageEmbed` class; object literals won't give you the expected result unless your embed data is inside an `embed` key.</p>
-
-```diff
-- channel.sendCode('js', 'const version = 11;');
-+ channel.send('const version = 12;', { code: 'js' });
-```
-
-<p class="tip">Assuming you have the `MessageAttachment` class required somewhere in your file, e.g. `const { MessageAttachment } = require('discord.js')`.</p>
-
-```diff
-- channel.sendFile('./file.png');
-+ channel.send({ files: [{ attachment: './file.png' }] });
-+ channel.send(new MessageAttachment('./file.png'));
-
-- channel.sendFile('./file.png', 'file-name.png');
-+ channel.send({ files: [{ attachment: './file.png', name: 'file-name.png' }] });
-+ channel.send(new MessageAttachment('./file.png', 'file-name.png'));
-
-- channel.sendFile('./file.png', 'file-name.png', 'With a message attached');
-+ channel.send('With a message attached', { files: [new MessageAttachment('./file.png', 'file-name.png')] });
-```
-
-```diff
-- channel.sendFiles(['./file-one.png', './file-two.png']);
-+ channel.send({ files: [{ attachment: './file-one.png' }, { attachment: './file-two.png' }] });
-+ channel.send({ files: [new MessageAttachment('./file-one.png'), new MessageAttachment('./file-two.png')] });
-```
 
 #### Channel#fetch(Pinned)Message(s)
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1,6 +1,6 @@
 # Changes in v12
 
-If you weren't already aware, v12 is constantly in development, and you can even start using it right now by running `npm install hydrabolt/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll more than likely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
+If you weren't already aware, v12 is constantly in development, and you can even start using it right now by running `npm install discordjs/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll more than likely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
 
 The section headers for breaking changes will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. The section headers for additions will be named after the v12 classes/methods/properties, to reflect their current syntax appropriately.
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -2,7 +2,13 @@
 
 If you weren't already aware, v12 is constantly in development, and you can even start using it by running `npm install hydrabolt/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll almost definitely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
 
-The section headers will be named after the v11 classes/methods/properties so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
+The section headers will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
+
+<p class="danger">This next bit is for me (Sanc) to keep track of the classes I've gone through and checked for breaking changes. Remove before making the PR.</p>
+
+* ClientUser
+* Guild
+* Invite
 
 ## Breaking changes
 
@@ -67,23 +73,121 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 
 ### Client#fetchUser
 
-`client.fetchUser()` has been removed and transformed in the shape of DataStores.
+`client.fetchUser()` has been removed and transformed in the shape of a DataStore.
 
 ```diff
 - client.fetchUser('123456789012345678');
 + client.users.fetch('123456789012345678');
 ```
 
-### ClientUser#setGame
+### ClientUser#acceptInvite
 
-`client.user.setGame()` has been changed to `client.user.setActivity()`. The second parameter is no longer for providing a streaming URL, but rather an object that allows you to provide the URL and activity type.
+`clientUser.acceptInvite()` has been removed entirely.
+
+### ClientUser#addFriend
+
+`clientUser.addFriend()` has been removed entirely.
+
+### ClientUser#block
+
+`clientUser.block()` has been removed entirely.
+
+### ClientUser#avatarURL
+
+`clientUser.avatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
-- client.user.setGame('with my bot friends!');
-+ client.user.setActivity('with my bot friends!');
+- clientUser.avatarURL;
++ clientUser.avatarURL();
++ clientUser.avatarURL({ format: 'png', size: 1024 });
+```
 
-- client.user.setGame('with my bot friends!', 'https://twitch.tv/your/stream/here');
-+ client.user.setActivity('with my bot friends!', { url: 'https://twitch.tv/your/stream/here', type: 'STREAMING' });
+### ClientUser#createGuild
+
+The second and third parameters in `clienrUser.createGuild()` have been changed/removed, leaving it with a total of two parameters. The `region` and `icon` parameters from v11 have been merged into an object as the second parameter.
+
+```diff
+- clientUser.createGuild('New server', 'us-east', './path/to/file.png');
++ clientUser.createGuild('New server', { region: 'us-east', icon: './path/to/file.png' });
+```
+
+### ClientUser#displayAvatarURL
+
+`clientUser.displayAvatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- clientUser.displayAvatarURL;
++ clientUser.displayAvatarURL();
++ clientUser.displayAvatarURL({ format: 'png', size: 1024 });
+```
+
+### ClientUser#removeFriend
+
+`clientUser.removeFriend()` has been removed entirely.
+
+### ClientUser#send\*\*\*
+
+Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
+
+### ClientUser#setGame
+
+`clientUser.setGame()` has been changed to `clientUser.setActivity()`. The second parameter is no longer for providing a streaming URL, but rather an object that allows you to provide the URL and activity type.
+
+```diff
+- clientUser.setGame('with my bot friends!');
++ clientUser.setActivity('with my bot friends!');
+
+- clientUser.setGame('with my bot friends!', 'https://twitch.tv/your/stream/here');
++ clientUser.setActivity('with my bot friends!', { url: 'https://twitch.tv/your/stream/here', type: 'STREAMING' });
+```
+
+### ClientUser#setPassword
+
+The second parameter in `clientUser.setPassword()` has been changed. The `oldPassword` parameter from v11 has been changed into an object as the second parameter.
+
+```diff
+- clientUser.setPassword('newpassword', 'oldpassword');
++ clientUser.setPassword('newpassword', { oldPassword: 'oldpassword', mfaCode: '123456' });
+```
+
+### ClientUser#unblock
+
+`clientUser.unblock()` has been removed entirely.
+
+### Guild#createChannel
+
+The third and fourth parameters in `guild.createChannel()` have been changed/removed, leaving it with a total of three parameters. The `overwrites` and `reason` parameters from v11 have been merged into an object as the third parameter.
+
+```diff
+- guild.createChannel('new-channel', 'text', permissionOverwriteArray, 'New channel');
++ guild.createChannel('new-channel', 'text', { overwrites: permissionOverwriteArray, reason: 'New channel' });
+```
+
+### Guild#createEmoji
+
+The third and fourth parameters in `guild.createEmoji()` have been changed/removed, leaving it with a total of three parameters. The `roles` and `reason` parameters from v11 have been merged into an object as the third parameter.
+
+```diff
+- guild.createEmoji('./path/to/file.png', 'NewEmoji', collectionOfRoles, 'New emoji added for fun!');
++ guild.createEmoji('./path/to/file.png', 'NewEmoji', { roles: collectionOfRoles, reason: 'New emoji added for fun!' });
+```
+
+### Guild#createRole
+
+The first and second parameters in `guild.createRole()` have been changed/removed, leaving it with a total of one parameter. The `data` and `reason` parameters from v11 have been moved into an object as the first parameter.
+
+```diff
+- guild.createRole(roleData, 'New staff role');
++ guild.createRole({ data: roleData, reason: 'New staff role' });
+```
+
+### Guild#deleteEmoji
+
+`Guild.deleteEmoji()` has been removed and transformed in the shape of a DataStore.
+
+```diff
+- guild.deleteEmoji('123456789012345678');
++ guild.emojis.resolve('123456789012345678').delete();
 ```
 
 ### Guild#defaultChannel
@@ -98,6 +202,15 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 2. Make a new command that creates a `welcome-messages` channel and use `guild.channels.find('name', 'welcome-messages')`. This method will work nearly the same as the one above, but will break if someone on that server decides to rename the channel. This may also give you unexpected results, due to Discord allowing multiple channels to have the same name.
 
 <p class="tip">Not sure how to set up a database? Check out [this page](/sequelize/)!</p>
+
+### Guild#defaultRole
+
+`guild.defaultRole` has been removed entirely. As an alternative, you can use `.get()` with the Guild's ID on the `guild.roles` Collection.
+
+```diff
+- guild.defaultRole;
++ guild.roles.get(guild.id);
+```
 
 ### Guild#fetchMember(s)
 
@@ -123,6 +236,33 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 + guild.iconURL({ format: 'png', size: 1024 });
 ```
 
+### Guild#pruneMembers
+
+The first, second, and third parameters in `guild.createEmoji()` have been changed/removed, leaving it with a total of one parameter. The `dry` and `reason` parameters from v11 have been merged into an object as the first parameter.
+
+```diff
+- guild.pruneMembers(7, true, 'Scheduled pruning');
++ guild.pruneMembers({ days: 7, dry: true, reason: 'Scheduled pruning' });
+```
+
+### Guild#setChannelPosition
+
+`guild.setChannelPosition()` has been removed entirely. As an alternative, you can use `channel.setPosition()`.
+
+### Guild#setRolePosition
+
+`guild.setRolePosition()` has been removed entirely. As an alternative, you can use `role.setPosition()`.
+
+### Guild#splashURL
+
+`guild.splashURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- guild.splashURL;
++ guild.splashURL();
++ guild.splashURL({ format: 'png', size: 1024 });
+```
+
 ### GuildChannel#createInvite
 
 `channel.createInvite()` no longer takes a second parameter. The `reason` parameter has been moved inside the first parameter's object as a `reason` property.
@@ -139,6 +279,16 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 ```diff
 - member.hasPermissions(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
 + member.hasPermission(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
+```
+
+### Message#delete
+
+The first parameter in `message.delete()` has been changed from a number to an object, also allowing you to set the reason for deleting that message.
+
+```diff
+- message.delete(5000);
++ message.delete({ timeout: 5000 });
++ message.delete({ timeout: 5000, reason: 'Very bad message' });
 ```
 
 ### Message#editCode

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -6,8 +6,109 @@ After a long time in development, Discord.js v12 is nearing a stable release, me
 
 v12 requires Node 10.x or higher to  use, so make sure you're up-to-date.  To check your Node version, use `node -v` in your terminal or command prompt, and if it's not high enough, update it!  There are many resources online to help you get up-to-date.
 
-For now, you do need Git installed and added to your PATH environment, so ensure that's done as well - again, guides are available online for a wide variety of operating systems.  Once you have Node up-to-date and Git installed, you can install v12 by running `npm install discordjs/discord.js` in your terminal or command prompt for text-only use, or `npm install discordjs/discord.js node-opus` for voice support.  
+For now, you do need Git installed and added to your PATH environment, so ensure that's done as well - again, guides are available online for a wide variety of operating systems.  Once you have Node up-to-date and Git installed, you can install v12 by running `npm install discordjs/discord.js` in your terminal or command prompt for text-only use, or `npm install discordjs/discord.js node-opus` for voice support.
 
+## Commonly Used Methods That Changed
+
+Below is a list a of the most commonly-used or asked-about methods and properties that changed from v11 to v12.
+
+### Fetch
+
+Some methods that retrieve uncached data have been changed, transformed in the shape of a DataStore.
+
+```diff
+- client.fetchUser('123456789012345678')
++ client.users.fetch('123456789012345678')
+
+- guild.fetchMember('123456789012345678')
++ guild.members.fetch('123456789012345678')
+
+- guild.fetchMembers()
++ guild.members.fetch()
+
+- textChannel.fetchMessage('123456789012345678')
++ textChannel.messages.fetch('123456789012345678')
+
+- textChannel.fetchMessages({limit: 10})
++ textChannel.messages.fetch({limit: 10})
+
+- textChannel.fetcHPinnedMessages()
++ textChannel.messages.fetchPinned()
+```
+
+### Roles
+
+The `GuildMember.roles` Collection has been changed to a DataStore in v12, so a lot of the associated methods for interacting with a member's roles have changed as well.  They're no longer on the GuildMember object itself, but instead now on the `GuildMemberRoleStore` Data Store.
+
+```diff
+- guildMember.addRole('123456789012345678')
+- guildMember.addRoles(['123456789012345678', '098765432109876543'])
++ guildMember.roles.add('123456789012345678')
++ guildMember.roles.add(['123456789012345678', '098765432109876543'])
+
+- guildMember.removeRole('123456789012345678')
+- guildMember.removeRoles(['123456789012345678', '098765432109876543'])
++ guildMember.roles.remove('123456789012345678')
++ guildMember.roles.remove(['123456789012345678', '098765432109876543'])
+
+- guildMember.setRoles(['123456789012345678', '098765432109876543'])
++ guildMember.roles.set(['123456789012345678', '098765432109876543'])
+```
+
+In addition, the GuildMember properties related to roles have also been moved to the `GuildMemberRoleStore` Data Store.
+
+```diff
+- guildMember.colorRole
++ guildMember.roles.color
+
+- guildMember.highestRole
++ guildMember.roles.highest
+
+- guildMember.hoistRole
++ guildMember.roles.hoist
+```
+
+### Ban and Unban
+
+The method to ban members and users have been moved to the `GuildMemberStore` Data Store.
+
+```diff
+- guildMember.ban()
+- guild.ban('123456789012345678')
++ guild.members.ban('123456789012345678')
+
+- guild.unban('123456789012345678')
++ guild.members.unban('123456789012345678')
++
+```
+
+### Image URLs
+
+Some image-related properties like `user.avatarURL` are now a method in v12, so that you can apply some options to them, eg. to affect their display size.
+
+```diff
+- user.avatarURL
++ user.avatarURL()
+
+- user.displayAvatarURL
++ user.displayAvatarURL()
+
+- guild.iconURL
++ guild.iconURL()
+
+- guild.splashURL
++ guild.splashURL()
+```
+
+### RichEmbed Constructor
+
+The RichEmbed constructor has been removed and is now called `MessageEmbed`.  It is largely the same to use, the only difference being the removal of `RichEmbed.attachFile()` - `MessageEmbed.attachFiles()` accepts a single file as a parameter as well.
+
+### User Account-Only Methods
+
+All user account-only methods have been removed, as they are no longer publicly accessible from the API.
+
+---
 <p class="danger">This stuff should keep getting shoved to the bottom, with the commonly-used methods that are changed, as well as topic overviews added before it.</p>
 
 The section headers for breaking changes will be named after the v11 classes/methods/properties and will be in alphabetical order, so that you can easily find what you're looking for. The section headers for additions will be named after the v12 classes/methods/properties, to reflect their current syntax appropriately.

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1,0 +1,271 @@
+# Changes in v12
+
+If you weren't already aware, v12 is constantly in development, and you can even start using it by running `npm install hydrabolt/discord.js` (as opposed to `npm install discord.js`). However, there are many breaking changes from v11 to v12; you'll almost definitely need to change your code in a few places. This section of the guide is here to let you know what those changes are and how you can change your code accordingly.
+
+The section headers will be named after the v11 classes/methods/properties so that you can easily find what you're looking for. "Difference" codeblocks will be used to show you the old methods vs the newer ones—the red being what's been removed and the green being its replacement. Some bits may have more than one version of being handled.
+
+## Breaking changes
+
+<p class="danger">Before anything, it is important to note that discord.js v12 (and so forth) requires a **minimum** Node version of v8. If you aren't sure what Node version you're on, run `node -v` in your console and update if necessary.</p>
+
+### Channel#send\*\*\*
+
+All the `.send***()` methods were removed in favor of one general `.send()` method.
+
+```diff
+- channel.sendMessage('Hey!');
++ channel.send('Hey!');
+```
+
+```diff
+- channel.sendEmbed(embedVariable);
++ channel.send(embedVariable);
++ channel.send({ embed: embedVariable });
+```
+
+<p class="warning">`channel.send(embedVariable)` will only work if that variable is an instance of the `MessageEmbed` class; object literals won't give you the expected result unless your embed data is inside an `embed` key.</p>
+
+```diff
+- channel.sendCode('js', 'const version = 11;');
++ channel.send('const version = 12;', { code: 'js' });
+```
+
+<p class="tip">Assuming you have the `MessageAttachment` class required somewhere in your file, e.g. `const { MessageAttachment } = require('discord.js')`.</p>
+
+```diff
+- channel.sendFile('./file.png', 'file-name.png');
++ channel.send({ files: [{ attachment: './file.png', name: 'file-name.png' }] });
++ channel.send(new MessageAttachment('./file.png', 'file-name.png'));
+
+- channel.sendFile('./file.png', 'file-name.png', 'With a message attached');
++ channel.send('With a message attached', { files: [new MessageAttachment('./file.png', 'file-name.png')] });
+```
+
+```diff
+- channel.sendFiles(['./file-one.png', './file-two.png']);
++ channel.send({ files: [{ attachment: './file-one.png' }, { attachment: './file-one.png' }] });
++ channel.send({ files: [new MessageAttachment('./file-one.png'), new MessageAttachment('./file-two.png')] });
+```
+
+### Channel#fetchMessage(s)
+
+`channel.fetchMessage()` and `channel.fetchMessages()` were both removed in favor of DataStores.
+
+```diff
+- channel.fetchMessage('123456789012345678');
++ channel.messages.fetch('123456789012345678');
+```
+
+```diff
+- channel.fetchMessages({ limit: 100 });
++ channel.messages.fetch({ limit: 100 });
+```
+
+### Client#fetchUser
+
+`client.fetchUser` has been removed in favor of DataStores.
+
+```diff
+- client.fetchUser('123456789012345678');
++ client.users.fetch('123456789012345678');
+```
+
+### Guild#defaultChannel
+
+Unfortunately, "default" channels don't exist in Discord anymore, and as such, the `guild.defaultChannel` property has been removed with no alternative.
+
+**Q:** "I previously had a welcome message system (or something similar) set up using that property. What can I do now?"
+
+**A:** There are a few ways to tackle this. Inside the `guildMemberAdd` event, you can:
+
+1. Make a new command that creates a `welcome-messages` channel, set up a database, store the channel ID in a column, and use `client.channels.get('id')` to send to that channel. This is the most reliable method and gives server staff freedom to rename the channel as they please.
+2. Make a new command that creates a `welcome-messages` channel and use `guild.channels.find('name', 'welcome-messages')`. This method will work nearly the same as the one above, but will break if someone on that server decides to rename the channel. This may also give you unexpected results, due to Discord allowing multiple channels to have the same name.
+
+<p class="tip">Not sure how to set up a database? Check out [this page](/sequelize/)!</p>
+
+### Guild#fetchMember(s)
+
+`guild.fetchMember()` and `guild.fetchMembers()` were both removed in favor of DataStores. In addition, `guild.members.fetch()` will return a `Collection` of `GuildMember`s in v12, where as v11 would return a `Guild` object.
+
+```diff
+- guild.fetchMember('123456789012345678');
++ guild.members.fetch('123456789012345678');
+```
+
+```diff
+- guild.fetchMembers();
++ guild.members.fetch();
+```
+
+### Guild#iconURL
+
+`guild.iconURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- guild.iconURL;
++ guild.iconURL();
++ guild.iconURL({ format: 'png', size: '1024' })
+```
+
+### GuildChannel#createInvite
+
+`channel.createInvite()` no longer takes a second parameter. The `reason` parameter has been moved inside the first parameter's object as a `reason` property.
+
+```diff
+- channel.createInvite({ temporary: true }, 'Just testing');
++ channel.createInvite({ temporary: true, reason: 'Just testing' });
+```
+
+### GuildMember#hasPermissions
+
+`member.hasPermissions()` has been removed, but `member.hasPermission()` now takes either a string or an array.
+
+```diff
+- member.hasPermissions(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
++ member.hasPermission(['MANAGE_MESSAGES', 'MANAGE_ROLES']);
+```
+
+### Message#editCode
+
+In the same sense that the `.send*()` methods were removed, `.editCode()` was also removed entirely.
+
+```diff
+- message.editCode('js', 'const version = 11;');
++ message.edit('const version = 12;', { code: 'js' });
+```
+
+### Message#is(Member)Mentioned
+
+`message.isMentioned()` and `message.isMemberMentioned()` have been removed in favor of `message.mentions.has()`.
+
+```diff
+- message.isMentioned('123456789012345678');
+- message.isMemberMentioned('123456789012345678');
++ message.mentions.has('123456789012345678');
+```
+
+### MessageCollector#max(Matches)
+
+The `max` and `maxMatches` properties of the `MessageCollector` class have been renamed and repurposed.
+
+```diff
+- `max`: The The maximum amount of messages to process.
++ `maxProcessed`: The maximum amount of messages to process.
+
+- `maxMatches`: The maximum amount of messages to collect.
++ `max`: The maximum amount of messages to collect.
+```
+
+### MessageEmbed#client
+
+`embed.client` has been removed entirely.
+
+### MessageEmbed#message
+
+`embed.message` has been removed entirely.
+
+### OAuth2Application
+
+The `OAuth2Application` class has been renamed to `ClientApplication`.
+
+### OAuth2Application#reset
+
+`application.reset()` has been renamed to `application.resetSecret()`.
+
+### OAuth2Application#iconURL
+
+`application.iconURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- user.iconURL;
++ user.iconURL();
++ user.iconURL({ format: 'png', size: '1024' })
+```
+
+### Permissions#flags
+
+The following permission flag names have been renamed:
+
+* `READ_MESSAGES` -> `VIEW_CHANNEL`
+* `EXTERNAL_EMOJIS` -> `USE_EXTERNAL_EMOJIS`
+* `MANAGE_ROLES_OR_PERMISSIONS` -> `MANAGE_ROLES`
+
+### Permissions#member
+
+`permissions.member` has been removed entirely with no alternative.
+
+### Permissions#missingPermissions
+
+`permissions.missingPermissions()` has been renamed to `permissions.missing()` and refactored a bit. The second parameter in v11 was named `explicit`, described as "Whether to require the user to explicitly have the exact permissions", defaulting to `false`. However, the second parameter in v11 is named `checkAdmin`, described as "Whether to allow the administrator permission to override", and defaulting to `true`.
+
+```diff
+- permissions.missingPermissions(['MANAGE_SERVER']);
++ permissions.missing(['MANAGE_SERVER']);
+```
+
+### Permissions#raw
+
+`permissions.raw` has been removed. Should you need to use this, you can use `permissions.bitfield` instead.
+
+### RichEmbeds
+
+The `MessageEmbed` class is the new and improved `RichEmbed`. In most cases, all you'll need to do is find & replace `RichEmbed` with `MessageEmbed` in your code. However, there are some small differences.
+
+```diff
+- new RichEmbed().attachFile('attachment://file-namme.png');
++ new MessageEmbed().attachFiles(['attachment://file-namme.png']);
+
+- new RichEmbed().attachFile({ attachment: './file-name.png' });
++ new MessageEmbed().attachFiles([{ attachment: './file-name.png' }]);
+
+- new RichEmbed().attachFile(new Attachment('./file-name.png'));
++ new MessageEmbed().attachFiles([new MessageAttachment('./file-name.png')]);
+```
+
+### Role#hasPermission(s)
+
+`role.hasPermission()` and `role.hasPermissions()` were both removed, but `Role` objects still have a `.permissions` property, in which you can use the `.has()` method on.
+
+```diff
+- role.hasPermission('MANAGE_MESSAGES');
++ role.permissions.has('MANAGE_MESSAGES');
+```
+
+```diff
+- role.hasPermissions(['MANAGE_MESSAGES', 'MANAGE_SERVER']);
++ role.permissions.has(['MANAGE_MESSAGES', 'MANAGE_SERVER']);
+```
+
+### TextChannel#createCollector
+
+`channel.createCollector()` has now been removed in favor of `channel.createMessageCollector()` (which was already available in v11.1). In addition, the `max` and `maxMatches` properties were renamed and repurposed. You can read more about that [here](/additional-info/changes-in-v12?id=messagecollectormaxmatches).
+
+```diff
+- channel.createCollector(filterFunction, { maxMatches: 2, max: 10, time: 15000 });
++ channel.createMessageCollector(filterFunction, { max: 2, maxProcessed: 10, time: 15000 });
+```
+
+### User#avatarURL
+
+`user.avatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- user.avatarURL;
++ user.avatarURL();
++ user.avatarURL({ format: 'png', size: '1024' })
+```
+
+### User#displayAvatarURL
+
+`user.displayAvatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- user.displayAvatarURL;
++ user.displayAvatarURL();
++ user.displayAvatarURL({ format: 'png', size: '1024' })
+```
+
+### Webhook#send\*\*\*
+
+Just like the `Channel#send***` methods, all the `.send***()` methods were removed in favor of one general `.send()` method. Read through the [Channel#send\*\*\*](/additional-info/changes-in-v12?id=channelsend) section for more information.
+

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -17,6 +17,7 @@ The section headers will be named after the v11 classes/methods/properties and w
 * ClientUser
 * DiscordAPIError
 * DMChannel
+* GroupDMChannel
 * Guild
 * Invite
 * OAuth2Application
@@ -112,7 +113,7 @@ All the `.send***()` methods were removed in favor of one general `.send()` meth
 
 ### ClientUser#avatarURL
 
-`clientUser.avatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`clientUser.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - clientUser.avatarURL;
@@ -131,7 +132,7 @@ The second and third parameters in `clienrUser.createGuild()` have been changed/
 
 ### ClientUser#displayAvatarURL
 
-`clientUser.displayAvatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`clientUser.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - clientUser.displayAvatarURL;
@@ -175,6 +176,39 @@ The second parameter in `clientUser.setPassword()` has been changed. The `oldPas
 ### Collector#cleanup
 
 `collector.cleanup()` has been removed entirely.
+
+### GroupDMChannel#iconURL
+
+`groupDM.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
+
+```diff
+- groupDM.iconURL;
++ groupDM.iconURL();
++ groupDM.iconURL({ format: 'png', size: 1024 });
+```
+
+### GroupDMChannel#addUser
+
+
+The first and second parameters in `groupDM.addUser()` have been changed/removed, leaving it with a total of one parameter. The `accessTokenOrID` and `reason` parameters from v11 have been merged into an object as the first parameter.
+
+```diff
+- groupDM.addUser('123456789012345678');
++ groupDM.addUser({ user: '123456789012345678' });
++ groupDM.addUser({ user: '123456789012345678', accessToken: 'access-token', nick: 'My Best Friend!' });
+```
+
+### Guild#ban
+
+The second parameter in `guild.ban()` has been changed. The `options` parameter no longer accepts a number, nor a string.
+
+```diff
+- guild.ban(user, 7);
++ guild.ban(user, { days: 7 });
+
+- guild.ban(user, 'Too much trolling');
++ guild.ban(user, { reason: 'Too much trolling' });
+```
 
 ### Guild#createChannel
 
@@ -225,13 +259,13 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 
 <p class="tip">Not sure how to set up a database? Check out [this page](/sequelize/)!</p>
 
-### Guild#defaultRole
+### Guild#fetchBans
 
-`guild.defaultRole` has been removed entirely. As an alternative, you can use `.get()` with the Guild's ID on the `guild.roles` Collection.
+`guild.fetchBans()` will return a `Collection` of objects in v12, whereas v11 would return a `Collection` of `User` objects.
 
 ```diff
-- guild.defaultRole;
-+ guild.roles.get(guild.id);
+- guild.fetchBans().then(bans => console.log(`${bans.first().tag} was banned`));
++ guild.fetchBans().then(bans => console.log(`${bans.first().user.tag} was banned because "${bans.first().reason}"`));
 ```
 
 ### Guild#fetchMember(s)
@@ -248,9 +282,18 @@ Unfortunately, "default" channels don't exist in Discord anymore, and as such, t
 + guild.members.fetch();
 ```
 
+### Guild#fetchWebhooks
+
+`guild.fetchWebhooks()` is now a Promise that returns a `Collection` of `Webhook`s.
+
+```diff
+- guild.fetchWebhooks().first();
++ guild.fetchWebhooks().then(webhooks => webhooks.first());
+```
+
 ### Guild#iconURL
 
-`guild.iconURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`guild.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - guild.iconURL;
@@ -269,7 +312,7 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 
 ### Guild#setChannelPosition
 
-`guild.setChannelPosition()` has been removed entirely. As an alternative, you can use `channel.setPosition()`.
+`guild.setChannelPosition()` has been removed entirely. As an alternative, you can use `channel.setPosition()`, or `guild.setChannelPositions()`, which accepts accepts the same form of data as `guild.setChannelPosition` but inside an array.
 
 ### Guild#setRolePosition
 
@@ -277,7 +320,7 @@ The first, second, and third parameters in `guild.createEmoji()` have been chang
 
 ### Guild#splashURL
 
-`guild.splashURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`guild.splashURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - guild.splashURL;
@@ -361,7 +404,7 @@ The `OAuth2Application` class has been renamed to `ClientApplication`.
 
 ### OAuth2Application#iconURL
 
-`application.iconURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`application.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - user.iconURL;
@@ -382,7 +425,6 @@ The following permission flags have been renamed:
 `permissions.member` has been removed entirely.
 
 ### Permissions#missingPermissions
-
 
 `permissions.missingPermissions()` has been renamed to `permissions.missing()` and also refactored. The second parameter in v11 was named `explicit`, described as "Whether to require the user to explicitly have the exact permissions", defaulting to `false`. However, the second parameter in v11 is named `checkAdmin`, described as "Whether to allow the administrator permission to override", defaulting to `true`.
 
@@ -444,7 +486,7 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 
 ### User#avatarURL
 
-`user.avatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`user.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - user.avatarURL;
@@ -454,7 +496,7 @@ The `RichEmbed` class has been removed in favor of the `MessageEmbed` class.
 
 ### User#displayAvatarURL
 
-`user.displayAvatarURL` is now a method as opposed to a property. It also allows you to determine the file format and size to return.
+`user.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
 
 ```diff
 - user.displayAvatarURL;
@@ -474,3 +516,57 @@ Just like the `Channel#send***` methods, all the `.send***()` methods were remov
 
 * DiscordAPIError
 * DMChannel
+* Emoji
+* GroupDMChannel
+
+### Emoji#addRestrictedRoles
+
+`emoji.addRestrictedRoles()` now also accepts a `Collection` of `Role` objects,, as opposed to only an array of `RoleResolvable`s.
+
+### Emoji#delete
+
+`emoji.delete()` has been added and (optionally) accepts a `reason` string as the first parameter.
+
+### Emoji#removeRestrictedRoles
+
+`emoji.removeRestrictedRoles()` now also accepts a `Collection` of `Role` objects,, as opposed to only an array of `RoleResolvable`s.
+
+### GroupDMChannel#edit
+
+`groupDM.edit()` has been added, accepts a `data` object as the first parameter, and (optionally) a `reason` string as the second parameter.
+
+### Guild#createChannel
+
+The third parameter in `guild.createChannel()` has been refactored in the following manner:
+
+* It now accepts a `nsfw` property (boolean).
+* It now accepts a `bitrate` property (number, voice channels only).
+* It now accepts a `userLimit` property (number, voice channels only).
+* It now accepts a `parent` property (ChannelResolvable).
+* The `overwrites` now accepts an array of `ChannelCreationOverwrites`.
+
+```js
+guild.createChannel('secret-text-channel', 'text', {
+	nsfw: true,
+	overwrites: [
+		{
+			deny: ['VIEW_CHANNEL', 'SEND_MESSAGES'],
+			id: '123456789012345678',
+		},
+		{
+			allow: ['VIEW_CHANNEL', 'SEND_MESSAGES'],
+			id: '876543210987654321',
+		},
+	],
+});
+
+guild.createChannel('Secret Voice Channel', 'voice', {
+	bitrate: 64,
+	userLimit: 2,
+	parent: '123456789012345678',
+});
+```
+
+### Guild#verified
+
+`Guild.verified` has been added.


### PR DESCRIPTION
Reformat the introduction to reflect current requirements and repo link, as well as add a section on a quick reference for commonly-used methods that have breaking changes from v11 -> v12.