### PR TITLE
Fix link to repl.it docs

### DIFF
--- a/guide/preparations/setting-up-a-bot-application.md
+++ b/guide/preparations/setting-up-a-bot-application.md
@@ -119,4 +119,4 @@ While we generally do not recommend using online editors as hosting solutions bu
 
 - Glitch.com: [storing secrets in .env](https://glitch.happyfox.com/kb/article/18)
 - Heroku.com: [config variables](https://devcenter.heroku.com/articles/config-vars)
-- Repl.it: [storing secrets in .env](https://docs.repl.it/repls/secret-keys)
+- Repl.it: [secrets & environment variables](https://docs.replit.com/repls/secrets-environment-variables)


### PR DESCRIPTION
Repl.it has recently changed how it stores environment variables. This PR reflects that and links to the new page in the documentation.