### PR TITLE
Use newer ecmaVersion in suggested ESLint configs

### DIFF
--- a/guide/preparations/setting-up-a-linter.md
+++ b/guide/preparations/setting-up-a-linter.md
@@ -49,7 +49,7 @@ ESLint may display a lot of warnings and errors about your code when you start u
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 2017
+		"ecmaVersion": 2019
 	},
 	"rules": {
 
@@ -71,7 +71,7 @@ Alternatively, if you don't want to go through everything one-by-one on your own
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 2017
+		"ecmaVersion": 2019
 	},
 	"rules": {
 		"brace-style": ["error", "stroustrup", { "allowSingleLine": true }],


### PR DESCRIPTION
`"ecmaVersion": 2017` is from a while ago, and while not everyone will use newest features from ES9 or ES10, some may experience problems with ESLint returning parse errors from using for example rest operators in objects, as mentioned [in issue on official ESLint repository](https://github.com/eslint/eslint/issues/10307#issuecomment-391688204)

On the other side, from guide itself - `Alternatively, if you don't want to go through everything one-by-one on your own, you can use the ESLint file we use for this guide.`
Guide's config for eslint extends `sora/vue`, which has `ecmaVersion` set to `2019`