### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/branching-content.md
+++ b/.github/ISSUE_TEMPLATE/branching-content.md
@@ -1,0 +1,13 @@
+---
+name: Branching Content
+about: Content is missing for a certain version and requires branching sections
+  or code samples
+labels: 'code refactoring'
+
+---
+
+**Part of the guide or code sample that needs a branching update**
+URL or path to the file or section in question.
+
+**Special Notices:**
+Anything that needs to or should be considered or addressed when implementing this branching request.

--- a/.github/ISSUE_TEMPLATE/branching-content.md
+++ b/.github/ISSUE_TEMPLATE/branching-content.md
@@ -7,7 +7,7 @@ labels: 'type: enhancement','meta: branching'
 ---
 
 **Part of the guide or code sample that needs a branching update**
-URL or path to the file or section in question.
+<!-- URL or path to the file or section in question. -->
 
-**Special Notices:**
-Anything that needs to or should be considered or addressed when implementing this branching request.
+**Additional notes**
+<!-- Add any other notes about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/branching-content.md
+++ b/.github/ISSUE_TEMPLATE/branching-content.md
@@ -2,7 +2,7 @@
 name: Branching Content
 about: Content is missing for a certain version and requires branching sections
   or code samples
-labels: 'code refactoring'
+labels: 'type: enhancement','meta: branching'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: 'bug'
+labels: 'type: bug'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,28 +6,22 @@ labels: 'type: bug'
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!-- Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Device (please complete the following information):**
+<!-- - Device/OS: [e.g. iOS]
+ - Browser: [e.g. chrome, safari]
+ - Version: [e.g. 22] -->
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.
+**Additional notes**
+<!-- Add any other notes about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: 'bug'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: 'request/suggestion'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to be addressed in the guide.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context, ideas, resources or rough drafts for this request

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,13 +6,13 @@ labels: 'type: request/suggestion'
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to be addressed in the guide.
+<!-- A clear and concise description of what you want to be addressed in the guide. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context, ideas, resources or rough drafts for this request
+**Additional notes**
+<!-- Add any other notes about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: 'request/suggestion'
+labels: 'type: request/suggestion'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question/General support request
+about: Ask questions about discord.js in Discord - https://discord.gg/bRCvFy9 
+labels: question
+
+---
+
+<!--
+**If you have specific questions about discord.js library usage, please ask in the Discord Server**
+https://discord.gg/bRCvFy9 
+-->
+
+**Part of the guide or code sample the question is about**
+URL or path to the file or section in question. If none please select "feature request" instead.
+
+**Question**
+Your question about the referenced part of the guide.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question/General support request
 about: Ask questions about discord.js in Discord - https://discord.gg/bRCvFy9 
-labels: question
+labels: 'type: question'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,7 +11,7 @@ https://discord.gg/bRCvFy9
 -->
 
 **Part of the guide or code sample the question is about**
-URL or path to the file or section in question. If none please select "feature request" instead.
+<!-- URL or path to the file or section in question. If none please select "feature request" instead. -->
 
 **Question**
-Your question about the referenced part of the guide.
+<!-- Your question about the referenced part of the guide. -->

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -6,7 +6,7 @@ labels: 'type: bug fix'
 ---
 
 **Describe the bug**
-Describe the bug you fixed (or provide a link to the issue for said bug)
+<!-- Describe the bug you fixed (or provide a link to the issue for said bug) -->
 
-**Additional context**
-Add any other context about the problem here.
+**Additional notes**
+<!-- Add any other notes about the problem here.-->

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,12 @@
+---
+name: Bug fix
+about: Fixed a bug
+labels: 'type: bug fix'
+
+---
+
+**Describe the bug**
+Describe the bug you fixed (or provide a link to the issue for said bug)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE/typo_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/typo_fix.md
@@ -1,0 +1,9 @@
+---
+name: Typo fix
+about: Fixed a typo
+labels: 'type: spelling/grammar'
+
+---
+
+**Spelling/Grammar fix**
+**This Pull Request does not include any semantical changes**


### PR DESCRIPTION
This PR proposes some issue templates for use on the guide, filing as PR to allow feedback/requests for additions/changes/wording improvements etc.

This removes the need for manual tagging for the most common issue types.
Where applicable uses the standard GitHub suggestion, possibly adapted to fit the context of the guide better.

* Added the `branching` tag to mark requests and PRs that deal with branching content (e.g. needs v12 implementation) which will automatically be assigned if the corresponding issue template is selected.