### PR TITLE
fix example(s) of overwritePermissions()

### DIFF
--- a/code-samples/popular-topics/permissions/12/index.js
+++ b/code-samples/popular-topics/permissions/12/index.js
@@ -55,8 +55,7 @@ client.on('message', message => {
 			return message.channel.send('Please make sure I have the `MANAGE_ROLES` permissions in this channel and retry.');
 		}
 
-		message.channel.overwritePermissions({
-			permissionOverwrites: [
+		message.channel.overwritePermissions([
 				{
 					id: message.guild.id,
 					deny: ['VIEW_CHANNEL'],
@@ -69,8 +68,7 @@ client.on('message', message => {
 					id: message.author.id,
 					allow: ['VIEW_CHANNEL'],
 				},
-			],
-		})
+			])
 			.then(() => message.channel.send(`Made channel \`${message.channel.name}\` private.`))
 			.catch(console.error);
 	} else if (message.content === '!create-private') {

--- a/code-samples/popular-topics/permissions/12/index.js
+++ b/code-samples/popular-topics/permissions/12/index.js
@@ -56,21 +56,21 @@ client.on('message', message => {
 		}
 
 		message.channel.overwritePermissions([
-				{
-					id: message.guild.id,
-					deny: ['VIEW_CHANNEL'],
-				},
-				{
-					id: client.user.id,
-					allow: ['VIEW_CHANNEL'],
-				},
-				{
-					id: message.author.id,
-					allow: ['VIEW_CHANNEL'],
-				},
-			])
-			.then(() => message.channel.send(`Made channel \`${message.channel.name}\` private.`))
-			.catch(console.error);
+			{
+				id: message.guild.id,
+				deny: ['VIEW_CHANNEL'],
+			},
+			{
+				id: client.user.id,
+				allow: ['VIEW_CHANNEL'],
+			},
+			{
+				id: message.author.id,
+				allow: ['VIEW_CHANNEL'],
+			},
+		])
+		.then(() => message.channel.send(`Made channel \`${message.channel.name}\` private.`))
+		.catch(console.error);
 	} else if (message.content === '!create-private') {
 		message.guild.channels.create('private', {
 			type: 'text', permissionOverwrites: [

--- a/code-samples/popular-topics/permissions/12/index.js
+++ b/code-samples/popular-topics/permissions/12/index.js
@@ -69,8 +69,8 @@ client.on('message', message => {
 				allow: ['VIEW_CHANNEL'],
 			},
 		])
-		.then(() => message.channel.send(`Made channel \`${message.channel.name}\` private.`))
-		.catch(console.error);
+			.then(() => message.channel.send(`Made channel \`${message.channel.name}\` private.`))
+			.catch(console.error);
 	} else if (message.content === '!create-private') {
 		message.guild.channels.create('private', {
 			type: 'text', permissionOverwrites: [

--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -245,21 +245,19 @@ channel.replacePermissionOverwrites({
 
 ```js
 // copying overwrites from another channel
-channel.overwritePermissions({ permissionOverwrites: otherChannel.permissionOverwrites });
+channel.overwritePermissions(otherChannel.permissionOverwrites);
 
 // replacing overwrites with PermissionOverwriteOptions
-channel.overwritePermissions({
-	permissionOverwrites: [
-		{
-			id: guild.id,
-			deny: ['VIEW_CHANNEL'],
-		},
-		{
-			id: user.id,
-			allow: ['VIEW_CHANNEL'],
-		},
-	],
-});
+channel.overwritePermissions([
+	{
+		id: guild.id,
+		deny: ['VIEW_CHANNEL'],
+	},
+	{
+		id: user.id,
+		allow: ['VIEW_CHANNEL'],
+	},
+]);
 ```
 
 </branch>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fix the V12 example for overwritePermissions() in the permissions guide which showed  ~~V11.X~~ master methodology.

One could argue demonstrating the `reason` option as well, but I don't personally see that as important here.