### PR TITLE
Update eslint install instructions

### DIFF
--- a/guide/preparations/setting-up-a-linter.md
+++ b/guide/preparations/setting-up-a-linter.md
@@ -18,10 +18,10 @@ First, be sure to install the [ESLint package](https://www.npmjs.com/package/esl
 
 ```bash
 # locally
-npm install eslint
+npm install eslint --save-dev
 
 # globally
-npm install --global eslint
+npm install eslint --global # Not recommended, and any plugins or shareable configs that you use must be installed locally.
 ```
 
 Afterward, install the appropriate plugin(s) for your editor of choice.

--- a/guide/preparations/setting-up-a-linter.md
+++ b/guide/preparations/setting-up-a-linter.md
@@ -17,11 +17,7 @@ One of the significant advantages proper code editors have over Notepad and Note
 First, be sure to install the [ESLint package](https://www.npmjs.com/package/eslint) so that you have it available in your project.
 
 ```bash
-# locally
 npm install eslint --save-dev
-
-# globally
-npm install eslint --global # Not recommended, and any plugins or shareable configs that you use must be installed locally.
 ```
 
 Afterward, install the appropriate plugin(s) for your editor of choice.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Marks eslint as a dev dependency, as it's recommended on https://eslint.org/docs/user-guide/getting-started
- Mark caveats in global install mentioned on the same eslint getting started page.