### PR TITLE
Revert "Enhance `configuration-files` example to utilize the configurized prefix."

### DIFF
--- a/code-samples/creating-your-bot/configuration-files/index.js
+++ b/code-samples/creating-your-bot/configuration-files/index.js
@@ -7,7 +7,7 @@ client.once('ready', () => {
 });
 
 client.on('message', message => {
-	if (message.content === config.prefix + 'ping') {
+	if (message.content === '!ping') {
 		message.channel.send('Pong.');
 	}
 });


### PR DESCRIPTION
Reverts discordjs/guide#278

Should not have been merged, the code is progressing as expected, and the changes made with this PR are only applied after the next guide section, where it's also applied in the code samples.
I overlooked this.