### PR TITLE
Update voice sections to use @discordjs/opus

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -6,7 +6,7 @@ After a long time in development, Discord.js v12 is nearing a stable release, me
 
 v12 requires Node 10.2.x or higher to  use, so make sure you're up-to-date.  To check your Node version, use `node -v` in your terminal or command prompt, and if it's not high enough, update it!  There are many resources online to help you get up-to-date.
 
-For now, you do need Git installed and added to your PATH environment, so ensure that's done as well - again, guides are available online for a wide variety of operating systems.  Once you have Node up-to-date and Git installed, you can install v12 by running `npm install discordjs/discord.js` in your terminal or command prompt for text-only use, or `npm install discordjs/discord.js node-opus` for voice support.
+For now, you do need Git installed and added to your PATH environment, so ensure that's done as well - again, guides are available online for a wide variety of operating systems.  Once you have Node up-to-date and Git installed, you can install v12 by running `npm install discordjs/discord.js` in your terminal or command prompt for text-only use, or `npm install discordjs/discord.js @discordjs/opus` for voice support.
 
 ## Commonly Used Methods That Changed
 

--- a/guide/popular-topics/miscellaneous-examples.md
+++ b/guide/popular-topics/miscellaneous-examples.md
@@ -17,7 +17,7 @@ npm install --save ytdl-core
 If you get an error that says 'OPUS_ENGINE_MISSING', you'll need to install one of the opus packages discord.js recommends.
 
 ```
-npm install --save node-opus
+npm install --save @discordjs/opus
 ```
 
 If you get an error that says 'FFMPEG not found', this can be resolved by installing ffmpeg.

--- a/guide/voice/README.md
+++ b/guide/voice/README.md
@@ -24,7 +24,8 @@ async function play(voiceChannel) {
 At the bare minimum, you'll need:
 
 - An Opus library:
-  - [`node-opus`](https://github.com/Rantanen/node-opus/) (best performance)
+  - [`@discordjs/opus`](https://github.com/discordjs/opus) (best performance)
+  - [`node-opus`](https://github.com/Rantanen/node-opus/)
   - [`opusscript`](https://github.com/abalabahaha/opusscript/)
 
 You may also choose to install the following dependencies.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR advises users to use `@discordjs/opus` over `node-opus` as it has better audio quality and comparable performance. This is especially important now that `node-opus` will [no longer be maintained](https://github.com/discordjs/discord.js/issues/3678).