### PR TITLE
Bump eslint-plugin-vue from 5.2.2 to 5.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^5.6.0",
     "eslint-config-sora": "^2.0.0",
     "eslint-plugin-markdown": "^1.0.0",
-    "eslint-plugin-vue": "^5.2.2",
+    "eslint-plugin-vue": "^5.2.3",
     "vuepress": "^0.14.10"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,10 +2917,10 @@ eslint-plugin-markdown@^1.0.0:
     remark-parse "^5.0.0"
     unified "^6.1.2"
 
-eslint-plugin-vue@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-5.2.2.tgz#86601823b7721b70bc92d54f1728cfc03b36283c"
-  integrity sha512-CtGWH7IB0DA6BZOwcV9w9q3Ri6Yuo8qMjx05SmOGJ6X6E0Yo3y9E/gQ5tuNxg2dEt30tRnBoFTbvtmW9iEoyHA==
+eslint-plugin-vue@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz#3ee7597d823b5478804b2feba9863b1b74273961"
+  integrity sha512-mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==
   dependencies:
     vue-eslint-parser "^5.0.0"
 


### PR DESCRIPTION

![chrome_43In1USoo6](https://user-images.githubusercontent.com/45435431/91435052-023bc080-e866-11ea-844f-a897cff81813.png)
Bumps [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue) from 5.2.2 to 5.2.3.
- [Release notes](https://github.com/vuejs/eslint-plugin-vue/releases)
- [Commits](https://github.com/vuejs/eslint-plugin-vue/compare/v5.2.2...v5.2.3)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

**Please describe the changes this PR makes and why it should be merged:**
