### PR TITLE
Rework of missing privileged intents symptoms as table

### DIFF
--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -25,11 +25,15 @@ Before storming off and doing so you should stop and carefully think about if yo
 
 ### Symptoms in version 12
 
-| `GUILD_MEMBERS` | `GUILD_PRESENCES` |
-| --------------- | ----------------- |
-| The client events `"guildMemberAdd"`, `"guildMemberRemove"`, `"guildMemberUpdate"` do not emit | Member caches are empty *(or only have very few entries)* |
-| [`Guild#memberCount`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=memberCount) returns the member count as of ready | User cache is empty *(or has only very few entries)* |
-| Fetching members times out | All members appear to be offline |
+`GUILD_MEMBERS`
+- The client events `"guildMemberAdd"`, `"guildMemberRemove"`, `"guildMemberUpdate"` do not emit
+- [`Guild#memberCount`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=memberCount) returns the member count as of ready
+- Fetching members times out
+
+`GUILD_PRESENCES`
+- Member caches are empty *(or only have very few entries)*
+- User cache is empty *(or has only very few entries)*
+- All members appear to be offline
 
 ### Error: Disallowed Intents
 

--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -25,12 +25,15 @@ Before storming off and doing so you should stop and carefully think about if yo
 
 ### Symptoms in version 12
 
-- Member caches are empty *(or only have very few entries)*
-- User cache is empty *(or has only very few entries)*
-- Fetching members times out
-- All members appear to be offline
+`GUILD_MEMBERS`
 - The client events `"guildMemberAdd"`, `"guildMemberRemove"`, `"guildMemberUpdate"` do not emit
 - [`Guild#memberCount`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=memberCount) returns the member count as of ready
+- Fetching members times out
+
+`GUILD_PRESENCES`
+- Member caches are empty *(or only have very few entries)*
+- User cache is empty *(or has only very few entries)*
+- All members appear to be offline
 
 ### Error: Disallowed Intents
 

--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -25,15 +25,11 @@ Before storming off and doing so you should stop and carefully think about if yo
 
 ### Symptoms in version 12
 
-`GUILD_MEMBERS`
-- The client events `"guildMemberAdd"`, `"guildMemberRemove"`, `"guildMemberUpdate"` do not emit
-- [`Guild#memberCount`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=memberCount) returns the member count as of ready
-- Fetching members times out
-
-`GUILD_PRESENCES`
-- Member caches are empty *(or only have very few entries)*
-- User cache is empty *(or has only very few entries)*
-- All members appear to be offline
+| `GUILD_MEMBERS` | `GUILD_PRESENCES` |
+| --------------- | ----------------- |
+| The client events `"guildMemberAdd"`, `"guildMemberRemove"`, `"guildMemberUpdate"` do not emit | Member caches are empty *(or only have very few entries)* |
+| [`Guild#memberCount`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=memberCount) returns the member count as of ready | User cache is empty *(or has only very few entries)* |
+| Fetching members times out | All members appear to be offline |
 
 ### Error: Disallowed Intents
 


### PR DESCRIPTION
I read the revised version of you on Gateway Intents and thought it was very good. I still have the suggestion to separate the effects of the individual privileged intents and format them as a list or table. Here are both options, currently the table is my choosen format in the PR.

> Table
> 
> ![Lightmode](https://i.imgur.com/7s8F8z7.png)
> 
> ![Darkmode](https://i.imgur.com/JBPyUzq.png)

> List
> 
> ![Lightmode](https://i.imgur.com/ReyFXqu.png)
> 
> ![Darkmode](https://i.imgur.com/pEQ6b8l.png)
