### PR TITLE
Move Promise.all approach to its own subheading

### DIFF
--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -138,21 +138,6 @@ If you try again with either of the codeblocks above, you'll get the result you 
 If you aren't familiar with Promises or `async`/`await`, you can read more about them on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) or [our guide page on async/await](/additional-info/async-await.md)!
 :::
 
-However, if you don't mind the order the emojis react in, you can take advantage of `Promise.all()`, like so:
-
-```js
-if (message.content === '!fruits') {
-	Promise.all([
-		message.react('🍎'),
-		message.react('🍊'),
-		message.react('🍇'),
-	])
-		.catch(() => console.error('One of the emojis failed to react.'));
-}
-```
-
-The benefit of this small optimization is that you can use `.then()` to handle when all of the Promises have resolved, or `.catch()` when one of them has failed. You can also `await` it since it's a Promise itself.
-
 ## Awaiting reactions
 
 A common use case for reactions in commands is having a user confirm or deny an action, or creating a poll system. Luckily, we actually [already have a guide page that covers this](/popular-topics/collectors.md)! Check out that page if you want a more in-depth explanation. Otherwise, here's a basic example for reference:

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -138,6 +138,23 @@ If you try again with either of the codeblocks above, you'll get the result you 
 If you aren't familiar with Promises or `async`/`await`, you can read more about them on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) or [our guide page on async/await](/additional-info/async-await.md)!
 :::
 
+## Handling multiple reactions if the order doesn't matter
+
+However, if you don't mind the order the emojis react in, you can take advantage of `Promise.all()`, like so:
+
+```js
+if (message.content === '!fruits') {
+	Promise.all([
+		message.react('🍎'),
+		message.react('🍊'),
+		message.react('🍇'),
+	])
+		.catch(() => console.error('One of the emojis failed to react.'));
+}
+```
+
+The benefit of this small optimization is that you can use `.then()` to handle when all of the Promises have resolved, or `.catch()` when one of them has failed. You can also `await` it since it returns a Promise itself.
+
 ## Awaiting reactions
 
 A common use case for reactions in commands is having a user confirm or deny an action, or creating a poll system. Luckily, we actually [already have a guide page that covers this](/popular-topics/collectors.md)! Check out that page if you want a more in-depth explanation. Otherwise, here's a basic example for reference:


### PR DESCRIPTION
We relatively regularly had and still have people on the support server interpreting this approach as if it should react in order, although it clearly states that it does not.

I can see however, where the confusion is coming from. The guide part is called "reacting in order" and deals with that topic, so the removed snippet really does not belong here.

If you are in favor of keeping it, maybe as misc. code sample please let me know, although i'm not too sure in which context we'd fit it in there.

**Edit:** Keeping it under its own subheading instead of removing, as it still is useful information on how to deal with parallel promises at once.