### PR TITLE
fix(Voice): remove passes option from example

### DIFF
--- a/guide/voice/the-basics.md
+++ b/guide/voice/the-basics.md
@@ -58,10 +58,10 @@ To end the stream yourself, you can run:
 dispatcher.destroy();
 ```
 
-You can also create the dispatcher with options. The following example will play a stream at 50% volume and with 3 passes (this is the number of times an audio packet is sent. Increasing this value will reduce the chance of packet loss, but will also increase bandwidth used!)
+You can also create the dispatcher with options. The following example will play a stream at 50% volume from the start on.
 
 ```js
-connection.play('audio.mp3', { volume: 0.5, passes: 3 });
+connection.play('audio.mp3', { volume: 0.5 });
 ```
 
 ### Which audio sources can I use?


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the `passes` option from the `VoiceConnection#play` example of the `Voice` guide in the `Playing audio` section.

This option was removed with the release of 12.0.0 and additionally Discord does not want to receive multiple streams of the same voice packets at all.