### PR TITLE
Update v11 -> v12 changes for client#shardResume

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -488,7 +488,7 @@ The `client.resume` event has been removed in favor of the `client.shardResume` 
 
 ```diff
 - client.on('resume', replayed => console.log(`Resumed connection and replayed ${replayed} events.`));
-+ client.on('shardResume', (replayed, shardID) => console.log(`Shard ID ${shardID} resumed connection and replayed ${replayed} events.`));
++ client.on('shardResume', (shardID, replayed) => console.log(`Shard ID ${shardID} resumed connection and replayed ${replayed} events.`));
 ```
 
 #### Client#status


### PR DESCRIPTION
In the guide, it states that client#shardResume has the parameters "replayed" and "shardID". These are in fact backward, as in the docs it states the parameters are "shardID" THEN "replayed". Tested this with my own bot to confirm that the order was incorrect for the guide instead of the docs.

**Please describe the changes this PR makes and why it should be merged:**
Changes guide on v11 to v12 changes for client#shardResume to show correct parameter orders instead of backward. Making sure that errors are not given when users are updating from v11 to v12 and using this event.