### PR TITLE
fix the old-messages example

### DIFF
--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -339,7 +339,7 @@ If you use [gateway intents](/popular-topics/intents.md) but can't or don't want
 
 ```js
 const Discord = require('discord.js');
-const client = new Discord.Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
+const client = new Discord.Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION', 'USER'] });
 client.on('messageReactionAdd', async (reaction, user) => {
 	// When we receive a reaction we check if the reaction is partial or not
 	if (reaction.partial) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes the example code for using partials to detect reactions on old messages.
The USER partial is needed now that Discord's enforcing privileged intents.