### PR TITLE
refactor(Sharding): move --trace-warnings to execArgv in additional-information

### DIFF
--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -35,24 +35,33 @@ client.shard.broadcastEval('if (this.shard.id === 0) process.exit();');
 
 If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <branch version="11.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/master/class/ShardClientUtil?scrollTo=broadcastEval)</branch> sends a message to **all** shards, so you have to check if it's on the shard you want.
 
-## `ShardingManager#shardArgs`
+## `ShardingManager#shardArgs` and `ShardingManager#execArgv`
 
 Consider the following example of creating a new `ShardingManager` instance:
 
 ```js
 const manager = new ShardingManager('./bot.js', {
-	shardArgs: ['--ansi', '--color', '--trace-warnings'],
+	execArgv: ['--trace-warnings'],
+	shardArgs: ['--ansi', '--color'],
 	token: 'your-token-goes-here',
 });
 ```
 
-The `shardArgs` property is what you would normally pass in if you executed your bot process without sharding, e.g.:
+The `execArgv` property is what you would normally pass to node without sharding, e.g.:
 
 ```
-node bot.js --ansi --color --trace-warnings
+node --trace-warnings bot.js
 ```
 
-Should you need them for whatever reason, they're available in `process.argv` property, which contains an array of command-line arguments used to execute the script.
+You can find a list of command line options for node [here](https://nodejs.org/api/cli.html).
+
+The `shardArgs` property is what you would normally pass to your bot without sharding, e.g.:
+
+```
+node bot.js --ansi --color
+```
+
+You can access the later as usual via `process.argv`, which contains an array of executable, your main file, and the command-line arguments used to execute the script.
 
 ## Eval arguments
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

TL;DR
- Moved `--trace-warnings` from `shardArgs` to `execArgv`
- Reworded note about `process.argv` suggesting it's not needed to access it if passing arguments
- Reworded note about `process.argv` about only containing `shardArgs`

---

The current example of `ShardingManger#shardArgs`  in the guide uses `--trace-warnings` as an argument for the script file rather than the executable (i.e. node).
Doing this is rather confusing, or perhaps misleading, as this is actually a node command line option. ([docs](https://nodejs.org/api/cli.html#cli_trace_warnings))

While it certainly _is_ possible to use this as a custom argument for your script, the guide should not do this to avoid confusing the reader.

I therefore moved `--trace-warnings` to be an example for `ShardingManager#execArgv` instead, showing how one would pass command line options to node, basically killing two birds with one stone.

I also linked the documentation about node command line options there.

---

I also reworded the note about `process.argv` to no longer suggest that accessing it is not necessarily needed.
> Should you need them for whatever reason [...]

This sounds like you usually do not need to access it.
If you don't need your arguments, you would not pass them in the first place.

---

The above note also suggested that `process.argv` only contains the `shardArgs`
> [...] which contains an array of command-line arguments used to execute the script.

This is not actually correct, see [`process.argv`](https://nodejs.org/api/process.html#process_process_argv).
The first two elements are the executable (e.g. `node`, `/usr/bin/node`, etc.) and the script file (e.g. `bot.js`, `index.js`, etc.), and then followed by the `shardArgs`.

---

If something about the wording can be improved, feel free to let me know.
