### PR TITLE
Tweaks to Sharding guide

### DIFF
--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -2,7 +2,7 @@
 
 ## When to shard
 
-Before you dive into this section, please note that sharding may not be necessary for you. Sharding is only necessary at 2,500 guilds—at that point, Discord will not allow your bot to login. With that in mind, you should consider this when your bot is around 2,000 guilds, which should be enough time to get this working. Contrary to popular belief, sharding itself is very simple. It can be complex depending on your bot's needs, however. If your bot is in a total of 2,000 or more servers, then please continue with this guide. Otherwise, it may be a good idea to wait until then.
+Before you dive into this section, please note that sharding may not be necessary for you. Sharding is only necessary at 2,500 guilds—at that point, Discord will not allow your bot to login without sharding. With that in mind, you should consider this when your bot is around 2,000 guilds, which should be enough time to get this working. Contrary to popular belief, sharding itself is very simple. It can be complex depending on your bot's needs, however. If your bot is in a total of 2,000 or more servers, then please continue with this guide. Otherwise, it may be a good idea to wait until then.
 
 ## How does sharding work?
 
@@ -44,7 +44,11 @@ You can find the methods available for the ShardingManager class <branch version
 
 ## Getting started
 
-You will most likely have to change some code in order to get your newly sharded bot to work. If your bot is very basic, then you're in luck! I assume you probably have a `stats` command, by which you can quickly view your bots statistics, such as its server count. In this code, you likely have the snippet <branch version="11.x" inline>`client.guilds.size`</branch><branch version="12.x" inline>`client.guilds.cache.size`</branch>, which counts the number of *cached* guilds attached to that client. With sharding, since multiple processes will be launched, each process (each shard) will now have its own subset collection of guilds. This means that your original code will not function as you expect it to. Here is some sample code for a `stats` command, without sharding taken into consideration.
+You will most likely have to change some code in order to get your newly sharded bot to work. If your bot is very basic, then you're in luck! We assume you probably have some form of a `stats` command, by which you can quickly view your bots statistics, such as its server count. We will use it as an example that needs to be adapted to running with shards.
+
+In this code, you likely have the snippet <branch version="11.x" inline>`client.guilds.size`</branch><branch version="12.x" inline>`client.guilds.cache.size`</branch>, which counts the number of *cached* guilds attached to that client. With sharding, since multiple processes will be launched, each process (each shard) will now have its own subset collection of guilds it is responsible for. This means that your original code will not function as you expect it to.
+
+Here is some sample code for a `stats` command, without sharding taken into consideration:
 
 <branch version="11.x">
 
@@ -93,11 +97,11 @@ client.login('token');
 
 </branch>
 
-Let's say your bot is in a total of 3,600 guilds. Using the recommended shard count you might end up at 4 shards, the first 3 containing 1,000 guilds each and the last one containing the remaining 600. If a guild is on a certain shard (shard #2, for example) and it receives this command, the guild count will be 1,000, which is obviously not the "correct" number of guilds for your bot. Likewise, if the message is received on a guild in shard 3 (shard IDs are zero-indexed), the guild count will be 600, which is still not what you want. "How can I fix this?", you ask? Well, that's why we're here, isn't it?
+Let's say your bot is in a total of 3,600 guilds. Using the recommended shard count you might end up at 4 shards, each containing approximately 900 guilds. If a guild is on a certain shard (shard #2, for example) and it receives this command, the guild count will be close to 900, which is obviously not the "correct" number of guilds for your bot. "How can I fix this?", you ask? Well, that's why we're here, isn't it?
 
 ## FetchClientValues
 
-First, let's take a look at <branch version="11.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=fetchClientValues)</branch><branch version="12.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=fetchClientValues)</branch> called `fetchClientValues`. This method retrieves a client property of all shards.
+First, let's take a look at <branch version="11.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=fetchClientValues)</branch><branch version="12.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=fetchClientValues)</branch> called `fetchClientValues`. This method retrieves a property on the Client object of all shards.
 
 Now, take the following snippet of code:
 
