### PR TITLE
Suggestion: Eslint Rules

### DIFF
--- a/guide/preparations/setting-up-a-linter.md
+++ b/guide/preparations/setting-up-a-linter.md
@@ -64,8 +64,7 @@ Alternatively, if you don't want to go through everything one by one on your own
 	"extends": "eslint:recommended",
 	"env": {
 		"node": true,
-		"es6": true,
-		"es2021": true
+		"es6": true
 	},
 	"parserOptions": {
 		"ecmaVersion": 2021

--- a/guide/preparations/setting-up-a-linter.md
+++ b/guide/preparations/setting-up-a-linter.md
@@ -64,10 +64,11 @@ Alternatively, if you don't want to go through everything one by one on your own
 	"extends": "eslint:recommended",
 	"env": {
 		"node": true,
-		"es6": true
+		"es6": true,
+		"es2021": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 2019
+		"ecmaVersion": 2021
 	},
 	"rules": {
 		"brace-style": ["error", "stroustrup", { "allowSingleLine": true }],


### PR DESCRIPTION
Update the Eslint rules to support the ES2021 since the guide and the docs use the optional chaining and the null coalescing operator and in the ES6 rule it gives a warn
