### PR TITLE
fix(reactions): fix presence intent name

### DIFF
--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -334,7 +334,7 @@ Since version 12 you can change this behaviour by activating partials. For a ful
 Make sure you enable partial structures for `MESSAGE`, `CHANNEL` and `REACTION` when instantiating your client, if you want reaction events on uncached messages for both server and direct message channels. If you do not want to support direct message channels you can exclude `CHANNEL`.
 
 :::tip
-If you use [gateway intents](/popular-topics/intents.md) but can't or don't want to use the privileged `GUILD_MEMBER_PRESENCE` intent you additionally need the `USER` partial.
+If you use [gateway intents](/popular-topics/intents.md) but can't or don't want to use the privileged `GUILD_PRESENCES` intent you additionally need the `USER` partial.
 :::
 
 ```js


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the incorrect name of the `GUILD_PRESENCES` intent added in https://github.com/discordjs/guide/commit/5e11b51c9cddd8b024bb89456dee25e3a6edb3bf