### PR TITLE
fix: move success message into try block

### DIFF
--- a/code-samples/command-handling/adding-features/11/commands/reload.js
+++ b/code-samples/command-handling/adding-features/11/commands/reload.js
@@ -16,10 +16,10 @@ module.exports = {
 		try {
 			const newCommand = require(`./${command.name}.js`);
 			message.client.commands.set(newCommand.name, newCommand);
+			message.channel.send(`Command \`${command.name}\` was reloaded!`);
 		} catch (error) {
 			console.log(error);
-			return message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
+			message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
 		}
-		message.channel.send(`Command \`${command.name}\` was reloaded!`);
 	},
 };

--- a/code-samples/command-handling/adding-features/12/commands/reload.js
+++ b/code-samples/command-handling/adding-features/12/commands/reload.js
@@ -16,10 +16,10 @@ module.exports = {
 		try {
 			const newCommand = require(`./${command.name}.js`);
 			message.client.commands.set(newCommand.name, newCommand);
+			message.channel.send(`Command \`${command.name}\` was reloaded!`);
 		} catch (error) {
 			console.log(error);
-			return message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
+			message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
 		}
-		message.channel.send(`Command \`${command.name}\` was reloaded!`);
 	},
 };

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -438,7 +438,7 @@ try {
 
 The snippet above uses a `try/catch` block to load the command file and add it to `client.commands`. In case of an error it will log the full error to console and notify the user about it with the error's message component `error.message`. Note the you never actually delete the command from the commands collection, and instead just overwrite it. This prevents you from deleting a command, and ending up with no command at all after a failed `require()` call, as each use of the reload command checks that collection again.
 
-The last thing you might want to add is sending a message if the reload was successful:
+The last slight improvement you might want to add to the try block is sending a message if the reload was successful:
 
 ```js
 message.channel.send(`Command \`${command.name}\` was reloaded!`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

After looking more into the inconsistency raised by #377 the success message semantically fits better into the try block instead of returning on catch. To facilitate this change I also mentioned the location explicitly in the guide article

* mention the location explicitly in the guide
* adapt code samples
* Closes #377