### PR TITLE
Add missing new VoiceConnection accessing

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1908,7 +1908,7 @@ This event has been removed entirely.
 
 ### VoiceConnection
 
-The `VoiceConnection` class is now accessed via respective `VoiceState` class.
+The `VoiceConnection` class is now accessed via the respective `VoiceState` class.
 
 ```diff
 - guild.voiceConnection;

--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1908,6 +1908,16 @@ This event has been removed entirely.
 
 ### VoiceConnection
 
+The `VoiceConnection` class is now accessed via respective `VoiceState` class.
+
+```diff
+- guild.voiceConnection;
++ guild.voice.connection;
+
+- member.voiceConnection;
++ member.voice.connection;
+```
+
 The `VoiceConnection` class also implements the new `PlayInterface` class in addition to extending `EventEmitter` from Node.
 
 #### VoiceConnection#createReceiver


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Accessing `VoiceConnection` changed from `.voiceConnection` to `.voice.connection`, but it was not listed in the updating guide.