### PR TITLE
Double negative [didn't...neither...nor]

### DIFF
--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -176,7 +176,7 @@ message.awaitReactions(filter, { max: 1, time: 60000, errors: ['time'] })
 	})
 	.catch(collected => {
 		console.log(`After a minute, only ${collected.size} out of 4 reacted.`);
-		message.reply('you didn\'t react with neither a thumbs up, nor a thumbs down.');
+		message.reply('you reacted with neither a thumbs up, nor a thumbs down.');
 	});
 ```
 


### PR DESCRIPTION
Saying you "**didn't** react with neither this nor that" is a double negative. (Double negatives are grammatically frowned upon in the English language). You can refer to [this page](https://www.grammar-monster.com/lessons/either_or_neither_nor_double_negative.htm) for more information. (Read the "Quick Answer").