### PR TITLE
Change addField to addFields for v12

### DIFF
--- a/code-samples/additional-info/rest-api/12/index.js
+++ b/code-samples/additional-info/rest-api/12/index.js
@@ -41,8 +41,8 @@ client.on('message', async message => {
 			.setTitle(answer.word)
 			.setURL(answer.permalink)
 			.addFields(
-				{ name: 'Definition', value: trim(answer.definition, 1024)},
-				{ name: 'Example', value: trim(answer.example, 1024)},
+				{ name: 'Definition', value: trim(answer.definition, 1024) },
+				{ name: 'Example', value: trim(answer.example, 1024) },
 				{ name: 'Rating', value: `${answer.thumbs_up} thumbs up. ${answer.thumbs_down} thumbs down.` },
 			);
 		message.channel.send(embed);

--- a/code-samples/additional-info/rest-api/12/index.js
+++ b/code-samples/additional-info/rest-api/12/index.js
@@ -40,10 +40,11 @@ client.on('message', async message => {
 			.setColor('#EFFF00')
 			.setTitle(answer.word)
 			.setURL(answer.permalink)
-			.addField('Definition', trim(answer.definition, 1024))
-			.addField('Example', trim(answer.example, 1024))
-			.addField('Rating', `${answer.thumbs_up} thumbs up. ${answer.thumbs_down} thumbs down.`);
-
+			.addFields(
+				{ name: 'Definition', value: trim(answer.definition, 1024)},
+				{ name: 'Example', value: trim(answer.example, 1024)},
+				{ name: 'Rating', value: `${answer.thumbs_up} thumbs up. ${answer.thumbs_down} thumbs down.` },
+			);
 		message.channel.send(embed);
 	}
 });

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1332,7 +1332,7 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 
 #### MessageEmbed#attachFiles
 
-`RichEmbed.attachFile()` is the only method that did not make the transition from v11 to v12.  The `MessageEmbed.attachFiles()` works for one or more files.
+`RichEmbed.attachFile()` has been removed in favor of `MessageEmbed.attachFiles()` method, which works for one or more files.
 
 #### MessageEmbed#client
 

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -187,7 +187,7 @@ user.avatarURL({ format: 'png', dynamic: true, size: 1024 });
 
 ### RichEmbed Constructor
 
-The RichEmbed constructor has been removed and now the `MessageEmbed` constructor is used.  It is largely the same to use, the only difference being the removal of `RichEmbed.attachFile()` - `MessageEmbed.attachFiles()` accepts a single file as a parameter as well.
+The RichEmbed constructor has been removed and now the `MessageEmbed` constructor is used. It is largely the same to use, the only differences being the removal of `RichEmbed.attachFile()` - `MessageEmbed.attachFiles()` accepts a single file as a parameter as well, and removing `RichEmbed.addField()` and `RichEmbed.addBlankField()` methods in favor of `MessageEmbed.addFields()` which can add multiple fields in one call.
 
 ### String Concatenation
 
@@ -1321,6 +1321,14 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 ### MessageEmbed
 
 `MessageEmbed` now encompasses both the received embeds in a message and the constructor - the `RichEmbed` constructor was removed in favor of `MessageEmbed`.
+
+#### MessageEmbed#addField
+
+`messageEmbed.addField()` has been removed in favor of `messageEmbed.addFields()` that can add multiple fields per call.
+
+#### MessageEmbed#addBlankField
+
+`messageEmbed.addBlankField()` has been removed entirely. To add a blank field, use `messageEmbed.addFields()` and pass `'\u200b'` as values for the field.
 
 #### MessageEmbed#attachFiles
 

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -215,9 +215,11 @@ const embed = new MessageEmbed()
 	.setColor('#EFFF00')
 	.setTitle(answer.word)
 	.setURL(answer.permalink)
-	.addField('Definition', trim(answer.definition, 1024))
-	.addField('Example', trim(answer.example, 1024))
-	.addField('Rating', `${answer.thumbs_up} thumbs up. ${answer.thumbs_down} thumbs down.`);
+	.addFields(
+		{ name: 'Definition', value: trim(answer.definition, 1024) },
+		{ name: 'Example', value: trim(answer.example, 1024) },
+		{ name: 'Rating', value: `${answer.thumbs_up} thumbs up. ${answer.thumbs_down} thumbs down.` }
+	);
 
 message.channel.send(embed);
 ```

--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -96,11 +96,13 @@ const exampleEmbed = new Discord.MessageEmbed()
 	.setAuthor('Some name', 'https://i.imgur.com/wSTFkRM.png', 'https://discord.js.org')
 	.setDescription('Some description here')
 	.setThumbnail('https://i.imgur.com/wSTFkRM.png')
-	.addField('Regular field title', 'Some value here')
-	.addBlankField()
-	.addField('Inline field title', 'Some value here', true)
-	.addField('Inline field title', 'Some value here', true)
-	.addField('Inline field title', 'Some value here', true)
+	.addFields(
+		{ name: 'Regular field title', value: 'Some value here' },
+		{ name: '\u200B', value: '\u200B' },
+		{ name: 'Inline field title', value: 'Some value here', inline: true },
+		{ name: 'Inline field title', value: 'Some value here', inline: true },
+		{ name: 'Inline field title', value: 'Some value here', inline: true },
+	)
 	.setImage('https://i.imgur.com/wSTFkRM.png')
 	.setTimestamp()
 	.setFooter('Some footer text here', 'https://i.imgur.com/wSTFkRM.png');
@@ -116,7 +118,16 @@ You don't need to include all the elements showcased above. If you want a simple
 
 The `.setColor()` method accepts an integer, HEX color string, an array of RGB values or specific color strings. You can find a list of them at <branch version="11.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/typedef/ColorResolvable)</branch><branch version="12.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/master/typedef/ColorResolvable)</branch>.
 
+<branch version="11.x">
+
 `.addBlankField()` is a convenience method for `.addField('\u200b', '\u200b')` to add a spacer to the embed. This can also be used inline by passing `true` as the first parameter.
+
+</branch>
+<branch version="12.x">
+
+`.addBlankField()` was a convienience method for using `.addField('\u200b', '\u200b')` to add a spacer to the embed. However, separate method for that was removed when `.addField()` method was replaced with `.addFields()`. To add a blank field with `.addFields()`, do `.addFields({ name: '\u200b', value: '\u200b' })`
+
+</branch>
 
 The above example chains the manipulating methods to the newly created <branch version="11.x" inline>RichEmbed</branch><branch version="12.x" inline>MessageEmbed</branch> object.
 If you want to modify the embed based on conditions you will need to reference it as the constant `exampleEmbed` (for our example).

--- a/guide/popular-topics/errors.md
+++ b/guide/popular-topics/errors.md
@@ -209,11 +209,11 @@ client.users.fetch('myId').then(someInitFunction);
 
 ### MessageEmbed field names may not be empty.
 
-This error originates from attempting to call `MessageEmbed.addField()` without the first parameter, which is a title. If you would like the title to be empty for a reason, you should use a zero width space, which can be inputted as `\u200b`.
+This error originates from attempting to call `MessageEmbed.addFields()` with field object that has an empty string as a value for `name` field. If you would like the title to be empty for a reason, you should use a zero width space, which can be inputted as `\u200b`.
 
 ### MessageEmbed field values may not be empty.
 
-This error, in conjunction to the previous error, is the result of calling `MessageEmbed.addField()` without the second parameter, the value. You can use a zero width space if you would like this empty.
+This error, in conjunction to the previous error, is the result of calling `MessageEmbed.addFields()` with field object that has an empty string as a value for `value` field. You can use a zero width space if you would like this empty.
 
 </branch>
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes `addField` to `addFields` for v12 code in embed and rest-api guides, as well as updates field related errors in common discord.js errors, and finally adds the fact of change to changes-in-v12.

Supersedes #331 