### PR TITLE
docs(readme): fix links to guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This guide is aimed at users who are either unfamiliar or inexperienced with Nod
 
 There are many different subjects covered, such as:
 
-- How to get a bot [up and running](https://discordjs.guide/#/preparations/) from scratch;
-- How to properly [create](https://discordjs.guide/#/creating-your-bot/), [organize](https://discordjs.guide/#/command-handling/), and [expand](https://discordjs.guide/#/command-handling/adding-features) on your commands;
-- In-depth explanations and examples regarding popular topics (e.g. [reactions](https://discordjs.guide/#/popular-topics/reactions), [embeds](https://discordjs.guide/#/popular-topics/embeds), [canvas](https://discordjs.guide/#/popular-topics/canvas));
-- Working with databases (e.g. [sequelize](https://discordjs.guide/#/sequelize/) and [keyv](https://discordjs.guide/#/keyv/));
-- Getting started with [sharding](https://discordjs.guide/#/sharding/);
+- How to get a bot [up and running](https://discordjs.guide/preparations/) from scratch;
+- How to properly [create](https://discordjs.guide/creating-your-bot/), [organize](https://discordjs.guide/command-handling/), and [expand](https://discordjs.guide/command-handling/adding-features) on your commands;
+- In-depth explanations and examples regarding popular topics (e.g. [reactions](https://discordjs.guide/popular-topics/reactions), [embeds](https://discordjs.guide/popular-topics/embeds), [canvas](https://discordjs.guide/popular-topics/canvas));
+- Working with databases (e.g. [sequelize](https://discordjs.guide/sequelize/) and [keyv](https://discordjs.guide/keyv/));
+- Getting started with [sharding](https://discordjs.guide/sharding/);
 - And much more.
 
 ## Contributing


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Before the links to various pages in the guide were for example `https://discordjs.guide/#/preparations/` which would take you to the homepage, so this commit fixes them to remove the `/#`: `https://discordjs.guide/preparations/`.
