### PR TITLE
feat: add allowedMentions to faq

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -327,8 +327,8 @@ This can be set as a default in `ClientOptions`, and controlled per-message sent
 
 Even more control can be achieved by listing specific `users` or `roles` to be mentioned by ID, eg:
 ```js
-message.channel.send("<@830569888157925434> <@122157285790187530>", { 
-  allowedMentions: { users: ["830569888157925434"] } 
+message.channel.send('<@830569888157925434> <@122157285790187530>', {
+	allowedMentions: { users: ['830569888157925434'] }
 });
 ```
 

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -321,14 +321,14 @@ Controlling which mentions (and replies) will send a ping is done via the `allow
 
 This can be set as a default in `ClientOptions`, and controlled per-message sent by your bot.
 ```diff
-- new Discord.Client({ disableMentions: "everyone" });
-+ new Discord.Client({ allowedMentions: { parse: ["users", "roles"], repliedUser: true });
+- new Discord.Client({ disableMentions: 'everyone' });
++ new Discord.Client({ allowedMentions: { parse: ['users', 'roles'] });
 ```
 
 Even more control can be achieved by listing specific `users` or `roles` to be mentioned by ID, eg:
 ```js
-message.channel.send('<@830569888157925434> <@122157285790187530>', {
-	allowedMentions: { users: ['830569888157925434'] }
+message.channel.send('<@123456789012345678> <@987654321098765432>', {
+	allowedMentions: { users: ['123456789012345678'] },
 });
 ```
 

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -315,6 +315,23 @@ const user = <message>.mentions.users.first();
 Mentions in embeds may resolve correctly in embed description and field values but will never notify the user. Other areas do not support mentions at all.
 :::
 
+### How do I control which users and/or roles are mentioned in a message?
+
+Controlling which mentions (and replies) will send a ping is done via the `allowedMentions` option, which replaces `disableMentions`.
+
+This can be set as a default in `ClientOptions`, and controlled per-message sent by your bot.
+```diff
+- new Discord.Client({ disableMentions: "everyone" });
++ new Discord.Client({ allowedMentions: { parse: ["users", "roles"], repliedUser: true });
+```
+
+Even more control can be achieved by listing specific `users` or `roles` to be mentioned by ID, eg:
+```js
+message.channel.send("<@830569888157925434> <@122157285790187530>", { 
+  allowedMentions: { users: ["830569888157925434"] } 
+});
+```
+
 ### How do I prompt the user for additional input?
 
 <branch version="11.x">

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -325,7 +325,7 @@ This can be set as a default in `ClientOptions`, and controlled per-message sent
 + new Discord.Client({ allowedMentions: { parse: ['users', 'roles'] });
 ```
 
-Even more control can be achieved by listing specific `users` or `roles` to be mentioned by ID, eg:
+Even more control can be achieved by listing specific `users` or `roles` to be mentioned by ID, e.g.:
 ```js
 message.channel.send('<@123456789012345678> <@987654321098765432>', {
 	allowedMentions: { users: ['123456789012345678'] },

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -317,7 +317,7 @@ Mentions in embeds may resolve correctly in embed description and field values b
 
 ### How do I control which users and/or roles are mentioned in a message?
 
-Controlling which mentions (and replies) will send a ping is done via the `allowedMentions` option, which replaces `disableMentions`.
+Controlling which mentions will send a ping is done via the `allowedMentions` option, which replaces `disableMentions`.
 
 This can be set as a default in `ClientOptions`, and controlled per-message sent by your bot.
 ```diff


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

It adds information about `ClientOptions#allowedMentions` /  `MessageOptions#allowedMentions` to the FAQ, thus answering a Frequently Asked Question.