### PR TITLE
Grammar Fix

### DIFF
--- a/guide/additional-info/changes-in-v12.md
+++ b/guide/additional-info/changes-in-v12.md
@@ -1375,7 +1375,7 @@ The `messageCollector.message` event has been removed in favor of the generic `c
 The `max` and `maxMatches` properties of the `MessageCollector` class have been renamed and repurposed.
 
 ```diff
-- `max`: The The maximum amount of messages to process.
+- `max`: The maximum amount of messages to process.
 + `maxProcessed`: The maximum amount of messages to process.
 
 - `maxMatches`: The maximum amount of messages to collect.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There was an error with some grammar where there was a sentence that was falsely doubled-up, where;
`The The messages` has been corrected to `The messages`