### PR TITLE
Specify that the 6000 char limit applies to all embeds in a message

### DIFF
--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -404,7 +404,7 @@ There are a few limits to be aware of while planning your embeds due to the API'
 - A field's name is limited to 256 characters and its value to 1024 characters
 - The footer text is limited to 2048 characters
 - The author name is limited to 256 characters
-- The sum of all characters in an embed structure must not exceed 6000 characters
+- The sum of all characters from all embed structures in a message must not exceed 6000 characters
 - A bot can have one embed per message
 - A webhook can have ten embeds per message
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since interactions use webhooks to send their messages, more and more users are discovering them and so, I think it's good to specify that the 6000 char limit applies to all characters from all embeds in a message, and not individually like the previous description could lead you to believe.