### PR TITLE
Add colon to HTTPS in Oauth2 readme

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -239,7 +239,7 @@ fetch('https://discordapp.com/api/oauth2/token', {
 	body: data,
 })
 	.then(res => res.json())
-	.then(info => fetch('https//discordapp.com/api/users/@me', {
+	.then(info => fetch('https://discordapp.com/api/users/@me', {
 		headers: {
 			authorization: `${info.token_type} ${info.access_token}`,
 		},


### PR DESCRIPTION
In the docs, a URL is missing a colon ( : ) after the scheme (https)