### PR TITLE
Use .toLowerCase() in mention prefix example

### DIFF
--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -92,7 +92,7 @@ client.on('message', message => {
 
 	const [, matchedPrefix] = message.content.match(prefixRegex);
 	const args = message.content.slice(matchedPrefix.length).trim().split(/ +/);
-	const command = args.shift();
+	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {
 		message.channel.send('Pong!');


### PR DESCRIPTION
[Example for command handler](https://discordjs.guide/command-handling/#command-handling) in the guide uses `.toLowerCase()` to get command. It's kind of missing in example for handling mention prefix.