### PR TITLE
feat: Initial v13 support in components.

### DIFF
--- a/.vscode/guide.code-snippets
+++ b/.vscode/guide.code-snippets
@@ -57,7 +57,7 @@
 		"prefix": [
 			"branch", "br"
 		],
-		"description": "v11-v12 branches",
+		"description": "version branches",
 		"body": [
 			"<branch version=\"11.x\">", 
 			"",
@@ -68,13 +68,17 @@
 			"",
 			"$2",
 			"",
-			"</branch>"
-		]
+			"</branch>",
+			"<branch version=\"13.x\">",
+			"",
+			"$3",
+			"",
+			"</branch>"]
 	},
 	"branch-inline": {
 		"prefix": ["branch-inline", "br-inline"],
-		"description": "v11-v12 branches (inline)",
-		"body": "<branch version=\"11.x\" inline>$1</branch><branch version=\"12.x\" inline>$2</branch>"
+		"description": "version branches (inline)",
+		"body": "<branch version=\"11.x\" inline>$1</branch><branch version=\"12.x\" inline>$2</branch><branch version=\"13.x\" inline>$3</branch>"
 	},
 	"docs": {
 		"prefix": ["docs", "djs-docs"],

--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -46,10 +46,11 @@ export default {
 	},
 	methods: {
 		formatBranch(version) {
-			// NOTE: v12 is the current stable branch,
+			// NOTE: v12 is the current stable branch and v13 is the current master branch,
 			// but linking to the `v12` branch points to an outdated version
 			// This is temporary until v13 comes stable
 			if (version.startsWith('12')) return 'stable';
+			if (version.startsWith('13')) return 'master';
 			return `v${version.slice(0, 2)}`;
 		},
 	},

--- a/guide/.vuepress/mixins/branches.js
+++ b/guide/.vuepress/mixins/branches.js
@@ -1,5 +1,10 @@
 const branches = [
 	{
+		label: 'v13 (master)',
+		version: '13.x',
+		aliases: ['13', 'master'],
+	},
+	{
 		label: 'v12 (stable)',
 		version: '12.x',
 		aliases: ['12', 'stable'],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[⭐ Demo](https://deploy-preview-687--discordjs-guide.netlify.app/)

This PR adds support for `v13` components and a `v13` branch to the guide. These will be useful in the current and future PRs regarding `v13`. The goal of this PR is to ensure a gradual and smooth update towards the additions and changes in the sections and pages for the new version.

**Status**
- [x] `v13` Branch.
- [x] Support in components.
    - [x] `Branch`es.
    - [x] `DocsLink`s.
 - [x] VSCode code snippets.
 
 ---
 