### PR TITLE
Slight rework of the grammar/text in the sequelize guide

### DIFF
--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -1,6 +1,6 @@
 # Storing data with Sequelize
 
-Sequelize is an object-relational-mapper, which means you can write a query using objects and have it run on almost any other database system that Sequelize supports.
+Sequelize is an object-relational-mapper, which means you can write a query using objects and have it runs on almost any other database system that Sequelize supports.
 
 ### Why use an ORM?
 
@@ -8,8 +8,8 @@ The main benefit of using an ORM like Sequelize is that it allows you to write c
 
 ## A simple tag system
 
-For this tutorial, we'll create a simple tag system. The tag system will allow you to add a tag, output a tag, edit the tag, show tag info, list tags, and delete a tag.   
-To begin, you should install Sequelize into your discord.js project. We'll use sqlite as our first storage engine, but we'll move into other databases later. Note that you'll need node 7.6 or above to utilize the `async/await` operators.
+For this tutorial, you will create a simple tag system. The tag system will allow you to add a tag, output a tag, edit the tag, show tag info, list tags, and delete a tag.   
+To begin, you should install Sequelize into your discord.js project. SQlite will be used as the first storage engine, other database will be expanded upon later. Note that you will need node 7.6 or above to utilize the `async/await` operators.
 
 ### Installing and using Sequelize
 
