### PR TITLE
fix: use console.error when logging errors

### DIFF
--- a/code-samples/command-handling/adding-features/11/commands/reload.js
+++ b/code-samples/command-handling/adding-features/11/commands/reload.js
@@ -18,7 +18,7 @@ module.exports = {
 			message.client.commands.set(newCommand.name, newCommand);
 			message.channel.send(`Command \`${command.name}\` was reloaded!`);
 		} catch (error) {
-			console.log(error);
+			console.error(error);
 			message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
 		}
 	},

--- a/code-samples/command-handling/adding-features/12/commands/reload.js
+++ b/code-samples/command-handling/adding-features/12/commands/reload.js
@@ -18,7 +18,7 @@ module.exports = {
 			message.client.commands.set(newCommand.name, newCommand);
 			message.channel.send(`Command \`${command.name}\` was reloaded!`);
 		} catch (error) {
-			console.log(error);
+			console.error(error);
 			message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
 		}
 	},

--- a/code-samples/popular-topics/reactions/12/uncached-messages.js
+++ b/code-samples/popular-topics/reactions/12/uncached-messages.js
@@ -10,7 +10,7 @@ client.on('messageReactionAdd', async (reaction, user) => {
 		try {
 			await reaction.message.fetch();
 		} catch (error) {
-			console.log('Something went wrong when fetching the message: ', error);
+			console.error('Something went wrong when fetching the message: ', error);
 		}
 	}
 	console.log(`${user.username} reacted with "${reaction.emoji.name}".`);
@@ -21,7 +21,7 @@ client.on('messageReactionRemove', async (reaction, user) => {
 		try {
 			await reaction.message.fetch();
 		} catch (error) {
-			console.log('Something went wrong when fetching the message: ', error);
+			console.error('Something went wrong when fetching the message: ', error);
 		}
 	}
 	console.log(`${user.username} removed their "${reaction.emoji.name}" reaction.`);

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -431,7 +431,7 @@ try {
 	const newCommand = require(`./${command.name}.js`);
 	message.client.commands.set(newCommand.name, newCommand);
 } catch (error) {
-	console.log(error);
+	console.error(error);
 	message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${error.message}\``);
 }
 ```

--- a/guide/miscellaneous/useful-packages.md
+++ b/guide/miscellaneous/useful-packages.md
@@ -124,7 +124,7 @@ This package lets you color and style your `console.log`s in many, many differen
 Let's say you want your error messages to be easily visible; Let us give them a nice red color:
 
 ```js
-console.log(chalk.redBright('FATAL ERROR'), 'Something really bad happened!');
+console.error(chalk.redBright('FATAL ERROR'), 'Something really bad happened!');
 ```
 
 ![image of code above](~@/images/chalk-red.png)

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -347,7 +347,7 @@ client.on('messageReactionAdd', async (reaction, user) => {
 		try {
 			await reaction.fetch();
 		} catch (error) {
-			console.log('Something went wrong when fetching the message: ', error);
+			console.error('Something went wrong when fetching the message: ', error);
 			// Return as `reaction.message.author` may be undefined/null
 			return;
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
resolves #475 
This PR changes some code samples to use `console.error` over `console.log` to
1. make it less confusing for some people (as seen in #475?)
2. to log the errors to the `stderr` rather than `stdout`