### PR TITLE
Change default Discord.js version of guide to v12

### DIFF
--- a/guide/.vuepress/branches.js
+++ b/guide/.vuepress/branches.js
@@ -1,12 +1,12 @@
 export default [
 	{
-		label: 'v11.5 (stable)',
-		version: '11.x',
-		aliases: ['11', 'stable'],
+		label: 'v12.x (stable)',
+		version: '12.x',
+		aliases: ['12', 'stable'],
 	},
 	{
-		label: 'v12.x (master)',
-		version: '12.x',
-		aliases: ['12', 'master'],
+		label: 'v11.5',
+		version: '11.x',
+		aliases: ['11'],
 	},
 ];


### PR DESCRIPTION
Changed the default Discord.js version of the guide to v12 because it is now stable
