### PR TITLE
fix(Permissions): overwritePermissions example for v12

### DIFF
--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -245,21 +245,19 @@ channel.replacePermissionOverwrites({
 
 ```js
 // copying overwrites from another channel
-channel.overwritePermissions({ permissionOverwrites: otherChannel.permissionOverwrites });
+channel.overwritePermissions(otherChannel.permissionOverwrites);
 
 // replacing overwrites with PermissionOverwriteOptions
-channel.overwritePermissions({
-	permissionOverwrites: [
-		{
-			id: guild.id,
-			deny: ['VIEW_CHANNEL'],
-		},
-		{
-			id: user.id,
-			allow: ['VIEW_CHANNEL'],
-		},
-	],
-});
+channel.overwritePermissions([
+	{
+		id: guild.id,
+		deny: ['VIEW_CHANNEL'],
+	},
+	{
+		id: user.id,
+		allow: ['VIEW_CHANNEL'],
+	},
+]);
 ```
 
 </branch>


### PR DESCRIPTION
The example was wrong.

Now it isn't.