### PR TITLE
chore: change label to v11.6 + point docs to v11 branch

### DIFF
--- a/guide/.vuepress/branches.js
+++ b/guide/.vuepress/branches.js
@@ -1,11 +1,11 @@
 export default [
 	{
-		label: 'v12.x (stable)',
+		label: 'v12 (stable)',
 		version: '12.x',
 		aliases: ['12', 'stable'],
 	},
 	{
-		label: 'v11.6',
+		label: 'v11',
 		version: '11.x',
 		aliases: ['11'],
 	},

--- a/guide/.vuepress/branches.js
+++ b/guide/.vuepress/branches.js
@@ -5,7 +5,7 @@ export default [
 		aliases: ['12', 'stable'],
 	},
 	{
-		label: 'v11.5',
+		label: 'v11.6',
 		version: '11.x',
 		aliases: ['11'],
 	},

--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -81,7 +81,7 @@ const client = new Discord.Client();
 :::
 
 ::: tip
-If you aren't exactly sure what Collections are, they're a class that extend JS's native Map class and include more extensive, useful functionality. You can read about Maps [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), and see all the available Collection methods <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Collection)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/collection/master/class/Collection)</branch>.
+If you aren't exactly sure what Collections are, they're a class that extend JS's native Map class and include more extensive, useful functionality. You can read about Maps [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), and see all the available Collection methods <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/Collection)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/collection/master/class/Collection)</branch>.
 :::
 
 This next step is how you'll dynamically retrieve all your newly created command files. Add this below your `client.commands` line:

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -328,7 +328,7 @@ There's nothing really complex here; all you do is append some strings, `.map()`
 Since help messages can get messy, you'll be DMing it to the message author instead of posting it in the requested channel. However, there is something very important you should consider: the possibility of not being able to DM the user, whether it be that they have DMs disabled on that server or overall, or they have the bot blocked. For that reason, you should `.catch()` it and let them know.
 
 ::: tip
-If you weren't already aware, `.send()` takes 2 parameters: the content to send, and the message options to pass in. You can read about the `MessageOptions` type <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/typedef/MessageOptions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/typedef/MessageOptions)</branch>. Using `split: true` here will automatically split our help message into 2 or more messages in the case that it exceeds the 2,000 character limit.
+If you weren't already aware, `.send()` takes 2 parameters: the content to send, and the message options to pass in. You can read about the `MessageOptions` type <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/typedef/MessageOptions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/typedef/MessageOptions)</branch>. Using `split: true` here will automatically split our help message into 2 or more messages in the case that it exceeds the 2,000 character limit.
 :::
 
 ::: tip
@@ -383,7 +383,7 @@ At the end of it all, you should be getting this as a result:
 No more manually editing your help command! If you aren't completely satisfied with how it looks, you can always adjust it to your liking later.
 
 ::: tip
-If you want to add categories or other information to your commands you can simply add properties reflecting it to your `module.exports`. If you only want to show a subset of commands remember that `commands` is a Collection you can <branch version="11.x" inline>[filter](https://discord.js.org/#/docs/main/11.5.1/class/Collection?scrollTo=filter)</branch><branch version="12.x" inline>[filter](https://discord.js.org/#/docs/collection/master/class/Collection?scrollTo=filter)</branch> to fit your specific needs!
+If you want to add categories or other information to your commands you can simply add properties reflecting it to your `module.exports`. If you only want to show a subset of commands remember that `commands` is a Collection you can <branch version="11.x" inline>[filter](https://discord.js.org/#/docs/main/v11/class/Collection?scrollTo=filter)</branch><branch version="12.x" inline>[filter](https://discord.js.org/#/docs/collection/master/class/Collection?scrollTo=filter)</branch> to fit your specific needs!
 :::
 
 ## Reloading commands

--- a/guide/commando/permissions.md
+++ b/guide/commando/permissions.md
@@ -44,7 +44,7 @@ super(client, {
 });
 ```
 
-All you need to do is set the properties to an array of permission flags. A list of those can be found <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS)</branch>.
+All you need to do is set the properties to an array of permission flags. A list of those can be found <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS)</branch>.
 
 ## Owner-only commands
 

--- a/guide/creating-your-bot/adding-more-commands.md
+++ b/guide/creating-your-bot/adding-more-commands.md
@@ -118,7 +118,7 @@ That would display both the server name _and_ the amount of members in it.
 You can, of course, modify this to your liking. You may want to also display the date the server was created, or the server's region. You would do those in the same manner - use `message.guild.createdAt` or `message.guild.region`, respectively.
 
 ::: tip
-Want a list of all the properties you can access and all the methods you can call on a server? Refer to <branch version="11.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/11.5.1/class/Guild)</branch><branch version="12.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/stable/class/Guild)</branch>!
+Want a list of all the properties you can access and all the methods you can call on a server? Refer to <branch version="11.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/v11/class/Guild)</branch><branch version="12.x" inline>[the discord.js documentation site](https://discord.js.org/#/docs/main/stable/class/Guild)</branch>!
 :::
 
 ### Member info command
@@ -146,7 +146,7 @@ This will display the message author's **username** (not nickname, if they have 
 </div>
 
 ::: tip
-`message.author` refers to the user who sent the message. For a full list of all the properties and methods for the author object (a member of the `User` class), check out <branch version="11.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/11.5.1/class/User)</branch><branch version="12.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/stable/class/User)</branch>.
+`message.author` refers to the user who sent the message. For a full list of all the properties and methods for the author object (a member of the `User` class), check out <branch version="11.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/v11/class/User)</branch><branch version="12.x" inline>[the documentation page for it](https://discord.js.org/#/docs/main/stable/class/User)</branch>.
 :::
 
 And there you have it! As you can see, it's quite simple to add additional commands.

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -227,7 +227,7 @@ Here is how the RegEx works:
 Using the `.match()` method on strings you can get the values of the capture group, i.e., the ID of the mention.
 
 ::: warning
-Discord.js has <branch version="11.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/11.5.1/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch><branch version="12.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/stable/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch>
+Discord.js has <branch version="11.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/v11/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch><branch version="12.x" inline>[built-in patterns](https://discord.js.org/#/docs/main/stable/class/MessageMentions?scrollTo=s-CHANNELS_PATTERN)</branch>
 for matching mentions, however as of version 11.4 they do not contain any groups
 and thus aren't useful for actually getting the ID out of the mention.
 :::

--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -5,7 +5,7 @@
 Collectors are a useful way to enable your bot to obtain *additional* input after the first command was sent. An example would be initiating a quiz, where the bot will "await" a correct response from somebody.
 
 ::: tip
-You can read the docs for the Collector class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Collector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Collector)</branch>.
+You can read the docs for the Collector class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/Collector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Collector)</branch>.
 :::
 
 ### Basic message collector
@@ -43,7 +43,7 @@ Those options you pass as the second argument in `.createMessageCollector()`. Th
 Using `.awaitMessages()` can be easier if you understand promises, and it allows you to have cleaner code overall. It is essentially identical to `.createMessageCollector()`, except promisified. The drawback of using this method, however, is that you cannot do things before the promise is resolved or rejected, either by an error or completion. However, it should do for most purposes, such as awaiting the correct response in a quiz. Instead of taking their example, let's set up a basic quiz command using the `.awaitMessages()` feature.
 
 ::: tip
-You can read the docs for the `.awaitMessages()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=awaitMessages)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=awaitMessages)</branch>.
+You can read the docs for the `.awaitMessages()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/TextChannel?scrollTo=awaitMessages)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=awaitMessages)</branch>.
 :::
 
 First, you'll need some questions and answers to choose from, so here's a basic set:
@@ -121,7 +121,7 @@ The filter looks for messages that match one of the answers in our array of poss
 These work quite similarly to message collectors, except that you apply them on a message rather than a channel. The following is an example taken from the documentation, with slightly better variable names for clarification. The filter will check for the 👌 emoji - in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
 
 ::: tip
-You can read the docs for the `.createReactionCollector()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=createReactionCollector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=createReactionCollector)</branch>.
+You can read the docs for the `.createReactionCollector()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/Message?scrollTo=createReactionCollector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=createReactionCollector)</branch>.
 :::
 
 <branch version="11.x">
@@ -168,7 +168,7 @@ collector.on('end', collected => {
 As before, these work almost exactly the same as a reaction collector, except it is promise based. The same differences apply as with channel collectors.
 
 ::: tip
-You can read the docs for the `.awaitReactions()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=awaitReactions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=awaitReactions)</branch>.
+You can read the docs for the `.awaitReactions()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/Message?scrollTo=awaitReactions)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=awaitReactions)</branch>.
 :::
 
 ```js

