### PR TITLE
replace 'multipart/form-data' with 'application/x-www-form-urlencoded'

### DIFF
--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -2,7 +2,6 @@ const http = require('http');
 const fs = require('fs');
 const url = require('url');
 const fetch = require('node-fetch');
-const querystring = require('querystring');
 
 const port = 53134;
 
@@ -25,7 +24,7 @@ http.createServer((req, res) => {
 
 		fetch('https://discordapp.com/api/oauth2/token', {
 			method: 'POST',
-			body: querystring.unescape(querystring.stringify(data)),
+			body: new URLSearchParams(data),
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},

--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -14,12 +14,12 @@ http.createServer((req, res) => {
 	if (urlObj.query.code) {
 		const accessCode = urlObj.query.code;
 		const data = {
-			'client_id': 'your client id',
-			'client_secret': 'your client secret',
-			'grant_type': 'authorization_code',
-			'redirect_uri': 'your redirect uri',
-			'code': accessCode,
-			'scope': 'the scopes'
+			client_id: 'your client id',
+			client_secret: 'your client secret',
+			grant_type: 'authorization_code',
+			redirect_uri: 'your redirect uri',
+			code: accessCode,
+			scope: 'the scopes',
 		};
 
 		// convert to application/x-www-form-urlencoded
@@ -32,9 +32,9 @@ http.createServer((req, res) => {
 		fetch('https://discordapp.com/api/oauth2/token', {
 			method: 'POST',
 			body: formUrlEncode(data),
-			headers : {
-				'Content-Type': 'application/x-www-form-urlencoded'
-			}
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
 		})
 			.then(discordRes => discordRes.json())
 			.then(info => {

--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -2,6 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const url = require('url');
 const fetch = require('node-fetch');
+const querystring = require('querystring');
 
 const port = 53134;
 
@@ -22,16 +23,9 @@ http.createServer((req, res) => {
 			scope: 'the scopes',
 		};
 
-		// convert to application/x-www-form-urlencoded
-		function formUrlEncode(data) {
-			return Object.entries(data)
-				.map(([k, v]) => k + '=' + v)
-				.join('&');
-		}
-
 		fetch('https://discordapp.com/api/oauth2/token', {
 			method: 'POST',
-			body: formUrlEncode(data),
+			body: querystring.unescape(querystring.stringify(data)),
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -196,10 +196,8 @@ Require `node-fetch` and make your request.
 
 ```js
 const fetch = require('node-fetch');
-const qs = require('querystring');
 
 // ...
-
 
 const data = {
 	client_id: 'your client id',
@@ -210,16 +208,9 @@ const data = {
 	scope: 'the scopes',
 };
 
-// convert to application/x-www-form-urlencoded
-function formUrlEncode(data) {
-	return Object.entries(data)
-		.map(([k, v]) => `${k}=${v}`)
-		.join('&');
-}
-
 fetch('https://discordapp.com/api/oauth2/token', {
 	method: 'POST',
-	body: qs.unescape(qs.stringify(data)),
+	body: new URLSearchParams(data),
 	headers: {
 		'Content-Type': 'application/x-www-form-urlencoded',
 	},

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -201,27 +201,27 @@ const fetch = require('node-fetch');
 
 
 const data = {
-	'client_id': 'your client id',
-	'client_secret': 'your client secret',
-	'grant_type': 'authorization_code',
-	'redirect_uri': 'your redirect uri',
-	'code': accessCode,
-	'scope': 'the scopes'
+	client_id: 'your client id',
+	client_secret: 'your client secret',
+	grant_type: 'authorization_code',
+	redirect_uri: 'your redirect uri',
+	code: accessCode,
+	scope: 'the scopes',
 };
 
 // convert to application/x-www-form-urlencoded
 function formUrlEncode(data) {
 	return Object.entries(data)
-		.map(([k, v]) => k + '=' + v)
+		.map(([k, v]) => `${k}=${v}`)
 		.join('&');
 }
 
 fetch('https://discordapp.com/api/oauth2/token', {
 	method: 'POST',
 	body: formUrlEncode(data),
-	headers : {
-		'Content-Type': 'application/x-www-form-urlencoded'
-	}
+	headers: {
+		'Content-Type': 'application/x-www-form-urlencoded',
+	},
 })
 	.then(res => res.json())
 	.then(console.log);

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -190,7 +190,7 @@ if (urlObj.pathname === '/') {
 }
 ```
 
-Now, that you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten them, head over to [your applications](https://discordapp.com/developers/applications) and get them. You can use `node-fetch` to make requests to Discord; you can install it with `npm i node-fetch`. Note that Discord does not accept tokens passed through `encodeUriComponent`.
+Now you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten them, head over to [your applications](https://discordapp.com/developers/applications) and get them. You can use `node-fetch` to make requests to Discord; you can install it with `npm i node-fetch`.
 
 Require `node-fetch` and make your request.
 
@@ -220,7 +220,7 @@ fetch('https://discordapp.com/api/oauth2/token', {
 ```
 
 ::: warning
-The content-type for the token url must be `application/x-www-form-urlencoded`. This is why `formUrlEncode()` is used.
+The content-type for the token url must be `application/x-www-form-urlencoded`. This is why `URLSearchParams` is used.
 :::
 
 Now try visiting your OAuth2 url and authorizing your application. Once you're redirected, you should see something like this in your console.

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -196,6 +196,7 @@ Require `node-fetch` and make your request.
 
 ```js
 const fetch = require('node-fetch');
+const qs = require('querystring');
 
 // ...
 
@@ -218,7 +219,7 @@ function formUrlEncode(data) {
 
 fetch('https://discordapp.com/api/oauth2/token', {
 	method: 'POST',
-	body: formUrlEncode(data),
+	body: qs.unescape(qs.stringify(data)),
 	headers: {
 		'Content-Type': 'application/x-www-form-urlencoded',
 	},

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -60,7 +60,7 @@ Take note of the `client id` field, the `client secret` field, and the "OAuth2" 
 
 ![img](~@/images/9fejia2.png)
 
-Once you've added your redirect url, you will want to generate an OAuth2 url. Lower down on the page, you can conveniently find an OAuth2 Url Generator provided by Discord. Use this to generate a url for yourself with the `identify` scope. 
+Once you've added your redirect url, you will want to generate an OAuth2 url. Lower down on the page, you can conveniently find an OAuth2 Url Generator provided by Discord. Use this to generate a url for yourself with the `identify` scope.
 
 ![img](~@/images/18e2dwi.png)
 
@@ -121,7 +121,7 @@ Here you just grab the access token and type from the url if it's there and use 
 
 ## More details
 
-### The state parameter 
+### The state parameter
 
 OAuth2's protocols provide a `state` parameter which is supported by Discord. This is used to help prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attacks and can also be used to represent the state of your application. This should be generated per user and appended to the OAuth2 url. For a very basic example, you can use a randomly generated string encoded in Base64 as the state parameter.
 
@@ -190,7 +190,7 @@ if (urlObj.pathname === '/') {
 }
 ```
 
-Now, that you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten them, head over to [your applications](https://discordapp.com/developers/applications) and get them. You can use `node-fetch` to make requests to Discord; you can install it with `npm i node-fetch`. Note that Discord adheres strict
+Now, that you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten them, head over to [your applications](https://discordapp.com/developers/applications) and get them. You can use `node-fetch` to make requests to Discord; you can install it with `npm i node-fetch`. Note that Discord does not accept tokens passed through `encodeUriComponent`.
 
 Require `node-fetch` and make your request.
 


### PR DESCRIPTION
In the guide you stated that you are using the npm [`form-data`](https://www.npmjs.com/package/form-data) module to convert the data to `application/x-www-form-urlencoded` as requested by [Discord](https://discord.com/developers/docs/topics/oauth2) and RFC 6749, however you used it actually which sends data as `multipart/form-data`.
 
It seems that discord accepts this format but it is different that what Discord recommends and what is stated in the guide. Adding `headers: { 'Content-Type': 'application/x-www-form-urlencoded' }` to the `fetch` call makes Discord flag it as invalid as the payload is in a different format.

https://medium.com/@rajajawahar77/content-type-x-www-form-urlencoded-form-data-and-json-e17c15926c69