### PR TITLE
Change "both" to "all of"

### DIFF
--- a/guide/popular-topics/partials.md
+++ b/guide/popular-topics/partials.md
@@ -24,7 +24,7 @@ const { Client } = require('discord.js');
 const client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
 ```
 :::tip
-Make sure you enable all partials you need for your use case! If you miss one the event does not get emitted. For example listening for reactions on uncached Messages in a direct message channel requires both `MESSAGE`, `CHANNEL` and `REACTION`!
+Make sure you enable all partials you need for your use case! If you miss one the event does not get emitted. For example listening for reactions on uncached Messages in a direct message channel requires all of `MESSAGE`, `CHANNEL` and `REACTION`!
 If you miss `CHANNEL` as enabled partial type reactions on uncached messages in servers will be emitted (as guild channels are always cached) but will not do so for direct messages.
 :::
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

![image](https://user-images.githubusercontent.com/27663662/81499964-62881000-9312-11ea-9fb3-6511cd77b400.png)

A nitpicky PR that changes "both" to "all of" because both is only used for two options.