### PR TITLE
fix: port documentation links to stable

### DIFF
--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -328,7 +328,7 @@ There's nothing really complex here; all you do is append some strings, `.map()`
 Since help messages can get messy, you'll be DMing it to the message author instead of posting it in the requested channel. However, there is something very important you should consider: the possibility of not being able to DM the user, whether it be that they have DMs disabled on that server or overall, or they have the bot blocked. For that reason, you should `.catch()` it and let them know.
 
 ::: tip
-If you weren't already aware, `.send()` takes 2 parameters: the content to send, and the message options to pass in. You can read about the `MessageOptions` type <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/typedef/MessageOptions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/typedef/MessageOptions)</branch>. Using `split: true` here will automatically split our help message into 2 or more messages in the case that it exceeds the 2,000 character limit.
+If you weren't already aware, `.send()` takes 2 parameters: the content to send, and the message options to pass in. You can read about the `MessageOptions` type <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/typedef/MessageOptions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/typedef/MessageOptions)</branch>. Using `split: true` here will automatically split our help message into 2 or more messages in the case that it exceeds the 2,000 character limit.
 :::
 
 ::: tip

--- a/guide/commando/permissions.md
+++ b/guide/commando/permissions.md
@@ -44,7 +44,7 @@ super(client, {
 });
 ```
 
-All you need to do is set the properties to an array of permission flags. A list of those can be found <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/class/Permissions?scrollTo=s-FLAGS)</branch>.
+All you need to do is set the properties to an array of permission flags. A list of those can be found <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS)</branch>.
 
 ## Owner-only commands
 

--- a/guide/creating-your-bot/adding-more-commands.md
+++ b/guide/creating-your-bot/adding-more-commands.md
@@ -118,7 +118,7 @@ That would display both the server name _and_ the amount of members in it.
 You can, of course, modify this to your liking. You may want to also display the date the server was created, or the server's region. You would do those in the same manner - use `message.guild.createdAt` or `message.guild.region`, respectively.
 
 ::: tip
-Want a list of all the properties you can access and all the methods you can call on a server? Refer to <branch version="11.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/11.5.1/class/Guild)</branch><branch version="12.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/master/class/Guild)</branch>!
+Want a list of all the properties you can access and all the methods you can call on a server? Refer to <branch version="11.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/11.5.1/class/Guild)</branch><branch version="12.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/stable/class/Guild)</branch>!
 :::
 
 ### Member info command
@@ -146,7 +146,7 @@ This will display the message author's **username** (not nickname, if they have 
 </div>
 
 ::: tip
-`message.author` refers to the user who sent the message. For a full list of all the properties and methods for the author object (a member of the `User` class), check out <branch version="11.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/11.5.1/class/User)</branch><branch version="12.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/master/class/User)</branch>.
+`message.author` refers to the user who sent the message. For a full list of all the properties and methods for the author object (a member of the `User` class), check out <branch version="11.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/11.5.1/class/User)</branch><branch version="12.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/stable/class/User)</branch>.
 :::
 
 And there you have it! As you can see, it's quite simple to add additional commands.

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -227,7 +227,7 @@ Here is how the RegEx works:
 Using the `.match()` method on strings you can get the values of the capture group, i.e., the ID of the mention.
 
 ::: warning
-Discord.js has <branch version="11.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/11.5.1/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch><branch version="12.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/master/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch>
+Discord.js has <branch version="11.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/11.5.1/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch><branch version="12.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/stable/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch>
 for matching mentions, however as of version 11.4 they do not contain any groups
 and thus aren't useful for actually getting the ID out of the mention.
 :::

--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -5,7 +5,7 @@
 Collectors are a useful way to enable your bot to obtain *additional* input after the first command was sent. An example would be initiating a quiz, where the bot will "await" a correct response from somebody.
 
 ::: tip
-You can read the docs for the Collector class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Collector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/class/Collector)</branch>.
+You can read the docs for the Collector class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Collector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Collector)</branch>.
 :::
 
 ### Basic message collector
@@ -43,7 +43,7 @@ Those options you pass as the second argument in `.createMessageCollector()`. Th
 Using `.awaitMessages()` can be easier if you understand promises, and it allows you to have cleaner code overall. It is essentially identical to `.createMessageCollector()`, except promisified. The drawback of using this method, however, is that you cannot do things before the promise is resolved or rejected, either by an error or completion. However, it should do for most purposes, such as awaiting the correct response in a quiz. Instead of taking their example, let's set up a basic quiz command using the `.awaitMessages()` feature.
 
 ::: tip
-You can read the docs for the `.awaitMessages()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=awaitMessages)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/class/TextChannel?scrollTo=awaitMessages)</branch>.
+You can read the docs for the `.awaitMessages()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=awaitMessages)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=awaitMessages)</branch>.
 :::
 
 First, you'll need some questions and answers to choose from, so here's a basic set:
@@ -121,7 +121,7 @@ The filter looks for messages that match one of the answers in our array of poss
 These work quite similarly to message collectors, except that you apply them on a message rather than a channel. The following is an example taken from the documentation, with slightly better variable names for clarification. The filter will check for the 👌 emoji - in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
 
 ::: tip
-You can read the docs for the `.createReactionCollector()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=createReactionCollector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/class/Message?scrollTo=createReactionCollector)</branch>.
+You can read the docs for the `.createReactionCollector()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=createReactionCollector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=createReactionCollector)</branch>.
 :::
 
 ```js
