### PR TITLE
`window.load` -> `window.onload`

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -144,7 +144,7 @@ function generateRandomString() {
 	return randomString;
 }
 
-window.load = () => {
+window.onload = () => {
 	// ...
 	if (!accessToken) {
 		const randomString = generateRandomString();


### PR DESCRIPTION
Typo in the example code