@@ -116,9 +120,13 @@ client.shard.fetchClientValues('guilds.cache.size').then(console.log);
 
 </branch>
 
-If you run it, you will notice an output like `[1000, 1000, 1000, 600]`. You will be correct in assuming that that's the total number of guilds per shard, which is stored in an array in the Promise. We can both assume this isn't the ideal output for guild count, so we will need to make use of an array manipulation method, specifically [Array.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce).
+If you run it, you will notice an output like `[898, 901, 900, 901]`. You will be correct in assuming that that's the total number of guilds per shard, which is stored in an array in the Promise. This probably isn't the ideal output for guild count, so we will need to make use of an array manipulation method, specifically [Array.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce).
 
-It's highly urged for you to visit that link to understand how the method works, as you will probably find great use of it in sharding. Basically, this method (in this case) iterates through the array and adds each current value to the total amount.
+::: tip
+It's highly recommended for you to visit [the documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) to understand how the `reduce()` method works, as you will probably find great use of it in sharding.
+:::
+
+In this case, this method iterates through the array and adds each current value to the total amount:
 
 <branch version="11.x">
 
@@ -176,7 +184,7 @@ While it's a bit unattractive to have more nesting in your commands, it is neces
 
 ## BroadcastEval
 
-Next, check out <branch version="11.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> known as `broadcastEval`. This method makes all of the shards evaluate a given script, where `this` is the `client` once each shard gets to evaluating it. You can read more about the `this` keyword [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this). For now, essentially understand that it is the "client" object.
+Next, check out <branch version="11.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> known as `broadcastEval`. This method makes all of the shards evaluate a given script, where `this` is the `client` once each shard gets to evaluating it. You can read more about the `this` keyword [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this). For now, essentially understand that it is the shard's Client object.
 
 <branch version="11.x">
 
@@ -258,6 +266,7 @@ Promise.all(promises)
 ```
 
 </branch>
+
 `Promise.all()` runs every promise you pass to it inside of an array in parallel, and waits for them all to finish before returning all of their results at once. The result is an array that corresponds with the array of promises you pass - so the first result element will be from the first promise. With that, your stats command should look something like this:
 
 <branch version="11.x">

--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -9,6 +9,10 @@ Before you dive into this section, please note that sharding may not be necessar
 As an application grows large, developers may find it necessary to split their process up to run parallel to one another in order to maximize efficiency. In a much larger scale of things, the developer might notice their process slow down, amongst other problems.
 [Check out the official Discord documentation on the topic.](https://discordapp.com/developers/docs/topics/gateway#sharding)
 
+:::warning
+This guide only explains the basics of sharding using the built-in ShardingManager, which can run shards as separate processes or threads on a single machine. If you need to scale beyond that (e.g. running shards on multiple machines/containers), you can still do it with discord.js by passing appropriate options to the Client constructor, but you will be on your own regarding managing shards and passing information between them.
+:::
+
 ## Sharding file
 
 First, you'll need to have a file that you'll be launching from now on, rather than your original `index.js` file. It's highly recommended renaming that to `bot.js` and naming this new file to `index.js` instead. Copy & paste the following snippet into your new `index.js` file.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR has multiple improvements to the Sharding guide:

1. The guide stated that for 3600 guilds and 4 shards, they will be distributed as `[1000, 1000, 1000, 600]`. My best understanding of sharding is that every shard will have ~900 guilds. The guide was updated to reflect it.
2. A notice was added that ShardingManager can only run shards on the same machine (as processes / threads).
3. Some rewording (e.g. "I" -> "we") and clarifications
4. Small formatting fix: newline after `</branch>`

**Why is the PR submitted as a draft**

I never worked with sharding, so I would like confirmation that my understanding is correct. Also, perhaps there's a better place for the remark about scaling beyond processes on the same machine.