### PR TITLE
Update parsing-mention-arguments.md

### DIFF
--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -84,7 +84,7 @@ Putting it into a function will make it easily reusable. We will use the name `g
 function getUserFromMention(mention) {
 	if (!mention) return;
 
-	if (mention.startsWith('<@') && mention.endsWith('>')) {
+	if (mention.startsWith('<@') && mention.endsWith('>') && mention[2] !== "&") {
 		mention = mention.slice(2, -1);
 
 		if (mention.startsWith('!')) {

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -84,7 +84,7 @@ Putting it into a function will make it easily reusable. We will use the name `g
 function getUserFromMention(mention) {
 	if (!mention) return;
 
-	if (mention.startsWith('<@') && mention.endsWith('>') && mention[2] !== "&") {
+	if (mention.startsWith('<@') && mention.endsWith('>') && mention[2] !== '&') {
 		mention = mention.slice(2, -1);
 
 		if (mention.startsWith('!')) {


### PR DESCRIPTION
Add test for `&` in user mentions resolver, which indicates a role mention

The `regex` section directly after is comparing the simplicity of using regex as an alternative. If the algorithms arent actually equivalent, the point isnt conveyed as clearly