### PR TITLE
Note to not use the Client Secret

### DIFF
--- a/guide/preparations/setting-up-a-bot-application.md
+++ b/guide/preparations/setting-up-a-bot-application.md
@@ -33,6 +33,10 @@ After creating a bot user, you'll see a section like this:
 
 In this panel, you can give your bot a snazzy avatar, set its username, and make it public or private. You can access your token in this panel as well, either by revealing it or simply pressing the "Copy" button. When we ask you to paste your token somewhere, this is the value that you need to put in. Don't worry if you do happen to lose it at some point; you can always come back to this page and copy it again.
 
+::: warning
+Make sure to use the Token from the Bot panel. There is a similar-looking Client Secret from the General Information panel; it will not work. 
+::: 
+
 ### What is a token, anyway?
 
 A token is essentially your bot's password; it's what your bot uses to login to Discord. With that being said, **it is vital that you do not ever share this token with anybody, purposely or accidentally**. If someone does manage to get a hold of your token, they can use your bot as if it were theirs—this means they can perform malicious acts with it.


### PR DESCRIPTION
Add a note to not use the Client Secret from the General Information panel.

In the event the user ignores the warning to read carefully (mea culpa) and is used to apps only having one secret token, it's possible to confuse the Token with the Client Secret.  If you end up in that spot, you'll get an invalid token response from Discord and be very confused.