@@ -145,7 +145,7 @@ collector.on('end', collected => {
 As before, these work almost exactly the same as a reaction collector, except it is promise based. The same differences apply as with channel collectors.
 
 ::: tip
-You can read the docs for the `.awaitReactions()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=awaitReactions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/class/Message?scrollTo=awaitReactions)</branch>.
+You can read the docs for the `.awaitReactions()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=awaitReactions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=awaitReactions)</branch>.
 :::
 
 ```js

--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -49,12 +49,12 @@ Here is an example of what an embed may look like. We will go over their constru
 
 ## Using the <branch version="11.x" inline>RichEmbed</branch><branch version="12.x" inline>MessageEmbed</branch> constructor
 
-Discord.js features the utility class <branch version="11.x" inline>[RichEmbed](https://discord.js.org/#/docs/main/11.5.1/class/MessageEmbed)</branch><branch version="12.x" inline>[MessageEmbed](https://discord.js.org/#/docs/main/master/class/MessageEmbed)</branch> for easy construction and manipulation of embeds.
+Discord.js features the utility class <branch version="11.x" inline>[RichEmbed](https://discord.js.org/#/docs/main/11.5.1/class/MessageEmbed)</branch><branch version="12.x" inline>[MessageEmbed](https://discord.js.org/#/docs/main/stable/class/MessageEmbed)</branch> for easy construction and manipulation of embeds.
 
 <branch version="11.x">
 
 ::: warning
-On the master branch, the receiving and outgoing embed classes have been unified; you will need to use `Discord.MessageEmbed()` as constructor instead.
+In version 12 the receiving and outgoing embed classes have been unified; you will need to use `Discord.MessageEmbed()` as constructor instead.
 :::
 
 ```js
@@ -116,7 +116,7 @@ channel.send(exampleEmbed);
 You don't need to include all the elements showcased above. If you want a simpler embed, just leave some out.
 :::
 
-The `.setColor()` method accepts an integer, HEX color string, an array of RGB values or specific color strings. You can find a list of them at <branch version="11.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/typedef/ColorResolvable)</branch><branch version="12.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/master/typedef/ColorResolvable)</branch>.
+The `.setColor()` method accepts an integer, HEX color string, an array of RGB values or specific color strings. You can find a list of them at <branch version="11.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/typedef/ColorResolvable)</branch><branch version="12.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/stable/typedef/ColorResolvable)</branch>.
 
 <branch version="11.x">
 
