### PR TITLE
Create a header link to API documentation

### DIFF
--- a/guide/.vuepress/config.js
+++ b/guide/.vuepress/config.js
@@ -34,7 +34,7 @@ const config = {
 				link: '/commando/',
 			},
 			{
-				text: 'API Documentation',
+				text: 'Discord.js Documentation',
 				link: 'https://discord.js.org/#/docs/main/stable/general/welcome',
 			},
 		],

--- a/guide/.vuepress/config.js
+++ b/guide/.vuepress/config.js
@@ -8,13 +8,7 @@ const config = {
 		['meta', { name: 'theme-color', content: '#42b983' }],
 		['meta', { name: 'twitter:card', content: 'summary' }],
 		['meta', { name: 'og:title', content: 'Discord.js Guide' }],
-		[
-			'meta',
-			{
-				name: 'og:description',
-				content: 'A guide made by the community of discord.js for its users.',
-			},
-		],
+		['meta', { name: 'og:description', content: 'A guide made by the community of discord.js for its users.' }],
 		['meta', { name: 'og:type', content: 'website' }],
 		['meta', { name: 'og:url', content: 'https://discordjs.guide/' }],
 		['meta', { name: 'og:locale', content: 'en_US' }],

--- a/guide/.vuepress/config.js
+++ b/guide/.vuepress/config.js
@@ -8,7 +8,13 @@ const config = {
 		['meta', { name: 'theme-color', content: '#42b983' }],
 		['meta', { name: 'twitter:card', content: 'summary' }],
 		['meta', { name: 'og:title', content: 'Discord.js Guide' }],
-		['meta', { name: 'og:description', content: 'A guide made by the community of discord.js for its users.' }],
+		[
+			'meta',
+			{
+				name: 'og:description',
+				content: 'A guide made by the community of discord.js for its users.',
+			},
+		],
 		['meta', { name: 'og:type', content: 'website' }],
 		['meta', { name: 'og:url', content: 'https://discordjs.guide/' }],
 		['meta', { name: 'og:locale', content: 'en_US' }],
@@ -32,6 +38,10 @@ const config = {
 			{
 				text: 'Commando',
 				link: '/commando/',
+			},
+			{
+				text: 'API Documentation',
+				link: 'https://discord.js.org/#/docs/main/stable/general/welcome',
 			},
 		],
 		sidebar,


### PR DESCRIPTION
# What this is doing
Adding a link to the official discord.js.org API documentation to the header of this guide.

# Why is this needed
Addressing [Issue 239](https://github.com/discordjs/guide/issues/239). When I was first researching how to create a discord bot, I was digging through Discord's official API and google searching for any javascript implementations. If you google how to create a discord bot, you end up being brought into the discordjs.guide site much more often (better SEO?).  The discoverability of the package's API is hard to find from that site and it took me a bit more googling to find the actual documentation. While there are links to the site from different pages in discordjs.guide, a top level link for more developers that are familiar with working with APIs would be helpful.

tl;dr; unless you know what to google, discord.js.org is a harder site to find than discordjs.guide, so I want to add a link in the header to find the official docs.

# Screenshot
<img width="1439" alt="Screen Shot 2019-07-01 at 5 23 10 PM" src="https://user-images.githubusercontent.com/3756067/60467831-b96a8680-9c25-11e9-8e14-18151214197e.png">
