### PR TITLE
refactor: use thumbs up emoji in examples

### DIFF
--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -118,7 +118,7 @@ The filter looks for messages that match one of the answers in our array of poss
 
 ### Basic reaction collector
 
-These work quite similarly to message collectors, except that you apply them on a message rather than a channel. The following is an example taken from the documentation, with slightly better variable names for clarification. The filter will check for the 👌 emoji - in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
+These work quite similarly to message collectors, except that you apply them on a message rather than a channel. The following is an example taken from the documentation, with slightly better variable names for clarification. The filter will check for the 👍 emoji - in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
 
 ::: tip
 You can read the docs for the `.createReactionCollector()` method <branch version="11.x" inline>[here](https://discord.js.org/#/docs/main/v11/class/Message?scrollTo=createReactionCollector)</branch><branch version="12.x" inline>[here](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=createReactionCollector)</branch>.
@@ -128,7 +128,7 @@ You can read the docs for the `.createReactionCollector()` method <branch versio
 
 ```js
 const filter = (reaction, user) => {
-	return reaction.emoji.name === '👌' && user.id === message.author.id;
+	return reaction.emoji.name === '👍' && user.id === message.author.id;
 };
 
 const collector = message.createReactionCollector(filter, { time: 15000 });
@@ -147,7 +147,7 @@ collector.on('end', collected => {
 
 ```js
 const filter = (reaction, user) => {
-	return reaction.emoji.name === '👌' && user.id === message.author.id;
+	return reaction.emoji.name === '👍' && user.id === message.author.id;
 };
 
 const collector = message.createReactionCollector(filter, { time: 15000 });
@@ -173,7 +173,7 @@ You can read the docs for the `.awaitReactions()` method <branch version="11.x" 
 
 ```js
 const filter = (reaction, user) => {
-	return reaction.emoji.name === '👌' && user.id === message.author.id;
+	return reaction.emoji.name === '👍' && user.id === message.author.id;
 };
 
 message.awaitReactions(filter, { max: 4, time: 60000, errors: ['time'] })


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR replaces the ok-hand emoji with 👍.
Closes #427 
Closes #428