### PR TITLE
Switch parameters for usage of GuildEmoji constructor

### DIFF
--- a/guide/sharding/extended.md
+++ b/guide/sharding/extended.md
@@ -362,7 +362,7 @@ Now, you will want to make use of it in the actual command:
 +						// Reconstruct a guild
 +						const guild = new Discord.Guild(client, raw);
 +						// Reconstruct an emoji object as required by discord.js
-+						const emoji = new Discord.GuildEmoji(client, guild, foundEmoji);
++						const emoji = new Discord.GuildEmoji(client, foundEmoji, guild);
 +						return message.reply(`I have found an emoji ${emoji.toString()}!`);
 +					});
 +		});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I switched around the parameters used when instantiating the `GuildEmoji` constructor which is used in the [Sharding](https://discordjs.guide/sharding/extended.html#using-functions-continued) section of the Discord.js Guide. In accordance with the [documentation](https://discord.js.org/#/docs/main/stable/class/GuildEmoji), this is the correct order of parameters for the constructor:
```js
new Discord.GuildEmoji(client, data, guild);
```
I realized when using the original code in the guide, I was getting incorrect information when logging the `GuildEmoji` object in the console: https://i.imgur.com/xTQrvIz.png