--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -49,7 +49,7 @@ Here is an example of what an embed may look like. We will go over their constru
 
 ## Using the <branch version="11.x" inline>RichEmbed</branch><branch version="12.x" inline>MessageEmbed</branch> constructor
 
-Discord.js features the utility class <branch version="11.x" inline>[RichEmbed](https://discord.js.org/#/docs/main/11.5.1/class/MessageEmbed)</branch><branch version="12.x" inline>[MessageEmbed](https://discord.js.org/#/docs/main/stable/class/MessageEmbed)</branch> for easy construction and manipulation of embeds.
+Discord.js features the utility class <branch version="11.x" inline>[RichEmbed](https://discord.js.org/#/docs/main/v11/class/MessageEmbed)</branch><branch version="12.x" inline>[MessageEmbed](https://discord.js.org/#/docs/main/stable/class/MessageEmbed)</branch> for easy construction and manipulation of embeds.
 
 <branch version="11.x">
 
@@ -116,7 +116,7 @@ channel.send(exampleEmbed);
 You don't need to include all the elements showcased above. If you want a simpler embed, just leave some out.
 :::
 
-The `.setColor()` method accepts an integer, HEX color string, an array of RGB values or specific color strings. You can find a list of them at <branch version="11.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/typedef/ColorResolvable)</branch><branch version="12.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/stable/typedef/ColorResolvable)</branch>.
+The `.setColor()` method accepts an integer, HEX color string, an array of RGB values or specific color strings. You can find a list of them at <branch version="11.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/v11/typedef/ColorResolvable)</branch><branch version="12.x" inline>[the Discord.js documentation](https://discord.js.org/#/docs/main/stable/typedef/ColorResolvable)</branch>.
 
 <branch version="11.x">
 
@@ -161,7 +161,7 @@ if (message.author.bot) {
 
 ### Attaching images
 
-You can use the `.attachFiles()` method to upload images alongside your embed and use them as source for embed fields that support image urls. The method accepts the source file as file path <branch version="11.x" inline>[FileOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/FileOptions)</branch><branch version="12.x" inline>[FileOptions](https://discord.js.org/#/docs/main/stable/typedef/FileOptions)</branch>, BufferResolvable (including a URL to an external image), or Attachment objects inside an array.
+You can use the `.attachFiles()` method to upload images alongside your embed and use them as source for embed fields that support image urls. The method accepts the source file as file path <branch version="11.x" inline>[FileOptions](https://discord.js.org/#/docs/main/v11/typedef/FileOptions)</branch><branch version="12.x" inline>[FileOptions](https://discord.js.org/#/docs/main/stable/typedef/FileOptions)</branch>, BufferResolvable (including a URL to an external image), or Attachment objects inside an array.
 
 You can then reference and use the images inside the embed itself with `attachment://fileName.extension`.
 
@@ -279,7 +279,7 @@ if (message.author.bot) {
 
 ### Attaching images
 
-You can upload images with your embedded message and use them as source for embed fields that support image urls by constructing <branch version="11.x" inline>an [Attachment](https://discord.js.org/#/docs/main/11.5.1/class/Attachment)</branch><branch version="12.x" inline>a [MessageAttachment](https://discord.js.org/#/docs/main/stable/class/MessageAttachment)</branch> from them to send as message option alongside the embed. The <branch version="11.x" inline>file</branch><branch version="12.x" inline>attachment</branch> parameter takes a BufferResolvable or Stream including the URL to an external image.
+You can upload images with your embedded message and use them as source for embed fields that support image urls by constructing <branch version="11.x" inline>an [Attachment](https://discord.js.org/#/docs/main/v11/class/Attachment)</branch><branch version="12.x" inline>a [MessageAttachment](https://discord.js.org/#/docs/main/stable/class/MessageAttachment)</branch> from them to send as message option alongside the embed. The <branch version="11.x" inline>file</branch><branch version="12.x" inline>attachment</branch> parameter takes a BufferResolvable or Stream including the URL to an external image.
 
 You can then reference and use the images inside the embed itself with `attachment://fileName.extension`.
 

--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -42,7 +42,7 @@ To include permission checks like `ADMINISTRATOR` or `MANAGE_GUILD`, keep readin
 * Permission: The ability to execute a certain action in Discord
 * Overwrite: Rule on a channel to modify the permissions for a member or role
 * Bit field: Binary representation of Discord permissions 
-* Flag: Human readable string in MACRO_CASE, for example `'KICK_MEMBERS'`, refers to a position in the permission bit field. You can find a list of all valid flags in the <branch version="11.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS)</branch>
+* Flag: Human readable string in MACRO_CASE, for example `'KICK_MEMBERS'`, refers to a position in the permission bit field. You can find a list of all valid flags in the <branch version="11.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/v11/class/Permissions?scrollTo=s-FLAGS)</branch><branch version="12.x" inline>[discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Permissions?scrollTo=s-FLAGS)</branch>
 * Base Permissions: Permissions for roles the member has, set on the guild level
 * Final Permissions: Permissions for a member or role, after all overwrites are applied
 
@@ -79,7 +79,7 @@ Note that flag names are literal. Although `VIEW_CHANNEL` grants access to view 
 
 ### Creating a role with permissions
 
-Alternatively you can provide permissions as a property of <branch version="11.x" inline>[RoleData](https://discord.js.org/#/docs/main/11.5.1/typedef/RoleData)</branch><branch version="12.x" inline>[RoleData](https://discord.js.org/#/docs/main/stable/typedef/RoleData)</branch> objects during role creation as an array of flag strings or a permission number:
+Alternatively you can provide permissions as a property of <branch version="11.x" inline>[RoleData](https://discord.js.org/#/docs/main/v11/typedef/RoleData)</branch><branch version="12.x" inline>[RoleData](https://discord.js.org/#/docs/main/stable/typedef/RoleData)</branch> objects during role creation as an array of flag strings or a permission number:
 
 <branch version="11.x">
 
@@ -98,7 +98,7 @@ guild.roles.create({ data: { name: 'Mod', permissions: ['MANAGE_MESSAGES', 'KICK
 
 ### Checking member permissions
 
-To know if a one of a member's roles has a permission enabled, you can use the `.hasPermission()` method of the <branch version="11.x" inline>[GuildMember](https://discord.js.org/#/docs/main/11.5.1/class/GuildMember)</branch><branch version="12.x" inline>[GuildMember](https://discord.js.org/#/docs/main/stable/class/GuildMember)</branch> class and provide a permission flag, array, or number to check for. You can also specify if you want to allow the `ADMINISTRATOR` permission or the guild owner status to override this check with the following parameters.
+To know if a one of a member's roles has a permission enabled, you can use the `.hasPermission()` method of the <branch version="11.x" inline>[GuildMember](https://discord.js.org/#/docs/main/v11/class/GuildMember)</branch><branch version="12.x" inline>[GuildMember](https://discord.js.org/#/docs/main/stable/class/GuildMember)</branch> class and provide a permission flag, array, or number to check for. You can also specify if you want to allow the `ADMINISTRATOR` permission or the guild owner status to override this check with the following parameters.
 
 <branch version="11.x">
 
@@ -149,7 +149,7 @@ As you have likely already seen in your desktop client, channel overwrites have 
 
 ### Adding overwrites
 
-To add a permission overwrite for a role or guild member, you access the channel object and use the <branch version="11.x" inline>`.overwritePermissions()`</branch><branch version="12.x" inline>`.updateOverwrite()`</branch> method. The first parameter is the target of the overwrite, either a Role or User object (or its respective resolvable), and the second is a <branch version="11.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionOverwriteOptions)</branch><branch version="12.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/stable/typedef/PermissionOverwriteOptions)</branch> object.
+To add a permission overwrite for a role or guild member, you access the channel object and use the <branch version="11.x" inline>`.overwritePermissions()`</branch><branch version="12.x" inline>`.updateOverwrite()`</branch> method. The first parameter is the target of the overwrite, either a Role or User object (or its respective resolvable), and the second is a <branch version="11.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/v11/typedef/PermissionOverwriteOptions)</branch><branch version="12.x" inline>[PermissionOverwriteOptions](https://discord.js.org/#/docs/main/stable/typedef/PermissionOverwriteOptions)</branch> object.
 
 Let's add an overwrite to lock everyone out of the channel. The guild ID doubles as the role id for the default role @everyone as demonstrated below:
 
@@ -191,7 +191,7 @@ guild.createChannel('new-channel', {
 ```
 
 ::: warning
-These objects are [ChannelCreationOverwrites](https://discord.js.org/#/docs/main/11.5.1/typedef/ChannelCreationOverwrites) and differ from [PermissionOverwriteOptions](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionOverwriteOptions); be careful to not mix them up!
+These objects are [ChannelCreationOverwrites](https://discord.js.org/#/docs/main/v11/typedef/ChannelCreationOverwrites) and differ from [PermissionOverwriteOptions](https://discord.js.org/#/docs/main/v11/typedef/PermissionOverwriteOptions); be careful to not mix them up!
 :::
 
 </branch>
@@ -217,7 +217,7 @@ guild.channels.create('new-channel', {
 
 ### Replacing overwrites
 
-To replace all permission overwrites on the channel with a provided set of new overwrites, you can use the <branch version="11.x" inline>`.replaceOverwrites()`</branch><branch version="12.x" inline>`.overwritePermissions()`</branch> function. This is extremely handy if you want to copy a channels full set of overwrites to another one, as this method allows passing an array or Collection of <branch version="12.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/stable/class/PermissionOverwritess)</branch><branch version="11.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/11.5.1/class/PermissionOverwrites) or [ChannelCreationOverwrites](https://discord.js.org/#/docs/main/11.5.1/typedef/ChannelCreationOverwrites)</branch>.
+To replace all permission overwrites on the channel with a provided set of new overwrites, you can use the <branch version="11.x" inline>`.replaceOverwrites()`</branch><branch version="12.x" inline>`.overwritePermissions()`</branch> function. This is extremely handy if you want to copy a channels full set of overwrites to another one, as this method allows passing an array or Collection of <branch version="12.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/stable/class/PermissionOverwritess)</branch><branch version="11.x" inline>[PermissionOverwrites](https://discord.js.org/#/docs/main/v11/class/PermissionOverwrites) or [ChannelCreationOverwrites](https://discord.js.org/#/docs/main/v11/typedef/ChannelCreationOverwrites)</branch>.
 
 <branch version="11.x">
 
@@ -291,7 +291,7 @@ channel.lockPermissions()
 
 <branch version="11.x">
 
-discord.js features two utility methods to easily determine the final permissions for a guild member or role in a specific channel: `.permissionsFor()` on the [GuildChannel](https://discord.js.org/#/docs/main/11.5.1/class/GuildChannel?scrollTo=permissionsFor) class and `.permissionsIn()` on the [GuildMember](https://discord.js.org/#/docs/main/11.5.1/class/GuildMember?scrollTo=permissionsIn) class. Both return a [Permissions](https://discord.js.org/#/docs/main/11.5.1/class/Permissions) object.
+discord.js features two utility methods to easily determine the final permissions for a guild member or role in a specific channel: `.permissionsFor()` on the [GuildChannel](https://discord.js.org/#/docs/main/v11/class/GuildChannel?scrollTo=permissionsFor) class and `.permissionsIn()` on the [GuildMember](https://discord.js.org/#/docs/main/v11/class/GuildMember?scrollTo=permissionsIn) class. Both return a [Permissions](https://discord.js.org/#/docs/main/v11/class/Permissions) object.
 
 </branch>
 <branch version="12.x">
@@ -321,7 +321,7 @@ If you want to know how to work with the returned Permissions objects keep readi
 
 ## The Permissions object
 
-The <branch version="11.x" inline>[Permissions](https://discord.js.org/#/docs/main/11.5.1/class/Permissions)</branch><branch version="12.x" inline>[Permissions](https://discord.js.org/#/docs/main/stable/class/Permissions)</branch> object is a discord.js class containing a permissions bit field and a bunch of utility methods to manipulate it easily.
+The <branch version="11.x" inline>[Permissions](https://discord.js.org/#/docs/main/v11/class/Permissions)</branch><branch version="12.x" inline>[Permissions](https://discord.js.org/#/docs/main/stable/class/Permissions)</branch> object is a discord.js class containing a permissions bit field and a bunch of utility methods to manipulate it easily.
 Remember that using these methods will not manipulate permissions, but create a new instance representing the changed bit field.
 
 ### Converting permission numbers
@@ -334,7 +334,7 @@ const { Permissions } = require('discord.js');
 const permissions = new Permissions(268550160);
 ```
 
-You can also use this approach for other <branch version="11.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/11.5.1/typedef/PermissionResolvable)</branch><branch version="12.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/stable/typedef/PermissionResolvable)</branch>s like flag arrays or flags.
+You can also use this approach for other <branch version="11.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/v11/typedef/PermissionResolvable)</branch><branch version="12.x" inline>[PermissionResolvable](https://discord.js.org/#/docs/main/stable/typedef/PermissionResolvable)</branch>s like flag arrays or flags.
 
 ```js
 const { Permissions } = require('discord.js');

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -214,7 +214,7 @@ message.reactions.removeAll().catch(error => console.error('Failed to clear reac
 
 <branch version="11.x">
 
-Removing reactions by emoji is not as straightforward as clearing all reactions. Discord.js version 11.5.x does not provide a method for selectively removing reactions by emoji, it only allows you to remove a user from a specific reaction. This means you will have to get the users who reacted with that emoji, and loop through and remove each one of them.
+Removing reactions by emoji is not as straightforward as clearing all reactions. Discord.js version 11.x does not provide a method for selectively removing reactions by emoji, it only allows you to remove a user from a specific reaction. This means you will have to get the users who reacted with that emoji, and loop through and remove each one of them.
 
 Reaction collections are keyed by `name:id` for custom emojis and by `name` for unicode emojis (represented by their unicode character, see [here](/popular-topics/reactions.html#unicode-emojis)). Once you have the key you can simply run a `.get()` on `message.reactions` to get the reaction representing the emoji you want.
 
@@ -245,7 +245,7 @@ message.reactions.cache.get('484535447171760141').remove().catch(error => consol
 
 ### Removing reactions by user
 ::: tip
-If you are not familiar with [`Collection.filter()`](https://discord.js.org/#/docs/main/stable/class/Collection?scrollTo=filter) and [`Collection.has()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) take the time to understand what they do and then come back.
+If you are not familiar with <branch version="11.x" inline>[`Collection.filter()`](https://discord.js.org/#/docs/main/v11/class/Collection?scrollTo=filter)</branch><branch version="12.x" inline>[`Collection.filter()`](https://discord.js.org/#/docs/collection/master/class/Collection?scrollTo=filter)</branch> and [`Collection.has()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) take the time to understand what they do and then come back.
 :::
 
 <branch version="11.x">

--- a/guide/popular-topics/webhooks.md
+++ b/guide/popular-topics/webhooks.md
@@ -18,7 +18,7 @@ Bots receive webhook messages in a text channel normally. You can detect if the 
 if (message.webhookID) return;
 ```
 
-If you would like to get the webhook object that sent the message, you can use <branch version="11.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/Message?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=fetchWebhook)</branch>.
+If you would like to get the webhook object that sent the message, you can use <branch version="11.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/v11/class/Message?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Message#fetchWebhook()`](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=fetchWebhook)</branch>.
 
 ## Fetching webhooks
 
@@ -28,17 +28,17 @@ Webhook fetching will always make use of collections and promises, if you do not
 
 ### Fetching all webhooks of a guild
 
-If you would like to get all webhooks of a guild you can use <branch version="11.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/11.5.1/class/Guild?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s.
+If you would like to get all webhooks of a guild you can use <branch version="11.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/v11/class/Guild?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`Guild#fetchWebhooks()`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s.
 
 ### Fetching webhooks of a channel
 
-Webhooks belonging to a channel can be fetched using <branch version="11.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s. A collection will be returned even if the channel contains a single webhook. If you are certain the channel contains a single webhook, you can use <branch version="11.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/main/11.5.1/class/Collection?scrollTo=first)</branch><branch version="12.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/collection/stable/class/Collection?scrollTo=first)</branch> on the Collection to get the webhook.
+Webhooks belonging to a channel can be fetched using <branch version="11.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/v11/class/TextChannel?scrollTo=fetchWebhooks)</branch><branch version="12.x" inline>[`TextChannel#fetchWebhooks()`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=fetchWebhooks)</branch>. This will return a promise which will resolve into a Collection of `Webhook`s. A collection will be returned even if the channel contains a single webhook. If you are certain the channel contains a single webhook, you can use <branch version="11.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/main/v11/class/Collection?scrollTo=first)</branch><branch version="12.x" inline>[`Collection#first()`](https://discord.js.org/#/docs/collection/stable/class/Collection?scrollTo=first)</branch> on the Collection to get the webhook.
 
 ### Fetching a single webhook
 
 #### Using client
 
-You can fetch a specific webhook using its `id` with <branch version="11.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/Client?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=fetchWebhook)</branch>. You can obtain the webhook id by looking at its link, the number after `https://discordapp.com/api/webhooks/` is the `id`, and the part after that is the `token`.
+You can fetch a specific webhook using its `id` with <branch version="11.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/v11/class/Client?scrollTo=fetchWebhook)</branch><branch version="12.x" inline>[`Client#fetchWebhook()`](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=fetchWebhook)</branch>. You can obtain the webhook id by looking at its link, the number after `https://discordapp.com/api/webhooks/` is the `id`, and the part after that is the `token`.
 
 #### Using the WebhookClient constructor
 
@@ -63,7 +63,7 @@ Once you are there, click on the `Create Webhook` button on the top right. This 
 ### Creating webhooks with discord.js
 
 
-Discord.js provides a method for creating webhooks called <branch version="11.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/11.5.1/class/TextChannel?scrollTo=createWebhook)</branch><branch version="12.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=createWebhook)</branch>.
+Discord.js provides a method for creating webhooks called <branch version="11.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/v11/class/TextChannel?scrollTo=createWebhook)</branch><branch version="12.x" inline>[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=createWebhook)</branch>.
 
 <branch version="11.x">
 
@@ -88,7 +88,7 @@ channel.createWebhook('Some-username', {
 
 <branch version="11.x">
 
-You can edit Webhooks and WebhookClients to change their avatar and name using [`Webhook#edit()`](https://discord.js.org/#/docs/main/11.5.1/class/Webhook?scrollTo=edit) and [`WebhookClient#edit()`](https://discord.js.org/#/docs/main/11.5.1/class/WebhookClient?scrollTo=edit).
+You can edit Webhooks and WebhookClients to change their avatar and name using [`Webhook#edit()`](https://discord.js.org/#/docs/main/v11/class/Webhook?scrollTo=edit) and [`WebhookClient#edit()`](https://discord.js.org/#/docs/main/v11/class/WebhookClient?scrollTo=edit).
 
 ```js
 webhook.edit('Some-username', 'https://i.imgur.com/wSTFkRM.png')
@@ -113,7 +113,7 @@ webhook.edit({
 
 ## Using webhooks
 
-Webhooks, unlike bots, can send more than one embed per message, up to 10. They can also send attachments and normal content. The <branch version="11.x" inline> [`Webhook#send()`](https://discord.js.org/#/docs/main/11.5.1/class/Webhook?scrollTo=send)</branch><branch version="12.x" inline>[`Webhook#send()`](https://discord.js.org/#/docs/main/stable/class/Webhook?scrollTo=send)</branch> method to send to a webhook is very similar to the method for sending to a text channel. Webhooks can also choose what the username and avatar will appear as when the message is sent.
+Webhooks, unlike bots, can send more than one embed per message, up to 10. They can also send attachments and normal content. The <branch version="11.x" inline> [`Webhook#send()`](https://discord.js.org/#/docs/main/v11/class/Webhook?scrollTo=send)</branch><branch version="12.x" inline>[`Webhook#send()`](https://discord.js.org/#/docs/main/stable/class/Webhook?scrollTo=send)</branch> method to send to a webhook is very similar to the method for sending to a text channel. Webhooks can also choose what the username and avatar will appear as when the message is sent.
 
 <branch version="11.x">
 

--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -39,7 +39,7 @@ manager.on('shardCreate', shard => console.log(`Launched shard ${shard.id}`));
 The above code utilizes discord.js's sharding manager to spawn the recommended amount of shards for your bot. The recommended amount should be approximately 1,000 guilds per shard. Even though you provide the token here, you will still need to send it over to the main bot file in `client.login()`, so don't forget to do that.
 
 ::: tip
-You can find the methods available for the ShardingManager class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/11.5.1/class/ShardingManager)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/ShardingManager)</branch>. Though, you may not be making much use of this section, unlike the next feature we will explore, which you may learn about by clicking [this link](/sharding/additional-information.md).
+You can find the methods available for the ShardingManager class <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/ShardingManager)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/ShardingManager)</branch>. Though, you may not be making much use of this section, unlike the next feature we will explore, which you may learn about by clicking [this link](/sharding/additional-information.md).
 :::
 
 ## Getting started
@@ -97,7 +97,7 @@ Let's say your bot is in a total of 3,600 guilds. Using the recommended shard co
 
 ## FetchClientValues
 
-First, let's take a look at <branch version="11.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=fetchClientValues)</branch><branch version="12.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=fetchClientValues)</branch> called `fetchClientValues`. This method retrieves a client property of all shards.
+First, let's take a look at <branch version="11.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=fetchClientValues)</branch><branch version="12.x" inline>[one of the most common sharding utility methods you'll be using](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=fetchClientValues)</branch> called `fetchClientValues`. This method retrieves a client property of all shards.
 
 Now, take the following snippet of code:
 
@@ -176,7 +176,7 @@ While it's a bit unattractive to have more nesting in your commands, it is neces
 
 ## BroadcastEval
 
-Next, check out <branch version="11.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> known as `broadcastEval`. This method makes all of the shards evaluate a given script, where `this` is the `client` once each shard gets to evaluating it. You can read more about the `this` keyword [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this). For now, essentially understand that it is the "client" object.
+Next, check out <branch version="11.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[another handy sharding method](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> known as `broadcastEval`. This method makes all of the shards evaluate a given script, where `this` is the `client` once each shard gets to evaluating it. You can read more about the `this` keyword [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this). For now, essentially understand that it is the "client" object.
 
 <branch version="11.x">
 

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -23,7 +23,7 @@ manager.on('message', (shard, message) => {
 
 As the property names imply, the `_eval` property is what the shard is attempting to evaluate, and the `_result` property is the output of said evaluation. However, these properties are only guaranteed if a _shard_ is sending a message. There will also be an `_error` property, should the evaluation have thrown an error.
 
-You can also send messages via `process.send('hello')`, which would not contain the same information. This is why the `.message` property's type is declared as `*` <branch version="11.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/11.5.1/class/Shard?scrollTo=e-message)</branch><branch version="12.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Shard?scrollTo=e-message)</branch>.
+You can also send messages via `process.send('hello')`, which would not contain the same information. This is why the `.message` property's type is declared as `*` <branch version="11.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/v11/class/Shard?scrollTo=e-message)</branch><branch version="12.x" inline>[in the discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Shard?scrollTo=e-message)</branch>.
 
 ## Specific shards
 
@@ -33,7 +33,7 @@ There might be times where you want to target a specific shard. An example would
 client.shard.broadcastEval('if (this.shard.id === 0) process.exit();');
 ```
 
-If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <branch version="11.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/11.5.1/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> sends a message to **all** shards, so you have to check if it's on the shard you want.
+If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <branch version="11.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/v11/class/ShardClientUtil?scrollTo=broadcastEval)</branch><branch version="12.x" inline>[Shard#BroadcastEval](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval)</branch> sends a message to **all** shards, so you have to check if it's on the shard you want.
 
 ## `ShardingManager#shardArgs` and `ShardingManager#execArgv`
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This updates the version selector to display 11.6 instead of 11.5 for the `11.x` branch.
Also, rewrites all 11.x specific doc links to `v11` branch of the docs (was `11.5.1`).
Also fixes a link to Collection in `reactions.md` by adding appropriate branching.

[Discussed](https://discordapp.com/channels/222078108977594368/682245563193884710/706862128597958727) in Discord.