### PR TITLE
fix: force viewport and charset meta tags

### DIFF
--- a/guide/.vuepress/config.js
+++ b/guide/.vuepress/config.js
@@ -4,6 +4,8 @@ const config = {
 	title: 'Discord.js Guide',
 	description: 'A guide made by the community of discord.js for its users.',
 	head: [
+		['meta', { charset: 'utf-8' }],
+		['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1.0' }],
 		['link', { rel: 'icon', href: '/favicon.png' }],
 		['meta', { name: 'theme-color', content: '#42b983' }],
 		['meta', { name: 'twitter:card', content: 'summary' }],


### PR DESCRIPTION
Currently, vuepress removes the charset and viewport meta tags.
This causes Firefox Mobile to display the page in desktop view.

This PR forces vuepress to add the tags again.

Currently: 
![Screenshot of firefox mobile showing the page](https://cdn.discordapp.com/attachments/444899329237581839/778978096283779132/Screenshot_20201119-153928_Firefox.png)
