### PR TITLE
Switch startsWith to IndexOf

### DIFF
--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -15,7 +15,7 @@ client.once('ready', () => {
 });
 
 client.on('message', message => {
-	if ((message.content.indexOf(prefix) !== 0)|| message.author.bot) return;
+	if ((message.content.indexOf(prefix) !== 0) || message.author.bot) return;
 
 	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();
@@ -105,7 +105,7 @@ With your `client.commands` Collection setup, you can use it to retrieve and exe
 
 ```js {7-14}
 client.on('message', message => {
-	if (!message.content.startsWith(prefix) || message.author.bot) return;
+	if ((message.content.indexOf(prefix) !== 0) || message.author.bot) return;
 
 	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();

--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -15,7 +15,7 @@ client.once('ready', () => {
 });
 
 client.on('message', message => {
-	if (!message.content.startsWith(prefix) || message.author.bot) return;
+	if ((message.content.indexOf(prefix) !== 0)|| message.author.bot) return;
 
 	const args = message.content.slice(prefix.length).trim().split(/ +/);
 	const command = args.shift().toLowerCase();


### PR DESCRIPTION
While the example is perfectly correct as it is, encouraging people to use IndexOf instead of startsWith is really a better choice for performance - and not just a few extra operations, but thousands of more operations per second.

Change checks if indexOf returns 0, or the first index of the string, which produces the same result.

https://www.measurethat.net/Benchmarks/Show/4797/1/js-regex-vs-startswith-vs-indexof

**Please describe the changes this PR makes and why it should be merged:**
