### PR TITLE
Improve branch selector UI/UX

### DIFF
--- a/guide/.vuepress/branches.js
+++ b/guide/.vuepress/branches.js
@@ -1,4 +1,12 @@
 export default [
-	{ label: 'v11.5 (stable)', version: '11.x' },
-	{ label: 'v12.x (master)', version: '12.x' },
+	{
+		label: 'v11.5 (stable)',
+		version: '11.x',
+		aliases: ['11', 'stable'],
+	},
+	{
+		label: 'v12.x (master)',
+		version: '12.x',
+		aliases: ['12', 'master'],
+	},
 ];

--- a/guide/.vuepress/components/BranchSelector.vue
+++ b/guide/.vuepress/components/BranchSelector.vue
@@ -1,6 +1,6 @@
 <template>
-	<div>
-		<label for="branch-selector">Discord.js Version:</label>
+	<div class="branch-selector-wrapper">
+		<label for="branch-selector" class="branch-selector-label">Discord.js Version:</label>
 		<select id="branch-selector" v-model="selectedBranch" @change="updateBranch">
 			<option v-for="branch in branches" :key="branch.version" :value="branch.version">
 				{{ branch.label }}
@@ -15,6 +15,18 @@ import eventBus from '../eventBus.js';
 
 const [defaultBranch] = branches;
 
+// `route.query` with `page.html?v=1#header` renders as `{ v: '1' }`
+// `route.query` with `page.html#header?v=1` renders as `{}`, and renders `route.hash` as `'#header?v=1'`
+// the former is plausible but the latter is more common
+function extractBranchVersion(query, hash) {
+	const versionRegex = /\?(?:v|version)=(.*)/;
+	const getBranch = version => branches.find(branch => branch.aliases.includes(version) || branch.version === version);
+
+	if (query.v || query.version) return getBranch(query.v || query.version);
+	if (hash.length && versionRegex.test(hash)) return getBranch(hash.match(versionRegex)[1]);
+	return null;
+}
+
 export default {
 	name: 'BranchSelector',
 
@@ -26,6 +38,13 @@ export default {
 	},
 
 	mounted() {
+		const branch = extractBranchVersion(this.$route.query, this.$route.hash);
+
+		if (branch) {
+			this.selectedBranch = branch.version;
+			return this.updateBranch();
+		}
+
 		this.selectedBranch = localStorage.getItem('branch-version') || defaultBranch.version;
 	},
 
@@ -38,14 +57,36 @@ export default {
 };
 </script>
 
-<style>
-#branch-selector {
-	display: block;
-	width: 100%;
-	border-color: #eaecef;
-	padding: 5px;
-	box-sizing: border-box;
-	border-radius: 4px;
+<style lang="stylus">
+.user-options-before {
+	display: flex;
+}
+
+.branch-selector-wrapper {
+	display: flex;
+	margin-right: 1em;
+	min-width: 240px;
+
+	.branch-selector-label {
+		margin-right: 0.5em;
+	}
+
+	#branch-selector {
+		display: block;
+		width: 100%;
+		border-color: #eaecef;
+		padding: 5px;
+		box-sizing: border-box;
+		border-radius: 4px;
+	}
+
+	@media screen and (max-width: 470px) {
+		min-width: unset;
+
+		.branch-selector-label {
+			display: none;
+		}
+	}
 }
 
 .yuu-theme-dark #branch-selector {

--- a/guide/.vuepress/config.js
+++ b/guide/.vuepress/config.js
@@ -18,7 +18,7 @@ const config = {
 	themeConfig: {
 		yuu: {
 			colorThemes: ['blue', 'red'],
-			extraOptions: { below: 'BranchSelector' },
+			extraOptions: { before: 'BranchSelector' },
 		},
 		repo: 'discordjs/guide',
 		docsDir: 'guide',

--- a/guide/.vuepress/styles/index.styl
+++ b/guide/.vuepress/styles/index.styl
@@ -1,0 +1,13 @@
+@media screen and (max-width: 600px) {
+	.navbar .home-link .site-name {
+		background: url('/favicon.png') top left / contain no-repeat;
+		text-indent: -999px;
+	}
+}
+
+@media screen and (max-width: 360px) {
+	// so that the branch selector and book icon don't overlap each other
+	.navbar .links {
+		padding-left: 0.25rem !important;
+	}
+}


### PR DESCRIPTION
This will allow people to link directly to the guide and set the user's version via a query string, e.g. `https://discordjs.guide/?v=12`, `https://discordjs.guide/?version=12`, `https://discordjs.guide/?v=stable` (11.x for now),  and `https://discordjs.guide/?v=master` (12.x for now).

Also moved the UI to the left of the cog icon, outside of the user settings menu, so that it's easy to tell which branch content you're currently viewing. To keep it mobile-friendly, the site name text gets changed to the guide book icon on mobile devices.

Desktop screenshot:
![Desktop screenshot](https://i.imgur.com/JSwkvmW.png)

Mobile screenshot:
![Mobile screenshot](https://i.imgur.com/AS8Xqol.png)

Resolves #273 