### PR TITLE
Fix typo in additional-information.md

### DIFF
--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -91,7 +91,7 @@ This snippet allows you to return fetched messages outside of the `broadcastEval
 
 ```js
 client.shard.broadcastEval(`
-	(async => {
+	(async () => {
 		let channel = this.channels.get('id');
 		let msg;
 		if (channel) {


### PR DESCRIPTION
Missing parenthesis in async arrow function to indicate no parameters