### PR TITLE
fix: for..of iteration in reactions guide

### DIFF
--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -256,7 +256,7 @@ Removing reactions by user is similar to what you did before. However, instead o
 ```js
 const userReactions = message.reactions.filter(reaction => reaction.users.has(userId));
 try {
-	for (const reaction of userReactions) {
+	for (const [id, reaction] of userReactions) {
 		await reaction.remove(userId);
 	}
 } catch (error) {
@@ -277,7 +277,7 @@ Removing reactions by user is not as straightforward as removing by emoji or rem
 ```js
 const userReactions = message.reactions.cache.filter(reaction => reaction.users.cache.has(userId));
 try {
-	for (const reaction of userReactions) {
+	for (const [id, reaction] of userReactions) {
 		await reaction.users.remove(userId);
 	}
 } catch (error) {

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -256,7 +256,7 @@ Removing reactions by user is similar to what you did before. However, instead o
 ```js
 const userReactions = message.reactions.filter(reaction => reaction.users.has(userId));
 try {
-	for (const [id, reaction] of userReactions) {
+	for (const reaction of userReactions.values()) {
 		await reaction.remove(userId);
 	}
 } catch (error) {
@@ -277,7 +277,7 @@ Removing reactions by user is not as straightforward as removing by emoji or rem
 ```js
 const userReactions = message.reactions.cache.filter(reaction => reaction.users.cache.has(userId));
 try {
-	for (const [id, reaction] of userReactions) {
+	for (const reaction of userReactions.values()) {
 		await reaction.users.remove(userId);
 	}
 } catch (error) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Whenever you iterate over a Collection with ``for...of`` loop, it has two parameters, a key and a value. This pr fixes those parts where ``for (const reaction of userReactions)`` is used, because the first parameter of the collection represents the `Snowflake`, and the second represents the `Object`. This has been fixed by the use of destructured array here.