### PR TITLE
Fix ReactionStore method

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1122,7 +1122,7 @@ Just like the `textChannel#send***` methods, all the `.send***()` methods have b
 
 ```diff
 - message.clearReactions();
-+ message.reactions.clear();
++ message.reactions.removeAll();
 ```
 
 #### Message#delete


### PR DESCRIPTION
Clearing all reactions is achieved with `removeAll()` not the inherited map method. 
(spotted by LostSorrow#1237)