### PR TITLE
feat(command-handling): Make cooldowns a property of client

### DIFF
--- a/code-samples/command-handling/adding-features/11/index.js
+++ b/code-samples/command-handling/adding-features/11/index.js
@@ -4,6 +4,7 @@ const { prefix, token } = require('./config.json');
 
 const client = new Discord.Client();
 client.commands = new Discord.Collection();
+client.cooldowns = new Discord.Collection();
 
 const commandFolders = fs.readdirSync('./commands');
 
@@ -14,8 +15,6 @@ for (const folder of commandFolders) {
 		client.commands.set(command.name, command);
 	}
 }
-
-const cooldowns = new Discord.Collection();
 
 client.once('ready', () => {
 	console.log('Ready!');
@@ -52,6 +51,8 @@ client.on('message', message => {
 
 		return message.channel.send(reply);
 	}
+
+	const cooldowns = client.cooldowns;
 
 	if (!cooldowns.has(command.name)) {
 		cooldowns.set(command.name, new Discord.Collection());

--- a/code-samples/command-handling/adding-features/11/index.js
+++ b/code-samples/command-handling/adding-features/11/index.js
@@ -52,7 +52,7 @@ client.on('message', message => {
 		return message.channel.send(reply);
 	}
 
-	const { cooldowns } = client;
+const { cooldowns } = client;
 
 	if (!cooldowns.has(command.name)) {
 		cooldowns.set(command.name, new Discord.Collection());

--- a/code-samples/command-handling/adding-features/11/index.js
+++ b/code-samples/command-handling/adding-features/11/index.js
@@ -52,7 +52,7 @@ client.on('message', message => {
 		return message.channel.send(reply);
 	}
 
-	const cooldowns = client.cooldowns;
+	const { cooldowns } = client;
 
 	if (!cooldowns.has(command.name)) {
 		cooldowns.set(command.name, new Discord.Collection());

--- a/code-samples/command-handling/adding-features/12/index.js
+++ b/code-samples/command-handling/adding-features/12/index.js
@@ -4,6 +4,7 @@ const { prefix, token } = require('./config.json');
 
 const client = new Discord.Client();
 client.commands = new Discord.Collection();
+client.cooldowns = new Discord.Collection();
 
 const commandFolders = fs.readdirSync('./commands');
 
@@ -14,8 +15,6 @@ for (const folder of commandFolders) {
 		client.commands.set(command.name, command);
 	}
 }
-
-const cooldowns = new Discord.Collection();
 
 client.once('ready', () => {
 	console.log('Ready!');
@@ -52,6 +51,8 @@ client.on('message', message => {
 
 		return message.channel.send(reply);
 	}
+
+	const cooldowns = client.cooldowns;
 
 	if (!cooldowns.has(command.name)) {
 		cooldowns.set(command.name, new Discord.Collection());

--- a/code-samples/command-handling/adding-features/12/index.js
+++ b/code-samples/command-handling/adding-features/12/index.js
@@ -52,7 +52,7 @@ client.on('message', message => {
 		return message.channel.send(reply);
 	}
 
-	const { cooldowns } = client;
+const { cooldowns } = client;
 
 	if (!cooldowns.has(command.name)) {
 		cooldowns.set(command.name, new Discord.Collection());

--- a/code-samples/command-handling/adding-features/12/index.js
+++ b/code-samples/command-handling/adding-features/12/index.js
@@ -52,7 +52,7 @@ client.on('message', message => {
 		return message.channel.send(reply);
 	}
 
-	const cooldowns = client.cooldowns;
+	const { cooldowns } = client;
 
 	if (!cooldowns.has(command.name)) {
 		cooldowns.set(command.name, new Discord.Collection());

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -203,14 +203,16 @@ module.exports = {
 In your main file (`index.js` in our examples), add this line preferably somewhere at the top before you handle any events:
 
 ```js
-const cooldowns = new Discord.Collection();
+client.cooldowns = new Discord.Collection();
 ```
 
-This initializes an empty Collection (remember, Collection is a utility data structure, which works based on key/value pairs) which you can then fill later when commands are used. The key will be the command name and the value will be another Collection associating the user id (key) to the last time (value) this specific user used this specific command. Overall the logical path to get a specific user's last usage of a specific command will be `cooldowns > command > user > timestamp`.
+This initializes an empty Collection (remember, Collection is a utility data structure, which works based on key/value pairs) as a property of the `client` object, which you can then fill later when commands are used. The key will be the command name and the value will be another Collection associating the user id (key) to the last time (value) this specific user used this specific command. Overall the logical path to get a specific user's last usage of a specific command will be `cooldowns > command > user > timestamp`.
 
 In your main file, directly above the `try/catch` block causing command execution, add in the following:
 
 ```js
+const cooldowns = client.cooldowns;
+
 if (!cooldowns.has(command.name)) {
 	cooldowns.set(command.name, new Discord.Collection());
 }

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -211,7 +211,7 @@ This initializes an empty Collection (remember, Collection is a utility data str
 In your main file, directly above the `try/catch` block causing command execution, add in the following:
 
 ```js
-	const { cooldowns } = client;
+const { cooldowns } = client;
 
 if (!cooldowns.has(command.name)) {
 	cooldowns.set(command.name, new Discord.Collection());

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -211,7 +211,7 @@ This initializes an empty Collection (remember, Collection is a utility data str
 In your main file, directly above the `try/catch` block causing command execution, add in the following:
 
 ```js
-const cooldowns = client.cooldowns;
+	const { cooldowns } = client;
 
 if (!cooldowns.has(command.name)) {
 	cooldowns.set(command.name, new Discord.Collection());


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

fixes: #615
This PR makes the `cooldowns` collection a property of `client`. Thus, making it possible to access the `cooldowns` in the `message.js` file later in the `event-handler` section. This change will somewhat reduce the hassle of adding back additional command-handling features after a reader has implemented the event-handler.