### PR TITLE
feat(v12): dynamic urls

### DIFF
--- a/code-samples/command-handling/adding-features/12/commands/avatar.js
+++ b/code-samples/command-handling/adding-features/12/commands/avatar.js
@@ -4,11 +4,11 @@ module.exports = {
 	aliases: ['icon', 'pfp'],
 	execute(message) {
 		if (!message.mentions.users.size) {
-			return message.channel.send(`Your avatar: <${message.author.displayAvatarURL()}>`);
+			return message.channel.send(`Your avatar: <${message.author.displayAvatarURL({ dynamic: true })}>`);
 		}
 
 		const avatarList = message.mentions.users.map(user => {
-			return `${user.username}'s avatar: <${user.displayAvatarURL()}>`;
+			return `${user.username}'s avatar: <${user.displayAvatarURL({ dynamic: true })}>`;
 		});
 
 		message.channel.send(avatarList);

--- a/code-samples/command-handling/dynamic-commands/12/commands/avatar.js
+++ b/code-samples/command-handling/dynamic-commands/12/commands/avatar.js
@@ -3,11 +3,11 @@ module.exports = {
 	description: 'Get the avatar URL of the tagged user(s), or your own avatar.',
 	execute(message) {
 		if (!message.mentions.users.size) {
-			return message.channel.send(`Your avatar: ${message.author.displayAvatarURL()}`);
+			return message.channel.send(`Your avatar: ${message.author.displayAvatarURL({ dynamic: true })}`);
 		}
 
 		const avatarList = message.mentions.users.map(user => {
-			return `${user.username}'s avatar: ${user.displayAvatarURL()}`;
+			return `${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`;
 		});
 
 		message.channel.send(avatarList);

--- a/code-samples/command-handling/file-setup/12/commands/avatar.js
+++ b/code-samples/command-handling/file-setup/12/commands/avatar.js
@@ -3,11 +3,11 @@ module.exports = {
 	description: 'Get the avatar URL of the tagged user(s), or your own avatar.',
 	execute(message) {
 		if (!message.mentions.users.size) {
-			return message.channel.send(`Your avatar: ${message.author.displayAvatarURL()}`);
+			return message.channel.send(`Your avatar: ${message.author.displayAvatarURL({ dynamic: true })}`);
 		}
 
 		const avatarList = message.mentions.users.map(user => {
-			return `${user.username}'s avatar: ${user.displayAvatarURL()}`;
+			return `${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`;
 		});
 
 		message.channel.send(avatarList);

--- a/code-samples/command-handling/file-setup/12/index.js
+++ b/code-samples/command-handling/file-setup/12/index.js
@@ -48,11 +48,11 @@ client.on('message', message => {
 		message.channel.send(`You wanted to kick: ${taggedUser.username}`);
 	} else if (command === 'avatar') {
 		if (!message.mentions.users.size) {
-			return message.channel.send(`Your avatar: ${message.author.displayAvatarURL}`);
+			return message.channel.send(`Your avatar: ${message.author.displayAvatarURL({ dynamic: true })}`);
 		}
 
 		const avatarList = message.mentions.users.map(user => {
-			return `${user.username}'s avatar: ${user.displayAvatarURL}`;
+			return `${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`;
 		});
 
 		message.channel.send(avatarList);

--- a/code-samples/creating-your-bot/commands-with-user-input/12/index.js
+++ b/code-samples/creating-your-bot/commands-with-user-input/12/index.js
@@ -38,11 +38,11 @@ client.on('message', message => {
 		message.channel.send(`You wanted to kick: ${taggedUser.username}`);
 	} else if (command === 'avatar') {
 		if (!message.mentions.users.size) {
-			return message.channel.send(`Your avatar: <${message.author.displayAvatarURL()}>`);
+			return message.channel.send(`Your avatar: <${message.author.displayAvatarURL({ dynamic: true })}>`);
 		}
 
 		const avatarList = message.mentions.users.map(user => {
-			return `${user.username}'s avatar: <${user.displayAvatarURL()}>`;
+			return `${user.username}'s avatar: <${user.displayAvatarURL({ dynamic: true })}>`;
 		});
 
 		message.channel.send(avatarList);

--- a/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
@@ -45,10 +45,10 @@ client.on('message', message => {
 				return message.reply('Please use a proper mention if you want to see someone else\'s avatar.');
 			}
 
-			return message.channel.send(`${user.username}'s avatar: ${user.displayAvatarURL()}`);
+			return message.channel.send(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);
 		}
 
-		return message.channel.send(`${message.author.username}, your avatar: ${message.author.displayAvatarURL()}`);
+		return message.channel.send(`${message.author.username}, your avatar: ${message.author.displayAvatarURL({ dynamic: true })}`);
 	}
 });
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -143,7 +143,7 @@ The method to ban members and users have been moved to the `GuildMemberStore` Da
 
 ### Image URLs
 
-Some image-related properties like `user.avatarURL` are now a method in v12, so that you can apply some options to them, eg. to affect their display size.
+Some image-related properties like `user.avatarURL` are now a method in v12, so that you can apply some options to them, eg. to affect their display size. 
 
 ```diff
 - user.avatarURL;
@@ -157,6 +157,14 @@ Some image-related properties like `user.avatarURL` are now a method in v12, so 
 
 - guild.splashURL;
 + guild.splashURL();
+```
+
+## Dynamic File type
+
+Version 12 now allows you to dynamically set the file type for images. If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
+
+```js
+user.avatarURL({ format: 'png', dynamic: true, size: 1024 });
 ```
 
 ### RichEmbed Constructor
@@ -525,12 +533,12 @@ There have been several changes made to the `ClientOptions` object located in `c
 
 #### ClientUser#avatarURL
 
-`clientUser.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
+`clientUser.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return. The `dynamic` option allows you to always get a `.gif` file for animated avatars. Otherwise the returned link will fall back to the format specified in the `format` option or `.webp` (it's default) if none is provided.
 
 ```diff
 - clientUser.avatarURL;
 + clientUser.avatarURL();
-+ clientUser.avatarURL({ format: 'png', size: 1024 });
++ clientUser.avatarURL({ dynamic: true, format: 'png', size: 1024 });
 ```
 
 #### ClientUser#block
@@ -552,12 +560,12 @@ There have been several changes made to the `ClientOptions` object located in `c
 
 #### ClientUser#displayAvatarURL
 
-`clientUser.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
+`clientUser.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return. If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 
 ```diff
 - clientUser.displayAvatarURL;
 + clientUser.displayAvatarURL();
-+ clientUser.displayAvatarURL({ format: 'png', size: 1024 });
++ clientUser.displayAvatarURL({ format: 'png', dynamic: true, size: 1024 });
 ```
 
 #### ClientUser#email
@@ -891,12 +899,12 @@ Not sure how to set up a database? Check out [this page](/sequelize/)!
 
 #### Guild#iconURL
 
-`guild.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
+`guild.iconURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return. If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 
 ```diff
 - guild.iconURL;
 + guild.iconURL();
-+ guild.iconURL({ format: 'png', size: 1024 });
++ guild.iconURL({ format: 'png', dynamic: true, size: 1024 });
 ```
 
 #### Guild#messageNotifications
@@ -1707,12 +1715,12 @@ All the `.send***()` methods have been removed in favor of one general `.send()`
 
 #### User#avatarURL
 
-`user.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
+`user.avatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return. If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 
 ```diff
 - user.avatarURL;
 + user.avatarURL();
-+ user.avatarURL({ format: 'png', size: 1024 });
++ user.avatarURL({ format: 'png', dynamic: true, size: 1024 });
 ```
 
 #### User#block
@@ -1721,12 +1729,12 @@ All the `.send***()` methods have been removed in favor of one general `.send()`
 
 #### User#displayAvatarURL
 
-`user.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return.
+`user.displayAvatarURL` is now a method, as opposed to a property. It also allows you to determine the file format and size to return. If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 
 ```diff
 - user.displayAvatarURL;
 + user.displayAvatarURL();
-+ user.displayAvatarURL({ format: 'png', size: 1024 });
++ user.displayAvatarURL({ format: 'png', dynamic: true, size: 1024 });
 ```
 
 #### User#fetchProfile

--- a/guide/creating-your-bot/commands-with-user-input.md
+++ b/guide/creating-your-bot/commands-with-user-input.md
@@ -221,12 +221,14 @@ else if (command === 'avatar') {
 ```js
 else if (command === 'avatar') {
 	if (!message.mentions.users.size) {
-		return message.channel.send(`Your avatar: <${message.author.displayAvatarURL()}>`);
+		return message.channel.send(`Your avatar: <${message.author.displayAvatarURL(format: "png", dynamic: true)}>`);
 	}
 
 	// ...
 }
 ```
+
+If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 
 </branch>
 
@@ -272,11 +274,11 @@ else if (command === 'avatar') {
 ```js
 else if (command === 'avatar') {
 	if (!message.mentions.users.size) {
-		return message.channel.send(`Your avatar: <${message.author.displayAvatarURL()}>`);
+		return message.channel.send(`Your avatar: <${message.author.displayAvatarURL(format: "png", dynamic: true)}>`);
 	}
 
 	const avatarList = message.mentions.users.map(user => {
-		return `${user.username}'s avatar: <${user.displayAvatarURL()}>`;
+		return `${user.username}'s avatar: <${user.displayAvatarURL(format: "png", dynamic: true)}>`;
 	});
 
 	// send the entire array of strings as a message
@@ -284,6 +286,8 @@ else if (command === 'avatar') {
 	message.channel.send(avatarList);
 }
 ```
+
+If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 
 </branch>
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

discord.js introduced a dynamic option for image URLs, which should be used to receive expected results (animated images being displayed as gif) throughout the v12 guide and in the changes section.

* use dynamic URLSs throughout the guide
* use dynamic URLs in code samples
* fix non-method usage of URL in code samples
* explain dynamic in v12-changes
