### PR TITLE
typo: change MessageAttachment to Attachment

### DIFF
--- a/guide/popular-topics/canvas.md
+++ b/guide/popular-topics/canvas.md
@@ -656,7 +656,7 @@ client.on('guildMemberAdd', async member => {
 	const avatar = await Canvas.loadImage(member.user.displayAvatarURL);
 	ctx.drawImage(avatar, 25, 25, 200, 200);
 
-	const attachment = new Discord.MessageAttachment(canvas.toBuffer(), 'welcome-image.png');
+	const attachment = new Discord.Attachment(canvas.toBuffer(), 'welcome-image.png');
 
 	channel.send(`Welcome to the server, ${member}!`, attachment);
 });


### PR DESCRIPTION
Canvas guide had a typo when referencing the `MessageAttachment` class, which should be `Attachment` for the stable branch of discord.js.