### PR TITLE
fix(v12-changes): fix ‘Dynamic File type’ heading

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -195,7 +195,7 @@ Some image-related properties like `user.avatarURL` are now a method in v12, so 
 + guild.splashURL();
 ```
 
-## Dynamic File type
+### Dynamic File type
 
 Version 12 now allows you to dynamically set the file type for images. If the `dynamic` option is provided you will receive a `.gif` URL if the image is animated, otherwise it will fall back to the specified `format` or its default `.webp` if none is provided.
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes ‘Dynamic File type’ in the updating to v12 guide to be a heading level 3 (used to be level 2).