### PR TITLE
Fix code snippet for Awaiting reactions

### DIFF
--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -177,7 +177,6 @@ message.awaitReactions(filter, { max: 1, time: 60000, errors: ['time'] })
 		}
 	})
 	.catch(collected => {
-		console.log(`After a minute, only ${collected.size} out of 4 reacted.`);
 		message.reply('you reacted with neither a thumbs up, nor a thumbs down.');
 	});
 ```


### PR DESCRIPTION
Since `max` is 1, an unfulfilled promise will always yield 0 reactions.