### PR TITLE
feat(parsing-mentions): add second command that showcases multiple mentions

### DIFF
--- a/code-samples/miscellaneous/parsing-mention-arguments/11/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/11/index.js
@@ -68,8 +68,8 @@ client.on('message', async message => {
 		const reason = args.slice(1).join(' ');
 		try {
 			await message.guild.ban(user, { reason });
-		} catch (e) {
-			return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+		} catch (error) {
+			return message.channel.send(`Failed to ban **${user.tag}**: ${error}`);
 		}
 
 		return message.channel.send(`Successfully banned **${user.tag}** from the server!`);

--- a/code-samples/miscellaneous/parsing-mention-arguments/11/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/11/index.js
@@ -66,7 +66,11 @@ client.on('message', async message => {
 		}
 
 		const reason = args.slice(1).join(' ');
-		await message.guild.ban(user, { reason });
+		try {
+			await message.guild.ban(user, { reason });
+		} catch (e) {
+			return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+		}
 
 		return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
 	}

--- a/code-samples/miscellaneous/parsing-mention-arguments/11/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/11/index.js
@@ -32,7 +32,7 @@ function getUserFromMentionRegEx(mention) {
 	return client.users.get(id);
 }
 
-client.on('message', message => {
+client.on('message', async message => {
 	if (!message.content.startsWith(config.prefix)) return;
 
 	const withoutPrefix = message.content.slice(config.prefix.length);
@@ -53,6 +53,22 @@ client.on('message', message => {
 		}
 
 		return message.channel.send(`${message.author.username}, your avatar: ${message.author.displayAvatarURL}`);
+	}
+
+	if (command === 'ban') {
+		if (args.length < 2) {
+			return message.reply('Please mention the user you want to ban and specify a ban reason.');
+		}
+
+		const user = getUserFromMention(args[0]);
+		if (!user) {
+			return message.reply('Please use a proper mention if you want to ban someone.');
+		}
+
+		const reason = args.slice(1).join(' ');
+		await message.guild.ban(user, { reason });
+
+		return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
 	}
 });
 

--- a/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
@@ -28,7 +28,7 @@ function getUserFromMentionRegEx(mention) {
 	return client.users.cache.get(id);
 }
 
-client.on('message', message => {
+client.on('message', async message => {
 	if (!message.content.startsWith(config.prefix)) return;
 
 	const withoutPrefix = message.content.slice(config.prefix.length);
@@ -49,6 +49,23 @@ client.on('message', message => {
 		}
 
 		return message.channel.send(`${message.author.username}, your avatar: ${message.author.displayAvatarURL({ dynamic: true })}`);
+	}
+
+
+	if (command === 'ban') {
+		if (args.length < 2) {
+			return message.reply('Please mention the user you want to ban and specify a ban reason.');
+		}
+
+		const user = getUserFromMention(args[0]);
+		if (!user) {
+			return message.reply('Please use a proper mention if you want to ban someone.');
+		}
+
+		const reason = args.slice(1).join(' ');
+		await message.guild.members.ban(user, { reason });
+
+		return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
 	}
 });
 

--- a/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
@@ -63,7 +63,11 @@ client.on('message', async message => {
 		}
 
 		const reason = args.slice(1).join(' ');
-		await message.guild.members.ban(user, { reason });
+		try {
+			await message.guild.members.ban(user, { reason });
+		} catch (e) {
+			return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+		}
 
 		return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
 	}

--- a/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
+++ b/code-samples/miscellaneous/parsing-mention-arguments/12/index.js
@@ -65,8 +65,8 @@ client.on('message', async message => {
 		const reason = args.slice(1).join(' ');
 		try {
 			await message.guild.members.ban(user, { reason });
-		} catch (e) {
-			return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+		} catch (error) {
+			return message.channel.send(`Failed to ban **${user.tag}**: ${error}`);
 		}
 
 		return message.channel.send(`Successfully banned **${user.tag}** from the server!`);

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -232,8 +232,8 @@ if (command === 'ban') {
 	const reason = args.slice(1).join(' ');
 	try {
 		await message.guild.ban(user, { reason });
-	} catch (e) {
-		return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+	} catch (error) {
+		return message.channel.send(`Failed to ban **${user.tag}**: ${error}`);
 	}
 
 	return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
@@ -259,8 +259,8 @@ if (command === 'ban') {
 	const reason = args.slice(1).join(' ');
 	try {
 		await message.guild.members.ban(user, { reason });
-	} catch (e) {
-		return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+	} catch (error) {
+		return message.channel.send(`Failed to ban **${user.tag}**: ${error}`);
 	}
 
 	return message.channel.send(`Successfully banned **${user.tag}** from the server!`);

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -210,11 +210,9 @@ But this does not mark the end of the page. If you feel adventurous you can read
 
 ### The ban command from the intro
 
-You now know how to parse user mentions for a simple command like the avatar command.
-However the avatar command does not benefit from it as much as the example used in the intro to this guide.
+You now know how to parse user mentions for a simple command like the avatar command. However the avatar command does not benefit from it as much as the example used in the intro to this guide.
 
-When writing a ban command where a mention might appear in the ban reason, manual parsing mentions
-is a lot more important. You can see an example of how to do it as follows:
+When writing a ban command where a mention might appear in the ban reason, manual parsing mentions is a lot more important. You can see an example of how to do it as follows:
 
 <branch version="11.x">
 
@@ -263,8 +261,7 @@ if (command === 'ban') {
 
 </branch>
 
-Now if you send a command like the following you can always be sure it will use the mention at the 
-very front to figure out who to ban, and will properly validate the mention:
+Now if you send a command like the following you can always be sure it will use the mention at the very front to figure out who to ban, and will properly validate the mention:
 
 <div is="discord-messages">
 	<discord-message author="User" avatar="djs">

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -9,9 +9,11 @@ then the mentions will still take up space in your args array which can mess up 
 Say you are writing a bot for moderating your server. Obviously you will want a kick or a ban command which allows you to mention the person you are trying to ban.
 But what happens if you try to use the command like this?
 
-```
-!ban @Offender because they were rude to @Victim
-```
+<div is="discord-messages">
+	<discord-message author="User" avatar="djs">
+		!ban @Offender Because they were rude to @Victim.
+	</discord-message>
+</div>
 
 You might expect it to ban @Offender, because that is who you mentioned first.
 However, the Discord API does not send the mentions in the order they appear; They are sorted by their ID instead.
@@ -20,9 +22,11 @@ If the @Victim happens to have joined Discord before @Offender and thus has a sm
 Or maybe someone uses a command incorrectly, the bot might still accept it but it will create an unexpected outcome.  
 Say someone accidentally used the ban command like this:
 
-```
-!ban because they were rude to @Victim
-```
+<div is="discord-messages">
+	<discord-message author="User" avatar="djs">
+		!ban Because they were rude to @Victim.
+	</discord-message>
+</div>
 
 The bot will still ban someone, but it will be the @Victim again. `message.mentions.users` still contains a mention, which the bot will use. But in reality you would want your bot to be able to tell the user they used the command incorrectly.
 
@@ -203,6 +207,70 @@ So now, instead of using `message.mentions` you can use your new, fantastic func
 This will allow you to add proper checks for all your args, so that you can tell when a command was used correctly and when it was used incorrectly.
 
 But this does not mark the end of the page. If you feel adventurous you can read on and learn how to use Regular Expressions to easily convert a mention into a user object in just two lines.
+
+### The ban command from the intro
+
+You now know how to parse user mentions for a simple command like the avatar command.
+However the avatar command does not benefit from it as much as the example used in the intro to this guide.
+
+When writing a ban command where a mention might appear in the ban reason, manual parsing mentions
+is a lot more important. You can see an example of how to do it as follows:
+
+<branch version="11.x">
+
+<!-- eslint-skip -->
+
+```js
+if (command === 'ban') {
+	if (args.length < 2) {
+		return message.reply('Please mention the user you want to ban and specify a ban reason.');
+	}
+
+	const user = getUserFromMention(args[0]);
+	if (!user) {
+		return message.reply('Please use a proper mention if you want to ban someone.');
+	}
+
+	const reason = args.slice(1).join(' ');
+	await message.guild.ban(user, { reason });
+
+	return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
+}
+```
+
+</branch>
+<branch version="12.x">
+
+<!-- eslint-skip -->
+
+```js
+if (command === 'ban') {
+	if (args.length < 2) {
+		return message.reply('Please mention the user you want to ban and specify a ban reason.');
+	}
+
+	const user = getUserFromMention(args[0]);
+	if (!user) {
+		return message.reply('Please use a proper mention if you want to ban someone.');
+	}
+
+	const reason = args.slice(1).join(' ');
+	await message.guild.members.ban(user, { reason });
+
+	return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
+}
+```
+
+</branch>
+
+Now if you send a command like the following you can always be sure it will use the mention at the 
+very front to figure out who to ban, and will properly validate the mention:
+
+<div is="discord-messages">
+	<discord-message author="User" avatar="djs">
+		!ban @Offender because they were rude to @Victim.
+	</discord-message>
+</div>
 
 ### Using Regular Expressions
 

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -230,7 +230,11 @@ if (command === 'ban') {
 	}
 
 	const reason = args.slice(1).join(' ');
-	await message.guild.ban(user, { reason });
+	try {
+		await message.guild.ban(user, { reason });
+	} catch (e) {
+		return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+	}
 
 	return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
 }
@@ -253,7 +257,11 @@ if (command === 'ban') {
 	}
 
 	const reason = args.slice(1).join(' ');
-	await message.guild.members.ban(user, { reason });
+	try {
+		await message.guild.members.ban(user, { reason });
+	} catch (e) {
+		return message.channel.send(`Failed to ban **${user.tag}**: ${e}`);
+	}
 
 	return message.channel.send(`Successfully banned **${user.tag}** from the server!`);
 }

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -208,7 +208,7 @@ This will allow you to add proper checks for all your args, so that you can tell
 
 But this does not mark the end of the page. If you feel adventurous you can read on and learn how to use Regular Expressions to easily convert a mention into a user object in just two lines.
 
-### The ban command from the intro
+### Ban command
 
 You now know how to parse user mentions for a simple command like the avatar command. However the avatar command does not benefit from it as much as the example used in the intro to this guide.
 

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -11,7 +11,7 @@ But what happens if you try to use the command like this?
 
 <div is="discord-messages">
 	<discord-message author="User" avatar="djs">
-		!ban @Offender Because they were rude to @Victim.
+		!ban <mention>Offender</mention> Because they were rude to <mention>Victim</mention>.
 	</discord-message>
 </div>
 
@@ -24,7 +24,7 @@ Say someone accidentally used the ban command like this:
 
 <div is="discord-messages">
 	<discord-message author="User" avatar="djs">
-		!ban Because they were rude to @Victim.
+		!ban Because they were rude to <mention>Victim</mention>.
 	</discord-message>
 </div>
 
@@ -268,7 +268,7 @@ very front to figure out who to ban, and will properly validate the mention:
 
 <div is="discord-messages">
 	<discord-message author="User" avatar="djs">
-		!ban @Offender because they were rude to @Victim.
+		!ban <mention>Offender</mention> because they were rude to <mention>Victim</mention>.
 	</discord-message>
 </div>
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This guide page originally opened with an example of a ban command which can go haywire due to
wrong usage of `message.mentions` and showed a method for fixing it.
However the example `avatar` command does not make good use of manually parsing mentions, so a second
example has been added to clearly show the advantage of manually parsing mentions in a ban command.