@@ -25,7 +25,7 @@ $ npm install --save sqlite3
 Make sure you use version 5 or later of Sequelize! Version 4 as used in this guide will pose a security threat. You can read more about this issue On the [Sequelize issue tracker](https://github.com/sequelize/sequelize/issues/7310).
 :::
 
-After you have installed discord.js and Sequelize, you can start with the following skeleton code. The comment labels will tell you where we'll insert our code.
+After having installed discord.js and Sequelize, you can start with the following skeleton code. The comment labels will tell you where to insert the later code blocks.
 
 <!-- eslint-disable require-await -->
 
@@ -82,22 +82,22 @@ const sequelize = new Sequelize('database', 'user', 'password', {
 });
 ```
 
-`host` tells Sequelize where to look for the database. This will be localhost for most systems, as the database usually resides with the application. But if you have a remote database, then you can set it to that connection address. But otherwise, don't touch this unless you know what you're doing.  
-`dialect` refers to the database engine you're going to use. For this tutorial, we'll use sqlite.  
-`logging` setting this to false disables the verbose output from Sequelize. Set it to true when you're trying to debug.  
+`host` tells Sequelize where to look for the database. This will be localhost for most systems, as the database usually resides with the application. If you have a remote database however, then you can set it to that connection address. Otherwise, don't touch this unless you know what you're doing.  
+`dialect` refers to the database engine you are going to use. For this tutorial, it will be sqlite.  
+`logging` setting this to false disables the verbose output from Sequelize. Set it to true when you are trying to debug.  
 `storage` is a sqlite-only setting, because sqlite is the only database that stores all its data to a single file.  
 
 
 ### [beta] Creating the model
 
-In any relational database, you need to create tables in order to store your data. We're going to create a simple tag system, and we'll have four fields. The table in the database will look something like this:
+In any relational database, you need to create tables in order to store your data. For this simple tag system, four fields will be used. The table in the database will look something like this:
 
 | name | description | username | usage_count |
 | --- | --- | --- | --- |
 | bob | is the best | bob | 0 |
 | tableflip | (╯°□°）╯︵ ┻━┻ | joe | 8 |
 
-In order to do that in Sequelize, we'll define a model object based on this structure.
+In order to do that in Sequelize, a model object will be defined based on this structure.
 
 ```js
 /*
@@ -123,30 +123,30 @@ const Tags = sequelize.define('tags', {
 });
 ```
 
-The model mirrors very closely to what is defined in the database. We'll have a table with 4 fields called `name`, `description`, `userid`, and `usage_count`.  
-`sequelize.define()` takes two parameters. We pass in `'tags'` as the name of our table, and an object that represents our table schema in key-value pairs. Keys in the object become the model's attributes, and the values describe the attributes
+The model mirrors very closely to what is defined in the database. There will be a table with 4 fields called `name`, `description`, `userid`, and `usage_count`.  
+`sequelize.define()` takes two parameters. `'tags'` is passed as the name of our table, and an object that represents the table's schema in key-value pairs. Keys in the object become the model's attributes, and the values describe the attributes.
 
 `type` refers to what kind of data this attribute should hold. The most common types are number, string, and date, but there are other data types that are available depending on the database.  
-`unique: true` will ensure that this field will never have duplicated entries. We'll disallow the existence of duplicate tag names in our database.  
-`defaultValue` lets us set a fallback value if we don't assign the value during the insert.  
+`unique: true` will ensure that this field will never have duplicated entries. Duplicate tag names will be disalowed in this database.  
+`defaultValue` allows to set a fallback value if no value is set during the insert.  
 `allowNull` is not all that important, but this will guarantee in the database that the attribute is never unset. You could potentially set it to be a blank or empty string, but has to be set to _something_.
 
 ::: tip
-`Sequelize.STRING` vs `Sequelize.TEXT`: In most database systems, the length of the string is a fixed length for performance reasons. Sequelize defaults this to 255. Use STRING if your input has a max length, and use TEXT if doesn't. For sqlite, there's no unbounded string type so it won't matter which one you pick.
+`Sequelize.STRING` vs `Sequelize.TEXT`: In most database systems, the length of the string is a fixed length for performance reasons. Sequelize defaults this to 255. Use STRING if your input has a max length, and use TEXT if does not. For sqlite, there is no unbounded string type so it will not matter which one you pick.
 :::
 
 ### [gamma] Syncing the model
 
-Now that we have defined our structure, we need to make sure the model exists in the database. This goes in our `.once('ready')` event. This way the table structure gets created, and we don't need to worry about it later.
+Now that our structure is defined, you need to make sure the model exists in the database. This goes in our `.once('ready')` event. This way the table structure gets created, and we do not need to worry about it later.
 ```js
 Tags.sync();
 ```
 
-The table doesn't actually get created until you `sync` it. The schema that we defined from before was simply creating the model that lets Sequelize know what our data should look like. For testing, you can use `Tags.sync({ force: true })` to recreate the table every time on startup. This way you can get blank slate each time.
+The table does not actually get created until you `sync` it. The schema that was defined from before was simply creating the model that lets Sequelize know what the data should look like. For testing, you can use `Tags.sync({ force: true })` to recreate the table every time on startup. This way you can get blank slate each time.
 
 ### [delta] Adding a tag
 
-We can finally get our first command. We'll start off with adding a tag.
+You can finally get your first command. Start off with adding a tag.
 
 <!-- eslint-skip -->
 
@@ -172,9 +172,9 @@ catch (e) {
 }
 ```
 
-`Tags.create()` uses our models that we created previously. The `.create()` method inserts some data into the model. We're going to be inserting a tag name, description, and the author name into the database.  
-`catch (e)` This section is absolutely necessary for our insert. We offload checking for duplicates to the database, so that it will tell us if we create a tag that already exists. The alternative is to query the database before adding data, and checking if we get a result. If we don't, only then do we add the data. But this requires two queries instead of one, so this method is less work.   
-`if (e.name === "SequelizeUniqueConstraintError")` Although this was mostly for doing less work, it's always good to handle your errors, especially if you know what types of errors you will receive. This error comes up if your unique constraint is violated, i.e. someone inserted duplicate values.
+`Tags.create()` uses the models that we created previously. The `.create()` method inserts some data into the model. you are going to be inserting a tag name, description, and the author name into the database.  
+`catch (e)` This section is necessary for the insert. This will offload checking for duplicates to the database, so that it will notify you if you attempt to create a tag that already exists. The alternative is to query the database before adding data, and checking if a result is returned. If there are no errors, or no identical tag is found, only then should you add the data. Of the two methods it is clear that catching the error is less work for yourself.  
+`if (e.name === "SequelizeUniqueConstraintError")` Although this was mostly for doing less work, it is always good to handle your errors, especially if you know what types of errors you will receive. This error comes up if your unique constraint is violated, i.e. someone inserted duplicate values.
 
 ::: warning
 Do not use catch for inserting new data. Only use it for gracefully handling things that go wrong in your code, or logging errors.
@@ -182,7 +182,7 @@ Do not use catch for inserting new data. Only use it for gracefully handling thi
 
 ### [epsilon] Fetching a tag
 
-Next we will fetch the tag we just inserted.
+Next you will fetch the tag that was just inserted.
 
 <!-- eslint-skip -->
 
@@ -199,8 +199,8 @@ if (tag) {
 return message.reply(`Could not find tag: ${tagName}`);
 ```
 
-This is our first query. We're finally doing something with our data, yay!  
-`.findOne()` is how we fetch a single row of data. The `where: { name: tagName }` makes sure we get we only get the row with the tag that we're searching for. Since our queries are asynchronous, we need to have await in order to fetch it. After we receive the data, we can use `.get()` on that object to grab the data. If we don't get any data, then we tell the user that we can't find it.
+This is your first query. You are finally doing something with our data, yay!  
+`.findOne()` is how you fetch a single row of data. The `where: { name: tagName }` makes sure you only get the row with the desired tag. Since the queries are asynchronous, you will need to make use of `await` in order to fetch it. After receiving the data, you can use `.get()` on that object to grab the data. If no data is received, then you can tell the user that it was not found.
 
 ### [zeta] Editing a tag
 
@@ -219,7 +219,7 @@ if (affectedRows > 0) {
 return message.reply(`Could not find a tag with name ${tagName}.`);
 ```
 
-We can edit a record by using the `.update()` function. The result from the update is the number of rows that were changed by the `where` condition. Since we can only have tags with unique names, we don't have to worry about how many rows it may change. And if we get that no rows were changed, then we can conclude that the tag that was trying to be edited did not exist.
+It is possible to edit a record by using the `.update()` function. The result from the update is the number of rows that were changed by the `where` condition. Since you can only have tags with unique names, you do not have to worry about how many rows it may change. Should you get that no rows were changed, then it can be concluded that the tag that was trying to be edited did not exist.
 
 ### [theta] Display info on a specific tag
 
@@ -236,11 +236,11 @@ if (tag) {
 return message.reply(`Could not find tag: ${tagName}`);
 ```
 
-This section is very similar to our previous command, except we're showing the tag metadata. `tag` contains our tag object. Notice two things here: firstly, we can access our object properties without the `.get()` function. This is because the object is an instance of a Tag, which we can treat as an object, and not just a row of data. Second, we accessed a property that we didn't define, `createdAt`. This is because Sequelize automatically adds that column to all tables. We can turn this feature off by passing another object into our model with `{ createdAt: false }`, but in this case, it was useful to have.
+This section is very similar to our previous command, except you will be showing the tag metadata. `tag` contains our tag object. Notice two things here: firstly, it is possible to access our object properties without the `.get()` function. This is because the object is an instance of a Tag, which you can treat as an object, and not just a row of data. Second, you can access a property that was not defined explicitly, `createdAt`. This is because Sequelize automatically adds that column to all tables. This feature can be disabled by passing another object into the model with `{ createdAt: false }`, but in this case, it was useful to have.
 
 ### [lambda] Listing all tags
 
-We'll use the next command to fetch a list of all the tags we've created so far.
+You will use the next command to fetch a list of all the tags that were created so far.
 
 <!-- eslint-skip -->
 
@@ -251,7 +251,7 @@ const tagString = tagList.map(t => t.name).join(', ') || 'No tags set.';
 return message.channel.send(`List of tags: ${tagString}`);
 ```
 
-Here, we use the `.findAll()` method to grab all the tag names. Notice that instead of having `where`, we have set the optional field, `attributes`. Setting attribute to name will let us get *only* the names of tags. If we tried to access other fields, like the tag author, then we'll get an error. If left blank, it will fetch *all* of our associated column data. It won't actually affect our results, but from a performance perspective, we should only grab the data that we need. If we get no results, `tagString` will default to 'No tags set'.
+Here, you can use the `.findAll()` method to grab all the tag names. Notice that instead of having `where`, the optional field, `attributes`, is set. Setting attributes to name will let you get *only* the names of tags. If you tried to access other fields, like the tag author, then you would get an error. If left blank, it will fetch *all* of the associated column data. It will not actually affect the results, but from a performance perspective, you should only grab the data that is needed. If no results are returned, `tagString` will default to 'No tags set'.
 
 ### [mu] Deleting a tag
 
@@ -265,7 +265,7 @@ if (!rowCount) return message.reply('That tag did not exist.');
 
 return message.reply('Tag deleted.');
 ```
-`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, we know nothing was deleted, and that tag didn't exist in the database in the first place.
+`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag didn't exist in the database in the first place.
 
 
 ## Resulting code

--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -82,7 +82,7 @@ const sequelize = new Sequelize('database', 'user', 'password', {
 });
 ```
 
-`host` tells Sequelize where to look for the database. This will be localhost for most systems, as the database usually resides with the application. If you have a remote database however, then you can set it to that connection address. Otherwise, don't touch this unless you know what you're doing.  
+`host` tells Sequelize where to look for the database. This will be localhost for most systems, as the database usually resides with the application. If you have a remote database however, then you can set it to that connection address. Otherwise, don't touch this unless you know what you are doing.  
 `dialect` refers to the database engine you are going to use. For this tutorial, it will be sqlite.  
 `logging` setting this to false disables the verbose output from Sequelize. Set it to true when you are trying to debug.  
 `storage` is a sqlite-only setting, because sqlite is the only database that stores all its data to a single file.  
@@ -265,7 +265,7 @@ if (!rowCount) return message.reply('That tag did not exist.');
 
 return message.reply('Tag deleted.');
 ```
-`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag didn't exist in the database in the first place.
+`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag did not exist in the database in the first place.
 
 
 ## Resulting code

--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -1,6 +1,6 @@
 # Storing data with Sequelize
 
-Sequelize is an object-relational-mapper, which means you can write a query using objects and have it run on almost any other database system that Sequelize supports.
+Sequelize is an object-relational-mapper, which means you can write a query using objects and have it runs on almost any other database system that Sequelize supports.
 
 ### Why use an ORM?
 
@@ -9,7 +9,7 @@ The main benefit of using an ORM like Sequelize is that it allows you to write c
 ## A simple tag system
 
 For this tutorial, you will create a simple tag system. The tag system will allow you to add a tag, output a tag, edit the tag, show tag info, list tags, and delete a tag.   
-To begin, you should install Sequelize into your discord.js project. SQlite will be used as the first storage engine, other database will be expanded upon later. Note that you will need node 7.6 or above to utilize the `async/await` operators.
+To begin, you should install Sequelize into your discord.js project. We will explain SQlite as the first storage engine and show how to use other databases later. Note that you will need node 7.6 or above to utilize the `async/await` operators.
 
 ### Installing and using Sequelize
 
@@ -25,7 +25,7 @@ $ npm install --save sqlite3
 Make sure you use version 5 or later of Sequelize! Version 4 as used in this guide will pose a security threat. You can read more about this issue On the [Sequelize issue tracker](https://github.com/sequelize/sequelize/issues/7310).
 :::
 
-After having installed discord.js and Sequelize, you can start with the following skeleton code. The comment labels will tell you where to insert the later code blocks.
+After you have installed discord.js and Sequelize, you can start with the following skeleton code. The comment labels will tell you where to insert the later code blocks.
 
 <!-- eslint-disable require-await -->
 
@@ -82,7 +82,7 @@ const sequelize = new Sequelize('database', 'user', 'password', {
 });
 ```
 
-`host` tells Sequelize where to look for the database. This will be localhost for most systems, as the database usually resides with the application. If you have a remote database however, then you can set it to that connection address. Otherwise, don't touch this unless you know what you are doing.  
+`host` tells Sequelize where to look for the database. This will be localhost for most systems, as the database usually resides with the application. If you have a remote database however, then you can set it to that connection address. Otherwise, don't touch this unless you know what you're doing.  
 `dialect` refers to the database engine you are going to use. For this tutorial, it will be sqlite.  
 `logging` setting this to false disables the verbose output from Sequelize. Set it to true when you are trying to debug.  
 `storage` is a sqlite-only setting, because sqlite is the only database that stores all its data to a single file.  
@@ -97,7 +97,7 @@ In any relational database, you need to create tables in order to store your dat
 | bob | is the best | bob | 0 |
 | tableflip | (╯°□°）╯︵ ┻━┻ | joe | 8 |
 
-In order to do that in Sequelize, a model object will be defined based on this structure.
+In order to do that in Sequelize, you define a model based on this structure, as shown below.
 
 ```js
 /*
@@ -124,11 +124,11 @@ const Tags = sequelize.define('tags', {
 ```
 
 The model mirrors very closely to what is defined in the database. There will be a table with 4 fields called `name`, `description`, `userid`, and `usage_count`.  
-`sequelize.define()` takes two parameters. `'tags'` will be passed as the name of our table, and an object that represents the table's schema in key-value pairs. Keys in the object become the model's attributes, and the values describe the attributes.
+`sequelize.define()` takes two parameters. `'tags'` is passed as the name of our table, and an object that represents the table's schema in key-value pairs. Keys in the object become the model's attributes, and the values describe the attributes.
 
 `type` refers to what kind of data this attribute should hold. The most common types are number, string, and date, but there are other data types that are available depending on the database.  
 `unique: true` will ensure that this field will never have duplicated entries. Duplicate tag names will be disalowed in this database.  
-`defaultValue` allows to set a fallback value if no value is set during the insert.  
+`defaultValue` allows you to set a fallback value if no value is set during the insert.  
 `allowNull` is not all that important, but this will guarantee in the database that the attribute is never unset. You could potentially set it to be a blank or empty string, but has to be set to _something_.
 
 ::: tip
@@ -137,16 +137,16 @@ The model mirrors very closely to what is defined in the database. There will be
 
 ### [gamma] Syncing the model
 
-Now that our structure is defined, you need to make sure the model exists in the database. This goes in our `.once('ready')` event. This way the table structure gets created, and you do not need to worry about it later.
+Now that your structure is defined, you need to make sure the model exists in the database. This goes in our `.once('ready')` event. This way the table structure gets created when the bot is ready and we do not need to worry about it later.
 ```js
 Tags.sync();
 ```
 
-The table does not actually get created until you `sync` it. The schema that was defined from before was simply creating the model that lets Sequelize know what the data should look like. For testing, you can use `Tags.sync({ force: true })` to recreate the table every time on startup. This way you can get blank slate each time.
+The table does not actually get created until you `sync` it. The schema you defined from before was simply creating the model that lets Sequelize know what the data should look like. For testing, you can use `Tags.sync({ force: true })` to recreate the table every time on startup. This way you can get blank slate each time.
 
 ### [delta] Adding a tag
 
-You can finally get your first command. Start off with adding a tag.
+After all this preperation, you can now write your first command! We will start off with the ability to add a tag.
 
 <!-- eslint-skip -->
 
@@ -172,7 +172,7 @@ catch (e) {
 }
 ```
 
-`Tags.create()` uses the models that was created previously. The `.create()` method inserts some data into the model. you are going to be inserting a tag name, description, and the author name into the database.  
+`Tags.create()` uses the models that you created previously. The `.create()` method inserts some data into the model. You are going to insert a tag name, description, and the author name into the database.  
 `catch (e)` This section is necessary for the insert. This will offload checking for duplicates to the database, so that it will notify you if you attempt to create a tag that already exists. The alternative is to query the database before adding data, and checking if a result is returned. If there are no errors, or no identical tag is found, only then should you add the data. Of the two methods it is clear that catching the error is less work for yourself.  
 `if (e.name === "SequelizeUniqueConstraintError")` Although this was mostly for doing less work, it is always good to handle your errors, especially if you know what types of errors you will receive. This error comes up if your unique constraint is violated, i.e. someone inserted duplicate values.
 
@@ -182,7 +182,7 @@ Do not use catch for inserting new data. Only use it for gracefully handling thi
 
 ### [epsilon] Fetching a tag
 
-Next you will fetch the tag that was just inserted.
+Next we will explain how to fetch the tag that was just inserted.
 
 <!-- eslint-skip -->
 
@@ -240,7 +240,7 @@ This section is very similar to our previous command, except you will be showing
 
 ### [lambda] Listing all tags
 
-You will use the next command to fetch a list of all the tags that were created so far.
+The next command will enable you to fetch a list of all the tags that were created so far.
 
 <!-- eslint-skip -->
 
@@ -265,7 +265,7 @@ if (!rowCount) return message.reply('That tag did not exist.');
 
 return message.reply('Tag deleted.');
 ```
-`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag did not exist in the database in the first place.
+`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag didn't exist in the database in the first place.
 
 
 ## Resulting code

--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -1,6 +1,6 @@
 # Storing data with Sequelize
 
-Sequelize is an object-relational-mapper, which means you can write a query using objects and have it runs on almost any other database system that Sequelize supports.
+Sequelize is an object-relational-mapper, which means you can write a query using objects and have it run on almost any other database system that Sequelize supports.
 
 ### Why use an ORM?
 
@@ -124,7 +124,7 @@ const Tags = sequelize.define('tags', {
 ```
 
 The model mirrors very closely to what is defined in the database. There will be a table with 4 fields called `name`, `description`, `userid`, and `usage_count`.  
-`sequelize.define()` takes two parameters. `'tags'` is passed as the name of our table, and an object that represents the table's schema in key-value pairs. Keys in the object become the model's attributes, and the values describe the attributes.
+`sequelize.define()` takes two parameters. `'tags'` will be passed as the name of our table, and an object that represents the table's schema in key-value pairs. Keys in the object become the model's attributes, and the values describe the attributes.
 
 `type` refers to what kind of data this attribute should hold. The most common types are number, string, and date, but there are other data types that are available depending on the database.  
 `unique: true` will ensure that this field will never have duplicated entries. Duplicate tag names will be disalowed in this database.  
@@ -137,7 +137,7 @@ The model mirrors very closely to what is defined in the database. There will be
 
 ### [gamma] Syncing the model
 
-Now that our structure is defined, you need to make sure the model exists in the database. This goes in our `.once('ready')` event. This way the table structure gets created, and we do not need to worry about it later.
+Now that our structure is defined, you need to make sure the model exists in the database. This goes in our `.once('ready')` event. This way the table structure gets created, and you do not need to worry about it later.
 ```js
 Tags.sync();
 ```
@@ -172,7 +172,7 @@ catch (e) {
 }
 ```
 
-`Tags.create()` uses the models that we created previously. The `.create()` method inserts some data into the model. you are going to be inserting a tag name, description, and the author name into the database.  
+`Tags.create()` uses the models that was created previously. The `.create()` method inserts some data into the model. you are going to be inserting a tag name, description, and the author name into the database.  
 `catch (e)` This section is necessary for the insert. This will offload checking for duplicates to the database, so that it will notify you if you attempt to create a tag that already exists. The alternative is to query the database before adding data, and checking if a result is returned. If there are no errors, or no identical tag is found, only then should you add the data. Of the two methods it is clear that catching the error is less work for yourself.  
 `if (e.name === "SequelizeUniqueConstraintError")` Although this was mostly for doing less work, it is always good to handle your errors, especially if you know what types of errors you will receive. This error comes up if your unique constraint is violated, i.e. someone inserted duplicate values.
 

--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -1,6 +1,6 @@
 # Storing data with Sequelize
 
-Sequelize is an object-relational-mapper, which means you can write a query using objects and have it runs on almost any other database system that Sequelize supports.
+Sequelize is an object-relational-mapper, which means you can write a query using objects and have it run on almost any other database system that Sequelize supports.
 
 ### Why use an ORM?
 
@@ -265,7 +265,7 @@ if (!rowCount) return message.reply('That tag did not exist.');
 
 return message.reply('Tag deleted.');
 ```
-`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag didn't exist in the database in the first place.
+`.destroy()` runs the delete operation. The operation returns a count of the number of affected rows. If it returns with a value of 0, then nothing was deleted and that tag did not exist in the database in the first place.
 
 
 ## Resulting code


### PR DESCRIPTION
Mostly making the text consistent by removing instances of `we` and `us` in favor of a neutral or `you` speech.

Remove contractions for a slightly more formal speech; though that may be an arguable change.

I probably am missing some stuff so feel free to mention it.

There is also the sentence `SQlite will be used as the first storage engine, other database will be expanded upon later.`, which as far as I can tell is incorrect since the guide does not really expand on further DBs, so I'm not sure if this should stay or not.