### PR TITLE
Add missing 's' in method call

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1369,7 +1369,7 @@ The `max` and `maxMatches` properties of the `MessageCollector` class have been 
 
 #### MessageEmbed#addBlankField
 
-`messageEmbed.addBlankField()` has been removed entirely. To add a blank field, use `messageEmbed.addField('\u200b', '\u200b')`.
+`messageEmbed.addBlankField()` has been removed entirely. To add a blank field, use `messageEmbed.addFields('\u200b', '\u200b')`.
 
 #### MessageEmbed#attachFiles
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Typo fix on the MessageEmbed#addFields reference for blank fields.