### PR TITLE
Updated querystring size parameter for avatar urls

### DIFF
--- a/guide/creating-your-bot/commands-with-user-input.md
+++ b/guide/creating-your-bot/commands-with-user-input.md
@@ -240,7 +240,7 @@ That part is simple; just recycle the if statement you used in the section above
 	</discord-message>
 	<discord-message author="Tutorial Bot" avatar="blue" :bot="true">
 		Your avatar:
-		https://cdn.discordapp.com/avatars/459757892778590229/72153038872deb9b81a2444a0edcf041.png?size=2084
+		https://cdn.discordapp.com/avatars/459757892778590229/72153038872deb9b81a2444a0edcf041.png?size=2048
 	</discord-message>
 </div>
 
@@ -299,9 +299,9 @@ And ta-da! You now have a list of avatar links of all the users you tagged.
 	</discord-message>
 	<discord-message author="Tutorial Bot" avatar="blue" :bot="true">
 		User's avatar:
-		https://cdn.discordapp.com/avatars/459757892778590229/72153038872deb9b81a2444a0edcf041.png?size=2084<br>
+		https://cdn.discordapp.com/avatars/459757892778590229/72153038872deb9b81a2444a0edcf041.png?size=2048<br>
 		Tutorial Bot's avatar:
-		https://cdn.discordapp.com/avatars/459757708720209940/d48f3d90d923e9531c02c6bb9850339f.png?size=2084
+		https://cdn.discordapp.com/avatars/459757708720209940/d48f3d90d923e9531c02c6bb9850339f.png?size=2048
 	</discord-message>
 </div>
 


### PR DESCRIPTION
Avatar URLs are currently broken because of incorrect size params. If an invalid integer is given to the size param, the resource request returns a "400 Bad Request" status. 

URLs should also work without a size param, but since one was used in the example I decided to correct rather than remove it. 

Updated the size from 2084 to 2048, as it needs to be 2^[3, →) in order to work. (That's 2 to the power of 3 or more)

The image requests should now return an OK status.

