### PR TITLE
refactor(oauth): Use express instead of native http module

### DIFF
--- a/code-samples/oauth/simple-oauth-webserver/config.json
+++ b/code-samples/oauth/simple-oauth-webserver/config.json
@@ -1,0 +1,5 @@
+{
+	"clientID": "",
+	"clientSecret": "",
+	"port": 53134
+}

--- a/code-samples/oauth/simple-oauth-webserver/index.html
+++ b/code-samples/oauth/simple-oauth-webserver/index.html
@@ -10,10 +10,10 @@
 	<a id="login" style="display: none;" href="your-oauth2-url-here">Identify Yourself</a>
 	<script>
 		function generateRandomString() {
-			const rand = Math.floor(Math.random() * 10);
 			let randomString = '';
+			const randomNumber = Math.floor(Math.random() * 10);
 
-			for (let i = 0; i < 20 + rand; i++) {
+			for (let i = 0; i < 20 + randomNumber; i++) {
 				randomString += String.fromCharCode(33 + Math.floor(Math.random() * 94));
 			}
 

--- a/code-samples/oauth/simple-oauth-webserver/index.html
+++ b/code-samples/oauth/simple-oauth-webserver/index.html
@@ -1,59 +1,52 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>My First OAuth2 App</title>
+	<title>My Discord OAuth2 App</title>
 </head>
 <body>
 	<div id="info">
 		Hoi!
 	</div>
-	<a id="login" style="display: none;" href="your oauth2 url here">Identify Yourself</a>
+	<a id="login" style="display: none;" href="your-oauth2-url-here">Identify Yourself</a>
 	<script>
 		function generateRandomString() {
 			const rand = Math.floor(Math.random() * 10);
-			let randStr = '';
+			let randomString = '';
 
 			for (let i = 0; i < 20 + rand; i++) {
-				randStr += String.fromCharCode(33 + Math.floor(Math.random() * 94));
+				randomString += String.fromCharCode(33 + Math.floor(Math.random() * 94));
 			}
 
-			return randStr;
+			return randomString;
 		}
 
 		window.onload = () => {
 			const fragment = new URLSearchParams(window.location.hash.slice(1));
+			const [accessToken, tokenType, state] = [fragment.get('access_token'), fragment.get('token_type'), fragment.get('state')];
 
-			if (fragment.has("access_token")) {
-				const urlState = fragment.get("state");
-				const stateParameter = localStorage.getItem('stateParameter');
-				if (stateParameter !== atob(decodeURIComponent(urlState))) {
-					return console.log('You may have been clickjacked!');
+			if (!accessToken) {
+				const randomString = generateRandomString();
+				localStorage.setItem('oauth-state', randomString);
+
+				document.getElementById('login').href += `&state=${encodeURIComponent(btoa(randomString))}`;
+				return document.getElementById('login').style.display = 'block';
+			}
+
+			if (localStorage.getItem('oauth-state') !== atob(decodeURIComponent(state))) {
+				return console.log('You may have been click-jacked!');
+			}
+
+			fetch('https://discord.com/api/users/@me', {
+				headers: {
+					authorization: `${tokenType} ${accessToken}`
 				}
-
-				const accessToken = fragment.get("access_token");
-				const tokenType = fragment.get("token_type");
-
-				fetch('https://discord.com/api/users/@me', {
-					headers: {
-						authorization: `${tokenType} ${accessToken}`
-					}
+			})
+				.then(result => result.json())
+				.then(response => {
+					const { username, discriminator } = response;
+					document.getElementById('info').innerText += ` ${username}#${discriminator}`;
 				})
-					.then(res => res.json())
-					.then(response => {
-						console.log(response);
-						const { username, discriminator } = response;
-						document.getElementById('info').innerText += ` ${username}#${discriminator}`;
-					})
-					.catch(console.error);
-
-			}
-			else {
-				const randStr = generateRandomString();
-				localStorage.setItem('stateParameter', randStr);
-
-				document.getElementById('login').href += `&state=${encodeURIComponent(btoa(randStr))}`;
-				document.getElementById('login').style.display = 'block';
-			}
+				.catch(console.error);
 		}
 	</script>
 </body>

--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 const express = require('express');
 const app = express();
-const { clientID, clientSecret, port } = require('./config.js');
+const { clientID, clientSecret, port } = require('./config.json');
 
 app.get('/', async ({ query }, response) => {
 	const { code } = query;

--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -1,7 +1,8 @@
 const fetch = require('node-fetch');
 const express = require('express');
-const app = express();
 const { clientID, clientSecret, port } = require('./config.json');
+
+const app = express();
 
 app.get('/', async ({ query }, response) => {
 	const { code } = query;

--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -7,30 +7,36 @@ app.get('/', async ({ query }, response) => {
 	const { code } = query;
 
 	if (code) {
-		const oauthResult = await fetch('https://discord.com/api/oauth2/token', {
-			method: 'POST',
-			body: new URLSearchParams({
-				client_id: clientID,
-				client_secret: clientSecret,
-				code,
-				grant_type: 'authorization_code',
-				redirect_uri: `http://localhost:${port}`,
-				scope: 'identify',
-			}),
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-		});
+		try {
+			const oauthResult = await fetch('https://discord.com/api/oauth2/token', {
+				method: 'POST',
+				body: new URLSearchParams({
+					client_id: clientID,
+					client_secret: clientSecret,
+					code,
+					grant_type: 'authorization_code',
+					redirect_uri: `http://localhost:${port}`,
+					scope: 'identify',
+				}),
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			});
 
-		const oauthData = await oauthResult.json();
+			const oauthData = await oauthResult.json();
 
-		const userResult = await fetch('https://discord.com/api/users/@me', {
-			headers: {
-				authorization: `${oauthData.token_type} ${oauthData.access_token}`,
-			},
-		});
+			const userResult = await fetch('https://discord.com/api/users/@me', {
+				headers: {
+					authorization: `${oauthData.token_type} ${oauthData.access_token}`,
+				},
+			});
 
-		console.log(await userResult.json());
+			console.log(await userResult.json());
+		} catch (error) {
+			// NOTE: An unauthorized token will not throw an error;
+			// it will return a 401 Unauthorized response in the try block above
+			console.error(error);
+		}
 	}
 
 	return response.sendFile('index.html', { root: '.' });

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -23,7 +23,7 @@ Most of the time, websites use OAuth2 to get information about their users from 
 ```js
 const express = require('express');
 const app = express();
-const { port } = require('./config.js');
+const { port } = require('./config.json');
 
 app.get('/', (request, response) => {
 	return response.sendFile('index.html', { root: '.' });
@@ -185,7 +185,7 @@ Require `node-fetch` and make your request.
 const fetch = require('node-fetch');
 const express = require('express');
 const app = express();
-const { clientID, clientSecret, port } = require('./config.js');
+const { clientID, clientSecret, port } = require('./config.json');
 
 app.get('/', async ({ query }, response) => {
 	const { code } = query;

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -121,10 +121,10 @@ OAuth2's protocols provide a `state` parameter, which Discord supports. This par
 
 ```js{1-10,15-18}
 function generateRandomString() {
-	const rand = Math.floor(Math.random() * 10);
 	let randomString = '';
+	const randomNumber = Math.floor(Math.random() * 10);
 
-	for (let i = 0; i < 20 + rand; i++) {
+	for (let i = 0; i < 20 + randomNumber; i++) {
 		randomString += String.fromCharCode(33 + Math.floor(Math.random() * 94));
 	}
 

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -50,6 +50,10 @@ app.listen(port, () => console.log(`App listening at http://localhost:${port}`))
 
 After running `npm i express`, you can start your server with `node index.js`. Once you start it, try connecting to `http://localhost:53134`, and you should see "Hoi!".
 
+::: tip
+Although we're using express, there are many other possible alternatives to handle a web server, such as: [fastify](https://www.fastify.io/), [koa](https://koajs.com/), and the [native Node.js http module](https://nodejs.org/api/http.html).
+:::
+
 ### Getting an OAuth2 url
 
 Now that you have your web server up and running, it's time to get some information from Discord. Head over to [your Discord applications](https://discord.com/developers/applications/) and click "Create an application", where the following page will greet you:

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -182,7 +182,7 @@ Now you have to exchange this code with Discord for an access token. To do this,
 
 Require `node-fetch` and make your request.
 
-```js{1,4,6-29}
+```js{1,3,7-8,10-34}
 const fetch = require('node-fetch');
 const express = require('express');
 const { clientID, clientSecret, port } = require('./config.json');

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -6,39 +6,39 @@ OAuth2 enables application developers to build applications that utilize authent
 
 ###  Setting up a basic web server
 
-Most of the time, websites use OAuth2 to get information about their users from an external service. In this example, you will use Node.js' built-in `http` module to create a web server to use a user's Discord information to greet them. First, create a file named `index.js`, which you'll use to start the server.
+Most of the time, websites use OAuth2 to get information about their users from an external service. In this example, you will use [`express`](https://expressjs.com/) to create a web server to use a user's Discord information to greet them. Start by creating three files: `config.json`, `index.js`, and `index.html`. 
 
-```js
-const http = require('http');
-const fs = require('fs');
-const port = 53134;
+`config.json` will be used to store the your client ID, client secret, and server port.
 
-http.createServer((req, res) => {
-	let responseCode = 404;
-	let content = '404 Error';
-
-	if (req.url === '/') {
-		responseCode = 200;
-		content = fs.readFileSync('./index.html');
-	}
-
-	res.writeHead(responseCode, {
-		'content-type': 'text/html;charset=utf-8',
-	});
-
-	res.write(content);
-	res.end();
-})
-	.listen(port);
+```json
+{
+	"clientID": "",
+	"clientSecret": "",
+	"port": "53134"
+}
 ```
 
-Right now, you have designated that the contents of an `index.html` file will be served to the user when they visit the root domain, so create an `index.html` file in the same directory with the following contents.
+`index.js` will be used to start the server and handle requests. When someone visits the index page (`/`), an HTML file will be sent in response.
+
+```js
+const express = require('express');
+const app = express();
+const { port } = require('./config.js');
+
+app.get('/', (request, response) => {
+	return response.sendFile('index.html', { root: '.' });
+});
+
+app.listen(port, () => console.log(`App listening at http://localhost:${port}`));
+```
+
+`index.html` will be used to display the user interface and OAuth data once logged in.
 
 ```html
 <!DOCTYPE html>
 <html>
 <head>
-	<title>My First OAuth2 App</title>
+	<title>My Discord OAuth2 App</title>
 </head>
 <body>
 	<div id="info">
@@ -48,7 +48,7 @@ Right now, you have designated that the contents of an `index.html` file will be
 </html>
 ```
 
-You can start your server with `node index.js`. Once you start it, try connecting to http://localhost:53134, and you should see "Hoi!".
+After running `npm i express`, you can start your server with `node index.js`. Once you start it, try connecting to `http://localhost:53134`, and you should see "Hoi!".
 
 ### Getting an OAuth2 url
 
@@ -56,7 +56,7 @@ Now that you have your web server up and running, it's time to get some informat
 
 ![Create an application page](~@/images/1ch98sm.png)
 
-Take note of the `client id` field, the `client secret` field, and the "OAuth2" link on the left side of the page. For now, click on "OAuth2" and add a redirect url to `http://localhost:53134` like so:
+Take note of the `client id` field, the `client secret` field, and the "OAuth2" link on the left side of the page. Copy your client ID and secret into your `config.json` file; you'll need them later. For now, click on "OAuth2" and add a redirect url to `http://localhost:53134` like so:
 
 ![img](~@/images/9fejia2.png)
 
@@ -68,53 +68,43 @@ The `identify` scope will allow your application to get basic user information f
 
 ### Putting it together
 
-You have your website, and you have a url. Now you need to use those two things to get an access token. For basic applications like [SPAs](https://en.wikipedia.org/wiki/Single-page_application), getting an access token directly is enough. If you want to do this, make sure the `response_type` in the url is `token`. However, this means you will not get a refresh token, which means the user will have to explicitly re-authorize when this access token has expired.
+You have your website, and you have a url. Now you need to use those two things to get an access token. For basic applications like [SPAs](https://en.wikipedia.org/wiki/Single-page_application), getting an access token directly is enough. You can do so by changing the `response_type` in the url to `token`. However, this means you will not get a refresh token, which means the user will have to explicitly re-authorize when this access token has expired.
 
-After you change the response type, you can test the url right away. Try visiting it in your browser, and you will be directed to a page that looks like this.
+After you change the `response_type`, you can test the url right away. Try visiting it in your browser, and you will be directed to a page that looks like this.
 
 ![img](~@/images/49jali8.png)
 
-You can see that by clicking `Authorize`, you allow the application to access your username and avatar. Once you click through, you should be redirected to the redirect url with a [fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier) appended to it. You now have an access token and can make requests to Discord's API to get information on the user. Modify `index.html` to add your OAuth2 url and to take advantage of the access token if it exists. Even though [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) is for working with query strings, it can work here because the structure of the fragment follows that of a query string after removing the leading "#".
+You can see that by clicking `Authorize`, you allow the application to access your username and avatar. Once you click through, you should be redirected to the redirect url with a [fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier) appended to it. You now have an access token and can make requests to Discord's API to get information on the user.
 
-```html
-<!DOCTYPE html>
-<html>
-<head>
-	<title>My First OAuth2 App</title>
-</head>
-<body>
-	<div id="info">
-		Hoi!
-	</div>
-	<a id="login" style="display: none;" href="your oauth2 url here">Identify Yourself</a>
-	<script>
-		window.onload = () => {
-			const fragment = new URLSearchParams(window.location.hash.slice(1));
+Modify `index.html` to add your OAuth2 url and to take advantage of the access token if it exists. Even though [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) is for working with query strings, it can work here because the structure of the fragment follows that of a query string after removing the leading "#".
 
-			if (fragment.has("access_token")) {
-				const accessToken = fragment.get("access_token");
-				const tokenType = fragment.get("token_type");
+```html{4-26}
+<div id="info">
+	Hoi!
+</div>
+<a id="login" style="display: none;" href="your-oauth2-url-here">Identify Yourself</a>
+<script>
+	window.onload = () => {
+		const fragment = new URLSearchParams(window.location.hash.slice(1));
+		const [accessToken, tokenType] = [fragment.get('access_token'), fragment.get('token_type')];
 
-				fetch('https://discord.com/api/users/@me', {
-					headers: {
-						authorization: `${tokenType} ${accessToken}`
-					}
-				})
-					.then(res => res.json())
-					.then(response => {
-						const { username, discriminator } = response;
-						document.getElementById('info').innerText += ` ${username}#${discriminator}`;
-					})
-					.catch(console.error);
-
-			}
-			else {
-				document.getElementById('login').style.display = 'block';
-			}
+		if (!accessToken) {
+			return document.getElementById('login').style.display = 'block';
 		}
-	</script>
-</body>
-</html>
+
+		fetch('https://discord.com/api/users/@me', {
+			headers: {
+				authorization: `${tokenType} ${accessToken}`
+			}
+		})
+			.then(result => result.json())
+			.then(response => {
+				const { username, discriminator } = response;
+				document.getElementById('info').innerText += ` ${username}#${discriminator}`;
+			})
+			.catch(console.error);
+	};
+</script>
 ```
 
 Here you grab the access token and type from the url if it's there and use it to get info on the user, which is then used to greet them. In the following sections, we'll go over various details of Discord and OAuth2.
@@ -125,38 +115,42 @@ Here you grab the access token and type from the url if it's there and use it to
 
 OAuth2's protocols provide a `state` parameter, which Discord supports. This parameter helps prevent [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attacks and represents your application's state. The state should be generated per user and appended to the OAuth2 url. For a basic example, you can use a randomly generated string encoded in Base64 as the state parameter.
 
-```js
+```js{1-10,15-18}
 function generateRandomString() {
 	const rand = Math.floor(Math.random() * 10);
-	let randStr = '';
+	let randomString = '';
 
 	for (let i = 0; i < 20 + rand; i++) {
-		randStr += String.fromCharCode(33 + Math.floor(Math.random() * 94));
+		randomString += String.fromCharCode(33 + Math.floor(Math.random() * 94));
 	}
 
-	return randStr;
+	return randomString;
 }
 
-// ...
+window.load = () => {
+	// ...
+	if (!accessToken) {
+		const randomString = generateRandomString();
+		localStorage.setItem('oauth-state', randomString);
 
-// generate and store the string
-const randStr = generateRandomString();
-localStorage.setItem('stateParameter', randStr);
-
-document.getElementById('login').href += `&state=${btoa(randStr)}`;
+		document.getElementById('login').href += `&state=${btoa(randomString)}`;
+		return document.getElementById('login').style.display = 'block';
+	}
+};
 ```
 
 When you visit a url with a `state` parameter appended to it and then click `Authorize`, you'll notice that after being redirected, the url will also have the `state` parameter appended, which you should then check against what was stored. You can modify the script in your `index.html` file to handle this.
 
-```js
+```js{2,8-10}
 const fragment = new URLSearchParams(window.location.hash.slice(1));
+const [accessToken, tokenType, state] = [fragment.get('access_token'), fragment.get('token_type'), fragment.get('state')];
 
-if (fragment.has('access_token')) {
-	const urlState = fragment.get('state');
-	const stateParameter = localStorage.getItem('stateParameter');
-	if (stateParameter !== atob(decodeURIComponent(urlState))) {
-		return console.log('You may have been clickjacked!');
-	}
+if (!accessToken) {
+	// ...
+}
+
+if (localStorage.getItem('oauth-state') !== atob(decodeURIComponent(state))) {
+	return console.log('You may have been clickjacked!');
 }
 ```
 
@@ -170,53 +164,50 @@ What you did in the quick example was go through the `implicit grant` flow, whic
 
 #### Authorization code grant
 
-Unlike the quick example, you need an OAuth2 url where the `response_type` is `code`. Once you've obtained it, try visiting the link and authorizing your application. You should notice that instead of a hash, the redirect url now has a single query parameter appended to it like `?code=ACCESS_CODE`. Modify your `index.js` file to pull the parameter out of the url if it exists. You can use the `url` module to do this for us.
+Unlike the quick example, you need an OAuth2 url where the `response_type` is `code`. Once you've obtained it, try visiting the link and authorizing your application. You should notice that instead of a hash, the redirect url now has a single query parameter appended to it like `?code=ACCESS_CODE`. Modify your `index.js` file to pull the parameter out of the url if it exists. In express, you can use the `request` parameter's `query` property.
 
-```js
-const url = require('url');
-
-// ...
-
-const urlObj = url.parse(req.url, true);
-
-if (urlObj.query.code) {
-	const accessCode = urlObj.query.code;
-	console.log(`The access code is: ${accessCode}`);
-}
-
-if (urlObj.pathname === '/') {
-	responseCode = 200;
-	content = fs.readFileSync('./index.html');
-}
+```js{2}
+app.get('/', (request, response) => {
+	console.log(`The access code is: ${request.query.code}`);
+	return response.sendFile('index.html', { root: '.' });
+});
 ```
 
 Now you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten these, head over to [your applications](https://discord.com/developers/applications) and get them. You can use `node-fetch` to make requests to Discord; you can install it with `npm i node-fetch`.
 
 Require `node-fetch` and make your request.
 
-```js
+```js{1,4,6-29}
 const fetch = require('node-fetch');
+const express = require('express');
+const app = express();
+const { clientID, clientSecret, port } = require('./config.js');
 
-// ...
+app.get('/', async ({ query }, response) => {
+	const { code } = query;
 
-const data = {
-	client_id: 'your client id',
-	client_secret: 'your client secret',
-	grant_type: 'authorization_code',
-	redirect_uri: 'your redirect uri',
-	code: accessCode,
-	scope: 'the scopes',
-};
+	if (code) {
+		const oauthResult = await fetch('https://discord.com/api/oauth2/token', {
+			method: 'POST',
+			body: new URLSearchParams({
+				client_id: clientID,
+				client_secret: clientSecret,
+				code,
+				grant_type: 'authorization_code',
+				redirect_uri: `http://localhost:${port}`,
+				scope: 'identify',
+			}),
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+		});
 
-fetch('https://discord.com/api/oauth2/token', {
-	method: 'POST',
-	body: new URLSearchParams(data),
-	headers: {
-		'Content-Type': 'application/x-www-form-urlencoded',
-	},
-})
-	.then(res => res.json())
-	.then(console.log);
+		const oauthData = await oauthResult.json();
+		console.log(oauthData);
+	}
+
+	return response.sendFile('index.html', { root: '.' });
+});
 ```
 
 ::: warning
@@ -237,18 +228,17 @@ Now try visiting your OAuth2 url and authorizing your application. Once you're r
 
 Try fetching the user's information now that you have an access token and a refresh token. It's the same as how the html file did it in the html file.
 
-```js
-fetch('https://discord.com/api/oauth2/token', {
-	method: 'POST',
-	body: data,
-})
-	.then(res => res.json())
-	.then(info => fetch('https://discord.com/api/users/@me', {
-		headers: {
-			authorization: `${info.token_type} ${info.access_token}`,
-		},
-	}))
-	.then(console.log);
+<!-- eslint-skip -->
+```js{3-7,9}
+const oauthData = await oauthResult.json();
+
+const userData = await fetch('https://discord.com/api/users/@me', {
+	headers: {
+		authorization: `${oauthData.token_type} ${oauthData.access_token}`,
+	},
+});
+
+console.log(await userData.json());
 ```
 
 ::: tip

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -193,23 +193,29 @@ app.get('/', async ({ query }, response) => {
 	const { code } = query;
 
 	if (code) {
-		const oauthResult = await fetch('https://discord.com/api/oauth2/token', {
-			method: 'POST',
-			body: new URLSearchParams({
-				client_id: clientID,
-				client_secret: clientSecret,
-				code,
-				grant_type: 'authorization_code',
-				redirect_uri: `http://localhost:${port}`,
-				scope: 'identify',
-			}),
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-		});
+		try {
+			const oauthResult = await fetch('https://discord.com/api/oauth2/token', {
+				method: 'POST',
+				body: new URLSearchParams({
+					client_id: clientID,
+					client_secret: clientSecret,
+					code,
+					grant_type: 'authorization_code',
+					redirect_uri: `http://localhost:${port}`,
+					scope: 'identify',
+				}),
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			});
 
-		const oauthData = await oauthResult.json();
-		console.log(oauthData);
+			const oauthData = await oauthResult.json();
+			console.log(oauthData);
+		} catch (error) {
+			// NOTE: An unauthorized token will not throw an error;
+			// it will return a 401 Unauthorized response in the try block above
+			console.error(error);
+		}
 	}
 
 	return response.sendFile('index.html', { root: '.' });

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -22,8 +22,9 @@ Most of the time, websites use OAuth2 to get information about their users from 
 
 ```js
 const express = require('express');
-const app = express();
 const { port } = require('./config.json');
+
+const app = express();
 
 app.get('/', (request, response) => {
 	return response.sendFile('index.html', { root: '.' });
@@ -184,8 +185,9 @@ Require `node-fetch` and make your request.
 ```js{1,4,6-29}
 const fetch = require('node-fetch');
 const express = require('express');
-const app = express();
 const { clientID, clientSecret, port } = require('./config.json');
+
+const app = express();
 
 app.get('/', async ({ query }, response) => {
 	const { code } = query;
@@ -236,13 +238,13 @@ Try fetching the user's information now that you have an access token and a refr
 ```js{3-7,9}
 const oauthData = await oauthResult.json();
 
-const userData = await fetch('https://discord.com/api/users/@me', {
+const userResult = await fetch('https://discord.com/api/users/@me', {
 	headers: {
 		authorization: `${oauthData.token_type} ${oauthData.access_token}`,
 	},
 });
 
-console.log(await userData.json());
+console.log(await userResult.json());
 ```
 
 ::: tip


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR rewrites the OAuth page to use express instead of the native http module. A few touch-ups have been made as well, in terms of readability, comprehension, etc.

Closes #472.