### PR TITLE
Partially revert recent commit fixing sharding guide

### DIFF
--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -30,16 +30,12 @@ manager.on('launch', shard => console.log(`Launched shard ${shard.id}`));
 </branch>
 <branch version="12.x">
 
-::: tip
-In version 12 shards can have multiple ids. If you use the default sharding manager the `.ids` array will only have one entry.
-:::
-
 ```js
 const { ShardingManager } = require('discord.js');
 const manager = new ShardingManager('./bot.js', { token: 'your-token-goes-here' });
 
 manager.spawn();
-manager.on('shardCreate', shard => console.log(`Launched shard id(s) ${shard.ids.join(', ')}`));
+manager.on('shardCreate', shard => console.log(`Launched shard id ${shard.id}`));
 ```
 
 </branch>

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -29,6 +29,8 @@ You can also send messages via `process.send('hello')`, which would not contain 
 
 There might be times where you want to target a specific shard. An example would be to kill a specific shard that isn't working as intended. You can achieve this by taking the following snippet (in a command, preferably):
 
+<branch version="11.x">
+
 ```js
 client.shard.broadcastEval('if (this.shard.id === 0) process.exit();');
 ```

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -15,28 +15,11 @@ Here are some extra topics covered about sharding that you might have concerns a
 
 In order for shards to communicate, they must send messages to one another, as they are each their own process. You can listen for these messages by adding the following listener in your `index.js` file:
 
-<branch version="11.x">
-
 ```js
 manager.on('message', (shard, message) => {
 	console.log(`Shard[${shard.id}] : ${message._eval} : ${message._result}`);
 });
 ```
-
-</branch>
-<branch version="12.x">
-
-::: tip
-In version 12 shards can have multiple ids. If you use the default sharding manager the `.ids` array will only have one entry.
-:::
-
-```js
-manager.on('message', (shard, message) => {
-	console.log(`Shard[${shard.ids.join(',')}] : ${message._eval} : ${message._result}`);
-});
-```
-
-</branch>
 
 As the property names imply, the `_eval` property is what the shard is attempting to evaluate, and the `_result` property is the output of said evaluation. However, these properties are only guaranteed if a _shard_ is sending a message. There will also be an `_error` property, should the evaluation have thrown an error.
 
@@ -54,6 +37,10 @@ client.shard.broadcastEval('if (this.shard.id === 0) process.exit();');
 
 </branch>
 <branch version="12.x">
+
+::: tip
+In version 12 [`client.shard`](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=ids) can hold multiple ids. If you use the default sharding manager the `.ids` array will only have one entry.
+:::
 
 ```js
 client.shard.broadcastEval('if (this.shard.ids.includes(0)) process.exit();');

--- a/guide/sharding/extended.md
+++ b/guide/sharding/extended.md
@@ -84,7 +84,7 @@ This will never work for a channel that lies on another shard. So, let's remedy 
 <branch version="12.x">
 
 ::: tip
-In version 12 shards can have multiple ids. If you use the default sharding manager the `.ids` array will only have one entry.
+In version 12 [`client.shard`](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=ids) can hold multiple ids. If you use the default sharding manager the `.ids` array will only have one entry.
 :::
 
 ```diff


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Recent commit [d2a5acf](https://github.com/discordjs/guide/commit/d2a5acf1a9b1beb720970437edd089718b0ad8c9) added incorrect informations about [`Shard`](https://discord.js.org/#/docs/main/stable/class/Shard) being able to have multiple IDs.

`Shard`s are already shards, they have single ID. It's the `Client` that is able to have multiple shards with internal sharding, so it's [`Client.shards`](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil) that is an array.