### PR TITLE
fix: expect filename to be commandname

### DIFF
--- a/code-samples/command-handling/adding-features/11/commands/reload.js
+++ b/code-samples/command-handling/adding-features/11/commands/reload.js
@@ -11,7 +11,7 @@ module.exports = {
 			return message.channel.send(`There is no command with name or alias \`${commandName}\`, ${message.author}!`);
 		}
 
-		const id = Object.values(require.cache).find(module => module.exports === command).id;
+		const { id } = Object.values(require.cache).find(module => module.exports === command);
 		delete require.cache[id];
 
 		try {

--- a/code-samples/command-handling/adding-features/11/commands/reload.js
+++ b/code-samples/command-handling/adding-features/11/commands/reload.js
@@ -11,10 +11,11 @@ module.exports = {
 			return message.channel.send(`There is no command with name or alias \`${commandName}\`, ${message.author}!`);
 		}
 
-		delete require.cache[require.resolve(`./${command.name}.js`)];
+		const id = Object.values(require.cache).find(module => module.exports === command).id;
+		delete require.cache[id];
 
 		try {
-			const newCommand = require(`./${command.name}.js`);
+			const newCommand = require(id);
 			message.client.commands.set(newCommand.name, newCommand);
 		} catch (error) {
 			console.log(error);

--- a/code-samples/command-handling/adding-features/12/commands/reload.js
+++ b/code-samples/command-handling/adding-features/12/commands/reload.js
@@ -11,7 +11,7 @@ module.exports = {
 			return message.channel.send(`There is no command with name or alias \`${commandName}\`, ${message.author}!`);
 		}
 
-		const id = Object.values(require.cache).find(module => module.exports === command).id;
+		const { id } = Object.values(require.cache).find(module => module.exports === command);
 		delete require.cache[id];
 
 		try {

--- a/code-samples/command-handling/adding-features/12/commands/reload.js
+++ b/code-samples/command-handling/adding-features/12/commands/reload.js
@@ -11,10 +11,11 @@ module.exports = {
 			return message.channel.send(`There is no command with name or alias \`${commandName}\`, ${message.author}!`);
 		}
 
-		delete require.cache[require.resolve(`./${command.name}.js`)];
+		const id = Object.values(require.cache).find(module => module.exports === command).id;
+		delete require.cache[id];
 
 		try {
-			const newCommand = require(`./${command.name}.js`);
+			const newCommand = require(id);
 			message.client.commands.set(newCommand.name, newCommand);
 		} catch (error) {
 			console.log(error);

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -421,7 +421,7 @@ A lot of library specific structures have `client` as a property. That means you
 Now, in theory, all there is to do, is to delete the previous command from `client.commands` and require the file again. In practice though, you cannot do this that easily as `require()` caches the file. If you were to require it again, you would simply load the previously cached file without any of your changes. In order to remove the file from the cache, you need to add the following lines to your code:
 
 ```js
-const id = Object.values(require.cache).find(module => module.exports === command).id;
+const { id } = Object.values(require.cache).find(module => module.exports === command);
 delete require.cache[id];
 ```
 

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -418,17 +418,18 @@ if (!command) return message.channel.send(`There is no command with name or alia
 A lot of library specific structures have `client` as a property. That means you don't have to pass the client reference as a parameter to commands to access for example `client.guilds` or `client.commands`, but can directly access the respective properties directly from the `message` object, as shown in the snippet above.
 :::
 
-Now, in theory, all there is to do, is to delete the previous command from `client.commands` and require the file again. In practice though, you cannot do this that easily as `require()` caches the file. If you were to require it again, you would simply load the previously cached file without any of your changes. In order to remove the file from the cache, you need to add the following line to your code:
+Now, in theory, all there is to do, is to delete the previous command from `client.commands` and require the file again. In practice though, you cannot do this that easily as `require()` caches the file. If you were to require it again, you would simply load the previously cached file without any of your changes. In order to remove the file from the cache, you need to add the following lines to your code:
 
 ```js
-delete require.cache[require.resolve(`./${command.name}.js`)];
+const id = Object.values(require.cache).find(module => module.exports === command).id;
+delete require.cache[id];
 ```
 
 After removing the command from the cache, all you have to do is require the file again and add the freshly loaded command to `client.commands`:
 
 ```js
 try {
-	const newCommand = require(`./${command.name}.js`);
+	const newCommand = require(id);
 	message.client.commands.set(newCommand.name, newCommand);
 } catch (error) {
 	console.log(error);


### PR DESCRIPTION
The reloading command expects the file to be called `./${command.name}.js`. Even though this is reasonable it might be better not to rely on it. Also the command handler does not make such a requirement.

The suggested solution is to search the old module in the cache and read it's id.

However this solution might be more confusing for the reader.