### PR TITLE
use permissions of command author rather than of the bot

### DIFF
--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -411,7 +411,7 @@ if (command.guildOnly && message.channel.type === 'dm') {
 }
 
 + if (command.permissions) {
-+ 	const authorPerms = message.channel.permissionsFor(message.client.user);
++ 	const authorPerms = message.channel.permissionsFor(message.author);
 + 	if (!authorPerms || !authorPerms.has(command.permissions)) {
 + 		return message.channel.reply('You can not do this!');
 + 	}


### PR DESCRIPTION
The  example code in https://discordjs.guide/command-handling/adding-features.html#command-permissions gets the permissions of the bot itself rather than the command author. This patch fixes that.

The separate code-samples themselves already have this patch, it seems.