@@ -161,7 +161,7 @@ if (message.author.bot) {
 
 ### Attaching images
 
-You can use the `.attachFiles()` method to upload images alongside your embed and use them as source for embed fields that support image urls. The method accepts the source file as file path <branch version="11.x" inline>[FileOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/FileOptions)</branch><branch version="12.x" inline>[FileOptions](https://discord.js.org/#/docs/main/master/typedef/FileOptions)</branch>, BufferResolvable (including a URL to an external image), or Attachment objects inside an array.
+You can use the `.attachFiles()` method to upload images alongside your embed and use them as source for embed fields that support image urls. The method accepts the source file as file path <branch version="11.x" inline>[FileOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/FileOptions)</branch><branch version="12.x" inline>[FileOptions](https://discord.js.org/#/docs/main/stable/typedef/FileOptions)</branch>, BufferResolvable (including a URL to an external image), or Attachment objects inside an array.
 
 You can then reference and use the images inside the embed itself with `attachment://fileName.extension`.
 
@@ -279,7 +279,7 @@ if (message.author.bot) {
 
 ### Attaching images
 
-You can upload images with your embedded message and use them as source for embed fields that support image urls by constructing <branch version="11.x" inline>an [Attachment](https://discord.js.org/#/docs/main/11.5.1/class/Attachment)</branch><branch version="12.x" inline>a [MessageAttachment](https://discord.js.org/#/docs/main/master/class/MessageAttachment)</branch> from them to send as message option alongside the embed. The <branch version="11.x" inline>file</branch><branch version="12.x" inline>attachment</branch> parameter takes a BufferResolvable or Stream including the URL to an external image.
+You can upload images with your embedded message and use them as source for embed fields that support image urls by constructing <branch version="11.x" inline>an [Attachment](https://discord.js.org/#/docs/main/11.5.1/class/Attachment)</branch><branch version="12.x" inline>a [MessageAttachment](https://discord.js.org/#/docs/main/stable/class/MessageAttachment)</branch> from them to send as message option alongside the embed. The <branch version="11.x" inline>file</branch><branch version="12.x" inline>attachment</branch> parameter takes a BufferResolvable or Stream including the URL to an external image.
 
 You can then reference and use the images inside the embed itself with `attachment://fileName.extension`.
 

--- a/guide/popular-topics/errors.md
+++ b/guide/popular-topics/errors.md
@@ -42,7 +42,7 @@ Now, when an error occurs it will be logged to the console and it will not termi
 
 <branch version="12.x">
 
-On master, WebSocket errors are handled internally, meaning your process should never crash from them. If you want to log these errors, should they happen, you can listen to the `shardError` event as shown below.
+In version 12, WebSocket errors are handled internally, meaning your process should never crash from them. If you want to log these errors, should they happen, you can listen to the `shardError` event as shown below.
 
 ```js
 client.on('shardError', error => {
@@ -116,7 +116,7 @@ message.delete().catch(error => {
 });
 ```
 
-You can find a list of constants <branch version="12.x" inline> [here](https://github.com/discordjs/discord.js/blob/master/src/util/Constants.js#L552) </branch> <branch version="11.x" inline> [here](https://github.com/discordjs/discord.js/blob/stable/src/util/Constants.js#L788) </branch>
+You can find a list of constants <branch version="12.x" inline> [here](https://github.com/discordjs/discord.js/blob/stable/src/util/Constants.js#L552) </branch> <branch version="11.x" inline> [here](https://github.com/discordjs/discord.js/blob/stable/src/util/Constants.js#L788) </branch>
 
 ### Method
 
@@ -145,7 +145,7 @@ This is a very common error, it originates from a wrong token being passed into 
 <branch version="12.x">
 
 ::: warning
-On master there used to be an issue where the token was not prefixed correctly which resulted in valid tokens being marked as invalid. If you have verified that all of the above is not the case, make sure you have updated discord.js to the latest commit.
+Before the release of version there used to be an issue where the token was not prefixed correctly which resulted in valid tokens being marked as invalid. If you have verified that all of the above is not the case, make sure you have updated discord.js to the currently stable version.
 :::
 
 </branch>

--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -42,7 +42,7 @@ To include permission checks like `ADMINISTRATOR` or `MANAGE_GUILD`, keep readin
 * Permission: The ability to execute a certain action in Discord
 * Overwrite: Rule on a channel to modify the permissions for a member or role
 * Bit field: Binary representation of Discord permissions 
-* Flag: Human readable string in MACRO_CASE, for example `'KICK_MEMBERS'`, refers to a position in the permission bit field. You can find a list of all valid flags in the <branch version="11.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/master/class/Permissions?scrollTo=s-FLAGS)</branch>
+* Flag: Human readable string in MACRO_CASE, for example `'KICK_MEMBERS'`, refers to a position in the permission bit field. You can find a list of all valid flags in the <branch version="11.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS)</branch>
 * Base Permissions: Permissions for roles the member has, set on the guild level
 * Final Permissions: Permissions for a member or role, after all overwrites are applied
 
@@ -79,7 +79,7 @@ Note that flag names are literal. Although `VIEW_CHANNEL` grants access to view 
 
 ### Creating a role with permissions
 
-Alternatively you can provide permissions as a property of <branch version="11.x" inline>[RoleData](https://discord.js.org/#/docs/main/11.5.1/typedef/RoleData)</branch><branch version="12.x" inline>[RoleData](https://discord.js.org/#/docs/main/master/typedef/RoleData)</branch> objects during role creation as an array of flag strings or a permission number:
+Alternatively you can provide permissions as a property of <branch version="11.x" inline>[RoleData](https://discord.js.org/#/docs/main/11.5.1/typedef/RoleData)</branch><branch version="12.x" inline>[RoleData](https://discord.js.org/#/docs/main/stable/typedef/RoleData)</branch> objects during role creation as an array of flag strings or a permission number:
 
 <branch version="11.x">
 
@@ -98,7 +98,7 @@ guild.roles.create({ data: { name: 'Mod', permissions: ['MANAGE_MESSAGES', 'KICK
 
 ### Checking member permissions
 
-To know if a one of a member's roles has a permission enabled, you can use the `.hasPermission()` method of the <branch version="11.x" inline>[GuildMember](https://discord.js.org/#/docs/main/11.5.1/class/GuildMember)</branch><branch version="12.x" inline>[GuildMember](https://discord.js.org/#/docs/main/master/class/GuildMember)</branch> class and provide a permission flag, array, or number to check for. You can also specify if you want to allow the `ADMINISTRATOR` permission or the guild owner status to override this check with the following parameters.
+To know if a one of a member's roles has a permission enabled, you can use the `.hasPermission()` method of the <branch version="11.x" inline>[GuildMember](https://discord.js.org/#/docs/main/11.5.1/class/GuildMember)</branch><branch version="12.x" inline>[GuildMember](https://discord.js.org/#/docs/main/stable/class/GuildMember)</branch> class and provide a permission flag, array, or number to check for. You can also specify if you want to allow the `ADMINISTRATOR` permission or the guild owner status to override this check with the following parameters.
 
 <branch version="11.x">
 
@@ -149,7 +149,7 @@ As you have likely already seen in your desktop client, channel overwrites have 
 
 ### Adding overwrites
 
-To add a permission overwrite for a role or guild member, you access the channel object and use the <branch version="11.x" inline>`.overwritePermissions()`</branch><branch version="12.x" inline>`.updateOverwrite()`</branch> method. The first parameter is the target of the overwrite, either a Role or User object (or its respective resolvable), and the second is a <branch version="11.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionOverwriteOptions)</branch><branch version="12.x" inline>[PermissionOverwriteOption](https://discord.js.org/#/docs/main/master/typedef/PermissionOverwriteOption)</branch> object.
+To add a permission overwrite for a role or guild member, you access the channel object and use the <branch version="11.x" inline>`.overwritePermissions()`</branch><branch version="12.x" inline>`.updateOverwrite()`</branch> method. The first parameter is the target of the overwrite, either a Role or User object (or its respective resolvable), and the second is a <branch version="11.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionOverwriteOptions)</branch><branch version="12.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/stable/typedef/PermissionOverwriteOptions)</branch> object.
 
 Let's add an overwrite to lock everyone out of the channel. The guild ID doubles as the role id for the default role @everyone as demonstrated below:
 
@@ -217,7 +217,7 @@ guild.channels.create('new-channel', {
 
 ### Replacing overwrites
 
-To replace all permission overwrites on the channel with a provided set of new overwrites, you can use the <branch version="11.x" inline>`.replaceOverwrites()`</branch><branch version="12.x" inline>`.overwritePermissions()`</branch> function. This is extremely handy if you want to copy a channels full set of overwrites to another one, as this method allows passing an array or Collection of <branch version="12.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/master/class/PermissionOverwrites)</branch><branch version="11.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/11.5.1/class/PermissionOverwrites) or [ChannelCreationOverwrites](https://discord.js.org/#/docs/main/11.5.1/typedef/ChannelCreationOverwrites)</branch>.
+To replace all permission overwrites on the channel with a provided set of new overwrites, you can use the <branch version="11.x" inline>`.replaceOverwrites()`</branch><branch version="12.x" inline>`.overwritePermissions()`</branch> function. This is extremely handy if you want to copy a channels full set of overwrites to another one, as this method allows passing an array or Collection of <branch version="12.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/stable/class/PermissionOverwritess)</branch><branch version="11.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/11.5.1/class/PermissionOverwrites) or [ChannelCreationOverwrites](https://discord.js.org/#/docs/main/11.5.1/typedef/ChannelCreationOverwrites)</branch>.
 
 <branch version="11.x">
 
@@ -296,7 +296,7 @@ discord.js features two utility methods to easily determine the final permission
 </branch>
 <branch version="12.x">
 
-discord.js features two utility methods to easily determine the final permissions for a guild member or role in a specific channel: `.permissionsFor()` on the [GuildChannel](https://discord.js.org/#/docs/main/master/class/GuildChannel?scrollTo=permissionsFor) class and `.permissionsIn()` on the [GuildMember](https://discord.js.org/#/docs/main/master/class/GuildMember?scrollTo=permissionsIn)and [Role](https://discord.js.org/#/docs/main/master/class/Role?scrollTo=permissionsIn) classes. Both return a [Permissions](https://discord.js.org/#/docs/main/master/class/Permissions) object.
+discord.js features two utility methods to easily determine the final permissions for a guild member or role in a specific channel: `.permissionsFor()` on the [GuildChannel](https://discord.js.org/#/docs/main/stable/class/GuildChannel?scrollTo=permissionsFor) class and `.permissionsIn()` on the [GuildMember](https://discord.js.org/#/docs/main/stable/class/GuildMember?scrollTo=permissionsIn)and [Role](https://discord.js.org/#/docs/main/stable/class/Role?scrollTo=permissionsIn) classes. Both return a [Permissions](hhttps://discord.js.org/#/docs/main/stable/class/Permissions) object.
 
 </branch>
 
@@ -321,7 +321,7 @@ If you want to know how to work with the returned Permissions objects keep readi
 
 ## The Permissions object
 
-The <branch version="11.x" inline>[Permissions](https://discord.js.org/#/docs/main/11.5.1/class/Permissions)</branch><branch version="12.x" inline>[Permissions](https://discord.js.org/#/docs/main/master/class/Permissions)</branch> object is a discord.js class containing a permissions bit field and a bunch of utility methods to manipulate it easily.
+The <branch version="11.x" inline>[Permissions](https://discord.js.org/#/docs/main/11.5.1/class/Permissions)</branch><branch version="12.x" inline>[Permissions](https://discord.js.org/#/docs/main/stable/class/Permissions)</branch> object is a discord.js class containing a permissions bit field and a bunch of utility methods to manipulate it easily.
 Remember that using these methods will not manipulate permissions, but create a new instance representing the changed bit field.
 
 ### Converting permission numbers
@@ -334,7 +334,7 @@ const { Permissions } = require('discord.js');
 const permissions = new Permissions(268550160);
 ```
 
-You can also use this approach for other <branch version="11.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionResolvable)</branch><branch version="12.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/master/typedef/PermissionResolvable)</branch>s like flag arrays or flags.
+You can also use this approach for other <branch version="11.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionResolvable)</branch><branch version="12.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/stable/typedef/PermissionResolvable)</branch>s like flag arrays or flags.
 
 ```js
 const { Permissions } = require('discord.js');

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -235,7 +235,7 @@ The reason we use a `for...of` loop over something like `.forEach()` is due to `
 </branch>
 <branch version="12.x">
 
-Removing reactions by emoji is easily done by using [`MessageReaction.remove()`](https://discord.js.org/#/docs/main/master/class/MessageReaction?scrollTo=remove).
+Removing reactions by emoji is easily done by using [`MessageReaction.remove()`](https://discord.js.org/#/docs/main/stable/class/MessageReaction?scrollTo=remove).
 
 ```js
 message.reactions.cache.get('484535447171760141').remove().catch(error => console.error('Failed to remove reactions: ', error));

--- a/guide/popular-topics/webhooks.md
+++ b/guide/popular-topics/webhooks.md
@@ -18,7 +18,7 @@ Bots receive webhook messages in a text channel normally. You can detect if the 
 if (message.webhookID) return;
 ```
 
-If you would like to get the webhook object that sent the message, you can use <branch version="11.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/master/class/Message?scrollTo=fetchWebhook)</branch>.
+If you would like to get the webhook object that sent the message, you can use <branch version="11.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=fetchWebhook)</branch>.
 
 ## Fetching webhooks
 
@@ -28,17 +28,17 @@ Webhook fetching will always make use of collections and promises, if you do not
 
 ### Fetching all webhooks of a guild
 
-If you would like to get all webhooks of a guild you can use <branch version="11.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/11.5.1/class/Guild?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/master/class/Guild?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s.
+If you would like to get all webhooks of a guild you can use <branch version="11.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/11.5.1/class/Guild?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s.
 
 ### Fetching webhooks of a channel
 
-Webhooks belonging to a channel can be fetched using <branch version="11.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/master/class/TextChannel?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s. A collection will be returned even if the channel contains a single webhook. If you are certain the channel contains a single webhook, you can use <branch version="11.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/main/11.5.1/class/Collection?scrollTo=first)</branch><branch version="12.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/collection/master/class/Collection?scrollTo=first)</branch> on the Collection to get the webhook.
+Webhooks belonging to a channel can be fetched using <branch version="11.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s. A collection will be returned even if the channel contains a single webhook. If you are certain the channel contains a single webhook, you can use <branch version="11.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/main/11.5.1/class/Collection?scrollTo=first)</branch><branch version="12.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/collection/stable/class/Collection?scrollTo=first)</branch> on the Collection to get the webhook.
 
 ### Fetching a single webhook
 
 #### Using client
 
-You can fetch a specific webhook using its `id` with <branch version="11.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/Client?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=fetchWebhook)</branch>. You can obtain the webhook id by looking at its link, the number after `https://discordapp.com/api/webhooks/` is the `id`, and the part after that is the `token`.
+You can fetch a specific webhook using its `id` with <branch version="11.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/Client?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=fetchWebhook)</branch>. You can obtain the webhook id by looking at its link, the number after `https://discordapp.com/api/webhooks/` is the `id`, and the part after that is the `token`.
 
 #### Using the WebhookClient constructor
 
@@ -62,7 +62,7 @@ Once you are there, click on the `Create Webhook` button on the top right. This 
 
 ### Creating webhooks with discord.js
 
-Discord.js provides a method for creating webhooks called <branch version="11.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=createWebhook)</branch><branch version="12.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/master/class/TextChannel?scrollTo=createWebhook)</branch>.
+Discord.js provides a method for creating webhooks called <branch version="11.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=createWebhook)</branch><branch version="12.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=createWebhook)</branch>.
 
 ```js
 channel.createWebhook('Some-username', 'https://i.imgur.com/wSTFkRM.png')
@@ -85,7 +85,7 @@ webhook.edit('Some-username', 'https://i.imgur.com/wSTFkRM.png')
 </branch>
 <branch version="12.x">
 
-You can edit Webhooks and WebhookClients to change their name, avatar, and channel using [`Webhook#edit()`](https://discord.js.org/#/docs/main/master/class/Webhook?scrollTo=edit).
+You can edit Webhooks and WebhookClients to change their name, avatar, and channel using [`Webhook#edit()`](https://discord.js.org/#/docs/main/stable/class/Webhook?scrollTo=edit).
 
 ```js
 webhook.edit({
@@ -99,7 +99,7 @@ webhook.edit({
 
 ## Using webhooks
 
-Webhooks, unlike bots, can send more than one embed per message, up to 10. They can also send attachments and normal content. The <branch version="11.x" inline> [`Webhook#send()`](https://discord.js.org/#/docs/main/11.5.1/class/Webhook?scrollTo=send)</branch><branch version="12.x" inline>[`Webhook#send()`](https://discord.js.org/#/docs/main/master/class/Webhook?scrollTo=send)</branch> method to send to a webhook is very similar to the method for sending to a text channel. Webhooks can also choose what the username and avatar will appear as when the message is sent.
+Webhooks, unlike bots, can send more than one embed per message, up to 10. They can also send attachments and normal content. The <branch version="11.x" inline> [`Webhook#send()`](https://discord.js.org/#/docs/main/11.5.1/class/Webhook?scrollTo=send)</branch><branch version="12.x" inline>[`Webhook#send()`](https://discord.js.org/#/docs/main/stable/class/Webhook?scrollTo=send)</branch> method to send to a webhook is very similar to the method for sending to a text channel. Webhooks can also choose what the username and avatar will appear as when the message is sent.
 
 <branch version="11.x">
 

--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -39,7 +39,7 @@ manager.on('shardCreate', shard => console.log(`Launched shard ${shard.id}`));
 The above code utilizes discord.js's sharding manager to spawn the recommended amount of shards for your bot. The recommended amount should be approximately 1,000 guilds per shard. Even though you provide the token here, you will still need to send it over to the main bot file in `client.login()`, so don't forget to do that.
 
 ::: tip
-You can find the methods available for the ShardingManager class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/ShardingManager)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/master/class/ShardingManager)</branch>. Though, you may not be making much use of this section, unlike the next feature we will explore, which you may learn about by clicking [this link](/sharding/additional-information.md).
+You can find the methods available for the ShardingManager class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/ShardingManager)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/ShardingManager)</branch>. Though, you may not be making much use of this section, unlike the next feature we will explore, which you may learn about by clicking [this link](/sharding/additional-information.md).
 :::
 
 ## Getting started
@@ -97,7 +97,7 @@ Let's say your bot is in a total of 3,600 guilds. Using the recommended shard co
 
 ## FetchClientValues
 
-First, let's take a look at <branch version="11.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=fetchClientValues)</branch><branch version="12.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/master/class/ShardClientUtil?scrollTo=fetchClientValues)</branch> called `fetchClientValues`. This method retrieves a client property of all shards.
+First, let's take a look at <branch version="11.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=fetchClientValues)</branch><branch version="12.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=fetchClientValues)</branch> called `fetchClientValues`. This method retrieves a client property of all shards.
 
 Now, take the following snippet of code:
 
@@ -176,7 +176,7 @@ While it's a bit unattractive to have more nesting in your commands, it is neces
 
 ## BroadcastEval
 
-Next, check out <branch version="11.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/master/class/ShardClientUtil?scrollTo=broadcastEval)</branch> known as `broadcastEval`. This method makes all of the shards evaluate a given script, where `this` is the `client` once each shard gets to evaluating it. You can read more about the `this` keyword [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this). For now, essentially understand that it is the "client" object.
+Next, check out <branch version="11.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> known as `broadcastEval`. This method makes all of the shards evaluate a given script, where `this` is the `client` once each shard gets to evaluating it. You can read more about the `this` keyword [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this). For now, essentially understand that it is the "client" object.
 
 <branch version="11.x">
 

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -23,7 +23,7 @@ manager.on('message', (shard, message) => {
 
 As the property names imply, the `_eval` property is what the shard is attempting to evaluate, and the `_result` property is the output of said evaluation. However, these properties are only guaranteed if a _shard_ is sending a message. There will also be an `_error` property, should the evaluation have thrown an error.
 
-You can also send messages via `process.send('hello')`, which would not contain the same information. This is why the `.message` property's type is declared as `*` <branch version="11.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/class/Shard?scrollTo=e-message)</branch><branch version="12.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/master/class/Shard?scrollTo=e-message)</branch>.
+You can also send messages via `process.send('hello')`, which would not contain the same information. This is why the `.message` property's type is declared as `*` <branch version="11.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/class/Shard?scrollTo=e-message)</branch><branch version="12.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Shard?scrollTo=e-message)</branch>.
 
 ## Specific shards
 
@@ -33,7 +33,7 @@ There might be times where you want to target a specific shard. An example would
 client.shard.broadcastEval('if (this.shard.id === 0) process.exit();');
 ```
 
-If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <branch version="11.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/master/class/ShardClientUtil?scrollTo=broadcastEval)</branch> sends a message to **all** shards, so you have to check if it's on the shard you want.
+If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <branch version="11.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> sends a message to **all** shards, so you have to check if it's on the shard you want.
 
 ## `ShardingManager#shardArgs`
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

There is still a bunch of links pointing to the master branch of the documentation (partially outdated) back from when v12 was in development.

This PR replaces them with the respective (now) stable counterparts and adapts the surrounding sentence where necessary