### PR TITLE
Use trim after slicing off the prefix

### DIFF
--- a/code-samples/additional-info/rest-api/11/index.js
+++ b/code-samples/additional-info/rest-api/11/index.js
@@ -14,7 +14,7 @@ client.once('ready', () => {
 client.on('message', async message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'cat') {

--- a/code-samples/additional-info/rest-api/12/index.js
+++ b/code-samples/additional-info/rest-api/12/index.js
@@ -14,7 +14,7 @@ client.once('ready', () => {
 client.on('message', async message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'cat') {

--- a/code-samples/command-handling/adding-features/11/index.js
+++ b/code-samples/command-handling/adding-features/11/index.js
@@ -21,7 +21,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const commandName = args.shift().toLowerCase();
 
 	const command = client.commands.get(commandName)

--- a/code-samples/command-handling/adding-features/12/index.js
+++ b/code-samples/command-handling/adding-features/12/index.js
@@ -21,7 +21,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const commandName = args.shift().toLowerCase();
 
 	const command = client.commands.get(commandName)

--- a/code-samples/command-handling/dynamic-commands/11/index.js
+++ b/code-samples/command-handling/dynamic-commands/11/index.js
@@ -19,7 +19,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (!client.commands.has(command)) return;

--- a/code-samples/command-handling/dynamic-commands/12/index.js
+++ b/code-samples/command-handling/dynamic-commands/12/index.js
@@ -19,7 +19,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (!client.commands.has(command)) return;

--- a/code-samples/command-handling/file-setup/11/index.js
+++ b/code-samples/command-handling/file-setup/11/index.js
@@ -19,7 +19,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/code-samples/command-handling/file-setup/12/index.js
+++ b/code-samples/command-handling/file-setup/12/index.js
@@ -19,7 +19,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/code-samples/creating-your-bot/commands-with-user-input/11/index.js
+++ b/code-samples/creating-your-bot/commands-with-user-input/11/index.js
@@ -9,7 +9,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/code-samples/creating-your-bot/commands-with-user-input/12/index.js
+++ b/code-samples/creating-your-bot/commands-with-user-input/12/index.js
@@ -9,7 +9,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/code-samples/keyv/index.js
+++ b/code-samples/keyv/index.js
@@ -26,7 +26,7 @@ client.on('message', async message => {
 		}
 
 		if (!prefix) return;
-		args = message.content.slice(prefix.length).split(/\s+/);
+		args = message.content.slice(prefix.length).trim().split(/\s+/);
 	} else {
 		const slice = message.content.startsWith(globalPrefix) ? globalPrefix.length : 0;
 		args = message.content.slice(slice).split(/\s+/);

--- a/code-samples/sequelize/tags/sequelize.js
+++ b/code-samples/sequelize/tags/sequelize.js
@@ -45,7 +45,7 @@ client.once('ready', () => {
 
 client.on('message', async message => {
 	if (message.content.startsWith(PREFIX)) {
-		const input = message.content.slice(PREFIX.length).split(' ');
+		const input = message.content.slice(PREFIX.length).trim().split(' ');
 		const command = input.shift();
 		const commandArgs = input.join(' ');
 

--- a/code-samples/sharding/extended/11/bot.js
+++ b/code-samples/sharding/extended/11/bot.js
@@ -16,7 +16,7 @@ function findEmoji(id) {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'stats') {

--- a/code-samples/sharding/extended/12/bot.js
+++ b/code-samples/sharding/extended/12/bot.js
@@ -16,7 +16,7 @@ function findEmoji(id) {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'stats') {

--- a/code-samples/sharding/getting-started/11/bot.js
+++ b/code-samples/sharding/getting-started/11/bot.js
@@ -6,7 +6,7 @@ const prefix = '!';
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'stats') {

--- a/code-samples/sharding/getting-started/12/bot.js
+++ b/code-samples/sharding/getting-started/12/bot.js
@@ -6,7 +6,7 @@ const prefix = '!';
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'stats') {

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -34,7 +34,7 @@ client.once('ready', () => {
 client.on('message', async message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	// ...
@@ -58,7 +58,7 @@ client.once('ready', () => {
 client.on('message', async message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	// ...

--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -17,7 +17,7 @@ client.once('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -7,7 +7,7 @@ This page is a follow-up and bases its code off of [the previous page](/command-
 The command handler you've been building so far doesn't do much aside from dynamically load and execute commands. Those two things alone are great, but definitely not the only things you want. Before diving into it, let's do some quick refactoring in preparation.
 
 ```diff
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 -	const command = args.shift().toLowerCase();
 +	const commandName = args.shift().toLowerCase();
 

--- a/guide/command-handling/dynamic-commands.md
+++ b/guide/command-handling/dynamic-commands.md
@@ -25,7 +25,7 @@ So, if you wanted to (assuming that you've copied & pasted all of your commands 
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/guide/creating-your-bot/commands-with-user-input.md
+++ b/guide/creating-your-bot/commands-with-user-input.md
@@ -16,13 +16,13 @@ Go to your main bot file and find the `client.on('message', ...)` bit. Add the f
 // client.on('message', message => {
 if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-const args = message.content.slice(prefix.length).split(' ');
+const args = message.content.slice(prefix.length).trim().split(' ');
 const command = args.shift().toLowerCase();
 // the rest of your code
 ```
 
 1. If the message either doesn't start with the prefix or was sent by a bot, exit early.
-2. Create an `args` variable that slices off the prefix entirely and then splits it into an array by spaces.
+2. Create an `args` variable that slices off the prefix entirely, removes the leftover whitespaces and then splits it into an array by spaces.
 3. Create a `command` variable by calling `args.shift()`, which will take the first element in array and return it while also removing it from the original array (so that you don't have the command name string inside the `args` array).
 
 Hopefully that's a bit clearer, if there was any confusion. Let's create a quick command to check out the result of our new addition:
@@ -107,8 +107,8 @@ Currently, you're using `.split(' ')` to split the command arguments. However, t
 If you've never done something like this before, this probably isn't what you'd expect, right? Thankfully, there's a simple solution for this issue. The red line is what to remove, and the green line is what to replace it with.
 
 ```diff
-- const args = message.content.slice(prefix.length).split(' ');
-+ const args = message.content.slice(prefix.length).split(/ +/);
+- const args = message.content.slice(prefix.length).trim().split(' ');
++ const args = message.content.slice(prefix.length).trim().split(/ +/);
 ```
 
 <div is="discord-messages">

--- a/guide/keyv/README.md
+++ b/guide/keyv/README.md
@@ -103,7 +103,7 @@ client.on('message', async message => {
 
 		// if we found a prefix, setup args; otherwise, this isn't a command
 		if (!prefix) return;
-		args = message.content.slice(prefix.length).split(/\s+/);
+		args = message.content.slice(prefix.length).trim().split(/\s+/);
 	} else {
 		// handle DMs
 		const slice = message.content.startsWith(globalPrefix) ? globalPrefix.length : 0;

--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -45,7 +45,7 @@ client.once('ready', () => {
 
 client.on('message', async message => {
 	if (message.content.startsWith(PREFIX)) {
-		const input = message.content.slice(PREFIX.length).split(' ');
+		const input = message.content.slice(PREFIX.length).trim().split(' ');
 		const command = input.shift();
 		const commandArgs = input.join(' ');
 

--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -65,7 +65,7 @@ const prefix = '!';
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'stats') {
@@ -88,7 +88,7 @@ const prefix = '!';
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'stats') {

--- a/guide/sharding/extended.md
+++ b/guide/sharding/extended.md
@@ -14,7 +14,7 @@ Let's start off with a basic usage with shards. At some point in bot development
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'send') {
@@ -36,7 +36,7 @@ client.on('message', message => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'send') {
@@ -177,7 +177,7 @@ If you remember, there was a brief mention of passing functions through `.broadc
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'emoji') {
@@ -196,7 +196,7 @@ client.on('message', message => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'emoji') {
@@ -243,7 +243,7 @@ Next, you need to properly call the function in your command. If you recall from
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/ +/);
+	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'emoji') {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes use of `trim()` after slicing the prefix when declaring `const args`. This should allow for using spaces between prefix and command without issues.
Additionally includes explanation in `guide/creating-your-bot/commands-with-user-input.md` for that, but it probably could be improved.

Closes #383 by superseding.