### PR TITLE
fix: color type in embed example

### DIFF
--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -189,7 +189,7 @@ If you want to modify the embed object based on conditions you will need to refe
 const exampleEmbed = { title: 'Some title' };
 
 if (message.author.bot) {
-	exampleEmbed.color = '#7289da';
+	exampleEmbed.color = 0x7289da;
 }
 ```
 


### PR DESCRIPTION
One of the examples for raw embed data and how to edit it based on conditions uses the wrong format for color, this PR fixes this mishap.

Thanks @holroy for pointing it out