### PR TITLE
Add branch version selector dropdown to user settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,3 +240,41 @@ The `author` and `avatar` attributes must be strings, and the `bot` attribute mu
 Do note the `<div is="discord-messages">` syntax instead of `<discord-messages>`. This is due to how VuePress renders markdown and HTML inside markdown files and doesn't recognize `<discord-messages>` as an HTML element, therefore rendering anything indented inside as a regular codeblock.
 
 You can read more about how to use these components by checking out [the package's GitHub repo](https://github.com/Danktuary/vue-discord-message).
+
+### Branch-specific content
+
+On some pages, you'll want to display content that applies only to the stable branch and other content that applies to a different branch. You can use the `<branch>` component inside any .md file like so:
+
+```md
+You can use
+<branch version="11.x" inline>`message.channel.fetchMessages()`</branch>
+<branch version="12.x" inline>`message.channel.messages.fetch()`</branch>
+to fetch all messages in a channel
+```
+
+If you're on the `11.x` branch, you'd see "You can use `message.channel.fetchMessages()` to fetch all messages in a channel. Use the `inline` attribute to make content display inline with the content around it. Otherwise, it'll be displayed on its own line.
+
+You can refer to the `guide/.vuepress/branches.js` file to see which values are valid to use for the `version` attribute.
+
+#### Codeblocks and other markdown
+
+A common use-case for this component would be with codeblocks. Using Vue components inside markdown can get tricky and cause weird errors, so in order for everything to render properly, an extra blank line should be added before and after the component tag. For example (ignoring the `\` before the backticks):
+
+```md
+You can use the following to fetch all messages in a channel:
+
+<branch version="11.x">
+
+\```js
+message.channel.fetchMessages();
+\```
+
+</branch>
+<branch version="12.x">
+
+\```js
+message.channel.messages.fetch();
+\```
+
+</branch>
+```

--- a/guide/.vuepress/branches.js
+++ b/guide/.vuepress/branches.js
@@ -1,5 +1,5 @@
 export default [
 	{ label: 'v11.x', version: '11.x' },
 	{ label: 'v11.5 (stable)', version: '11.5' },
-	{ label: 'v12 (master)', version: '12.x' },
+	{ label: 'v12.x (master)', version: '12.x' },
 ];

--- a/guide/.vuepress/branches.js
+++ b/guide/.vuepress/branches.js
@@ -1,0 +1,5 @@
+export default [
+	{ label: 'v11.x', version: '11.x' },
+	{ label: 'v11.5 (stable)', version: '11.5' },
+	{ label: 'v12 (master)', version: '12.x' },
+];

--- a/guide/.vuepress/components/Branch.vue
+++ b/guide/.vuepress/components/Branch.vue
@@ -1,6 +1,6 @@
 <template>
 	<div v-show="displayContent">
-		<slot />
+		<slot></slot>
 	</div>
 </template>
 
@@ -14,16 +14,22 @@ const [defaultBranch] = branches;
 export default {
 	name: 'Branch',
 
+	props: {
+		version: {
+			type: String,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
 			selectedBranch: defaultBranch.version,
 		};
 	},
 
-	props: {
-		version: {
-			type: String,
-			required: true,
+	computed: {
+		displayContent() {
+			return semver.satisfies(semver.coerce(this.version), this.selectedBranch);
 		},
 	},
 
@@ -34,12 +40,6 @@ export default {
 
 	destroyed() {
 		eventBus.$off('branch-update', this.updateBranch);
-	},
-
-	computed: {
-		displayContent() {
-			return semver.satisfies(semver.coerce(this.version), this.selectedBranch);
-		},
 	},
 
 	methods: {

--- a/guide/.vuepress/components/Branch.vue
+++ b/guide/.vuepress/components/Branch.vue
@@ -1,0 +1,50 @@
+<template>
+	<div v-show="displayContent">
+		<slot />
+	</div>
+</template>
+
+<script>
+import semver from 'semver';
+import branches from '../branches.js';
+import eventBus from '../eventBus.js';
+
+const [defaultBranch] = branches;
+
+export default {
+	name: 'Branch',
+
+	data() {
+		return {
+			selectedBranch: localStorage.getItem('branch-version') || defaultBranch.version,
+		};
+	},
+
+	props: {
+		version: {
+			type: String,
+			required: true,
+		},
+	},
+
+	mounted() {
+		eventBus.$on('branch-update', this.updateBranch);
+	},
+
+	destroyed() {
+		eventBus.$off('branch-update', this.updateBranch);
+	},
+
+	computed: {
+		displayContent() {
+			return semver.satisfies(semver.coerce(this.version), this.selectedBranch);
+		},
+	},
+
+	methods: {
+		updateBranch(branch) {
+			this.selectedBranch = branch;
+		},
+	},
+};
+</script>

--- a/guide/.vuepress/components/Branch.vue
+++ b/guide/.vuepress/components/Branch.vue
@@ -16,7 +16,7 @@ export default {
 
 	data() {
 		return {
-			selectedBranch: localStorage.getItem('branch-version') || defaultBranch.version,
+			selectedBranch: defaultBranch.version,
 		};
 	},
 
@@ -28,6 +28,7 @@ export default {
 	},
 
 	mounted() {
+		this.selectedBranch = localStorage.getItem('branch-version') || defaultBranch.version;
 		eventBus.$on('branch-update', this.updateBranch);
 	},
 

--- a/guide/.vuepress/components/Branch.vue
+++ b/guide/.vuepress/components/Branch.vue
@@ -21,7 +21,7 @@ export default {
 		},
 		inline: {
 			type: Boolean,
-			'default': false,
+			default: false,
 		},
 	},
 

--- a/guide/.vuepress/components/Branch.vue
+++ b/guide/.vuepress/components/Branch.vue
@@ -1,7 +1,7 @@
 <template>
-	<div v-show="displayContent">
+	<span v-show="displayContent" :style="{ display: inline ? 'inline-block' : 'block' }">
 		<slot></slot>
-	</div>
+	</span>
 </template>
 
 <script>
@@ -18,6 +18,10 @@ export default {
 		version: {
 			type: String,
 			required: true,
+		},
+		inline: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/guide/.vuepress/components/Branch.vue
+++ b/guide/.vuepress/components/Branch.vue
@@ -21,7 +21,7 @@ export default {
 		},
 		inline: {
 			type: Boolean,
-			default: false,
+			'default': false,
 		},
 	},
 

--- a/guide/.vuepress/components/BranchSelector.vue
+++ b/guide/.vuepress/components/BranchSelector.vue
@@ -1,0 +1,52 @@
+<template>
+	<div>
+		<label for="branch-selector">Discord.js Version:</label>
+		<select id="branch-selector" v-model="selectedBranch" @change="updateBranch">
+			<option v-for="branch in branches" :key="branch.version" :value="branch.version">
+				{{ branch.label }}
+			</option>
+		</select>
+	</div>
+</template>
+
+<script>
+import branches from '../branches.js';
+import eventBus from '../eventBus.js';
+
+const [defaultBranch] = branches;
+
+export default {
+	name: 'BranchSelector',
+
+	data() {
+		return {
+			branches,
+			selectedBranch: localStorage.getItem('branch-version') || defaultBranch.version,
+		};
+	},
+
+	methods: {
+		updateBranch() {
+			localStorage.setItem('branch-version', this.selectedBranch);
+			eventBus.$emit('branch-update', this.selectedBranch);
+		},
+	},
+};
+</script>
+
+<style>
+#branch-selector {
+	display: block;
+	width: 100%;
+	border-color: #eaecef;
+	padding: 5px;
+	box-sizing: border-box;
+	border-radius: 4px;
+}
+
+.yuu-theme-dark #branch-selector {
+	color: #f3f3f3;
+	background-color: #1a1a1a;
+	border-color: rgba(255, 255, 255, 0.1);
+}
+</style>

--- a/guide/.vuepress/components/BranchSelector.vue
+++ b/guide/.vuepress/components/BranchSelector.vue
@@ -21,8 +21,12 @@ export default {
 	data() {
 		return {
 			branches,
-			selectedBranch: localStorage.getItem('branch-version') || defaultBranch.version,
+			selectedBranch: defaultBranch.version,
 		};
+	},
+
+	mounted() {
+		this.selectedBranch = localStorage.getItem('branch-version') || defaultBranch.version;
 	},
 
 	methods: {

--- a/guide/.vuepress/config.js
+++ b/guide/.vuepress/config.js
@@ -17,6 +17,7 @@ const config = {
 	themeConfig: {
 		yuu: {
 			colorThemes: ['blue', 'red'],
+			extraOptions: { below: 'BranchSelector' },
 		},
 		algolia: {
 			apiKey: 'c8d9361fb8403f7c5111887e0edf4b5e',

--- a/guide/.vuepress/eventBus.js
+++ b/guide/.vuepress/eventBus.js
@@ -1,0 +1,2 @@
+import Vue from 'vue';
+export default new Vue();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "vuepress": "^0.14.4"
   },
   "dependencies": {
+    "semver": "^6.0.0",
     "vue-discord-message": "^3.0.0",
     "vuepress-theme-yuu": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "vue-discord-message": "^3.0.0",
-    "vuepress-theme-yuu": "^1.0.0"
+    "vuepress-theme-yuu": "^1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5848,6 +5848,11 @@ semver-diff@^2.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
+semver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
+
 serialize-javascript@^1.3.0, serialize-javascript@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6823,8 +6823,14 @@ vuepress-html-webpack-plugin@^3.2.0:
     util.promisify "1.0.0"
 
 vuepress-theme-yuu@^1.0.0:
+<<<<<<< HEAD
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vuepress-theme-yuu/-/vuepress-theme-yuu-1.0.0.tgz#970b6aa8f5f6bd2e5db5d00539ccacba83ad4389"
+=======
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vuepress-theme-yuu/-/vuepress-theme-yuu-1.1.0.tgz#bbf177b82ba3eb0f52193042150d8b02946ede20"
+  integrity sha512-fuwT1xprMT9zz2d3cKO76DU6IaUe1H6U4g4e62aagsPH0na/DJLhXzIc1uxo/x3iU+EsJ95Guyb0pdpxRPzX9g==
+>>>>>>> Update vuepress-theme-yuu to v1.1.0
   dependencies:
     vue-click-outside "^1.0.7"
 


### PR DESCRIPTION
![](https://i.imgur.com/eErrjSP.png)

This PR adds a `<branch>` component to the guide so that we can use it to conditionally render content on pages depending on the version the user selects from the dropdown menu shown above. This will allow us to easily account for both v11 and v12 syntax on the same page the rest of the relevant content is.

Examples:

```vue
Here's some conditional content that'll display depending on your choice from the site settings, in the dropdown menu from the cog icon above.

<branch version="11.x">v11.x content</branch>
<branch version="11.4">v11.4 content</branch>
<branch version="11.5">v11.5 (stable) content</branch>
<branch version="12.x">v12.x (master) content</branch>
```

And of course, you can see a live demo of this here: https://yuu-version-selector.netlify.com/version-selector.html

Finally closes #121.