### PR TITLE
Removed escape characters showing in Markdown

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1875,7 +1875,7 @@ This method has been moved from the `VoiceBroadcast` class to the `BroadcastDisp
 
 #### VoiceBroadcast#play\*\*\*
 
-All `.play\*\*\*()` methods have been removed and transformed into a single `.play()` method.
+All `.play***()` methods have been removed and transformed into a single `.play()` method.
 
 #### VoiceBroadcast#prism
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I removed escape characters that shouldn't be showing in the Markdown render at [voiceBroadcast#play***](https://discordjs.guide/additional-info/changes-in-v12.html#voicebroadcast-play).
> All `.play\*\*\*()` methods have been removed and transformed into a single .play() method.
