### PR TITLE
Add information about intents

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -353,6 +353,7 @@ While this list has been carefully crafted, it may be incomplete! If you notice 
 * Webhook [(changes)](/additional-info/changes-in-v12.md#webhook) [(additions)](/additional-info/changes-in-v12.md#webhook-2)
 * WebhookClient [(changes)](/additional-info/changes-in-v12.md#webhookclient)
 * WebSocketManager [(additions)](/additional-info/changes-in-v12.md#websocketmanager)
+* WebsocketOptions [(additions)](/additional-info/changes-in-v12.md#websocketoptions)
 * WebSocketShard [(additions)](/additional-info/changes-in-v12.md#websocketshard)
 
 ### Dependencies

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -543,6 +543,10 @@ There have been several changes made to the `ClientOptions` object located in `c
 
 `clientOptions.sync` has been removed entirely, along with all other user account-only properties and methods.
 
+#### ClientOptions#disabledEvents
+
+`clientOptions.disabledEvents` has been removed in favor of using intents. Please refer to our more [detailed article about this topic](/popular-topics/intents)
+
 ### ClientUser
 
 #### ClientUser#acceptInvite
@@ -2342,6 +2346,12 @@ This new property returns a `string` representing the URL of the webhook, and is
 ### WebSocketManager
 
 This new class represents the manager of the websocket connection for the client.
+
+### WebsocketOptions
+
+#### WebsocketOptions#intents
+
+This new parameter adds support for Intents, controlling which events you receive from Discord. Please refer to our more [detailed article about this topic](/popular-topics/intents)
 
 ### WebSocketShard
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds information to the v11 to v12 update guide about `disabledEvents` being removed in favor of specifying intents in `clientOptions`.