### PR TITLE
refactor(intents): more explicit on how to read ddev docs

### DIFF
--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -2,7 +2,7 @@
 
 <branch version="11.x">
 
-Intents are not available in version 11; please update to version 12 of the library if you want to use gateway intents in your bot.
+Intents are not available in version 11; please update to version 12 of the library if you want to use gateway intents in your application.
 
 </branch>
 <branch version="12.x">
@@ -11,13 +11,44 @@ Intents are not available in version 11; please update to version 12 of the libr
 Version 13 of Discord.js will require you to choose intents (as it uses a new version of Discord's API), it's worthwhile reading this section even if you don't currently want to update, so you know what to do later.
 :::
 
-Gateway Intents were introduced by Discord so bot developers can choose which events their bot receives based on which data it needs to function. Intents are named groups of pre-defined WebSocket events, which the Discord.js client will receive. If you omit `DIRECT_MESSAGE_TYPING`, for example, you will no longer receive typing events from direct messages. If you provide no intents, version 12 will receive all events for allowed intents, and version 13 will throw an error.
+Discord introduced gateway intents so developers can choose which events their application receives. Intents are named groups of pre-defined WebSocket events, which the discord.js client will receive.
+
+## Enabling Intents
+
+You can find an up-to-date list of all available intents on the [Discord Developer Documention](https://discord.com/developers/docs/topics/gateway#list-of-intents) in the following format:
+
+```
+INTENT_NAME (0 << 0)
+	- EVENT_NAME
+	- OTHER_EVENT_NAME
+```
+
+If you want to listen to `'eventName'` or `'otherEventName'` in discord.js you need to supply `INTENT_NAME` (`0 << 0` is the bit representation for this intent).
+
+Take a look at your event handlers (like `client.on('message', ...)`, `client.on('inviteCreate', ...)`) and figure out which intent corresponds to each event. Note that discord.js event names follow the lowerCamelCase convention, while discord uses MACRO_CASE for WebSocket events. Discord.js also emits both `MESSAGE_CREATE` for direct and guild messages in the `'message'` client event.
+
+In the case of `'message'` for guilds you will find `MESSAGE_CREATE` to be listed under the `GUILD_MESSAGES` intent and so on. After you found all intents, provide them to the Client constructor as shown below:
+
+```js
+const { Client } = require('discord.js');
+const client = new Client({ ws: { intents: ['GUILDS', 'GUILD_MESSAGES'] } });
+```
+
+::: warning
+Note that discord.js relies heavily on caching to provide its functionality. Some methods that seem unrelated might stop working if certain events do not arrive.
+
+Please make sure to provide the list of gateway intents and partials you use in your Client constructor when asking for support on our [Discord server](https://discord.gg/djs) or [GitHub repository](https://github.com/discordjs/discord.js).
+:::
 
 ## Privileged Intents
 
-Discord defines some intents as "privileged" due to the data's sensitive nature. At the time of writing this article, privileged intents are `GUILD_PRESENCES` and `GUILD_MEMBERS`. If your bot is not verified and in less than 100 guilds, you can enable privileged gateway intents in the [Discord Developer Portal](https://discord.com/developers/applications) under "Privileged Gateway Intents" in the "Bot" section. If your bot is already verified or is about to [require verification](https://support.discord.com/hc/en-us/articles/360040720412), you need to request privileged intents. You can do this in your verification application or by reaching out to Discord's [support team](https://dis.gd/contact), including why you require access to each privileged intent.
+Discord defines some intents as "privileged" due to the data's sensitive nature. If your application is not verified and its bot is in less than 100 guilds, you can enable privileged gateway intents in the [Discord Developer Portal](https://discord.com/developers/applications) under "Privileged Gateway Intents" in the "Bot" section. If your application is already verified or is about to [require verification](https://support.discord.com/hc/en-us/articles/360040720412), you need to request privileged intents. You can do this in your verification application or by reaching out to Discord's [support team](https://dis.gd/contact), including an explanation as to why you require access to each privileged intent.
 
-Before storming off and doing so, you should stop and carefully think about if you need these events. Discord made them opt-in so users across the platform can enjoy a higher level of [privacy](https://en.wikipedia.org/wiki/Privacy_by_design). Presences can expose quite a bit of personal information through games and online times, for example. You might find it sufficient for your bot to have a little less information about all guild members at all times, considering you still get the command author as GuildMember from the command execution message and can fetch targets separately.
+Before storming off and doing so, you should stop and carefully think about if you need these events. Discord made them opt-in so users across the platform can enjoy a higher level of [privacy](https://en.wikipedia.org/wiki/Privacy_by_design). Presences can expose quite a bit of personal information through games and online times, for example. You might find it sufficient for your application to have a little less information about all guild members at all times, considering you still get the command author as GuildMember from the command execution message and can fetch targets separately.
+
+### Error: Disallowed Intents
+
+Should you receive an error prefixed with `[DISALLOWED_INTENTS]`, please review your developer dashboard settings for all privileged intents you use. This topic's official documentation is on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents).
 
 ### Problems in version 12
 
@@ -31,32 +62,11 @@ Before storming off and doing so, you should stop and carefully think about if y
 - User cache is empty *(or has only very few entries)*
 - All members appear to be offline
 
-### Error: Disallowed Intents
-
-Should you receive an error prefixed with `[DISALLOWED_INTENTS]`, please review your developer dashboard settings for all privileged intents you use. This topic's official documentation is on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents).
-
-## Enabling Intents
-
-To specify which events you want your bot to receive, first think about which events your bot needs to operate. Then select the required intents and add them to your client constructor, as shown below.
-
-All gateway intents, and the events belonging to each, are listed on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#list-of-intents). If you need your bot to receive messages (`MESSAGE_CREATE` - `"message"` in discord.js), you need the `GUILD_MESSAGES` intent. If you want your bot to post welcome messages for new members (`GUILD_MEMBER_ADD` - `"guildMemberAdd"` in discord.js), you need the `GUILD_MEMBERS` intent, and so on.
-
-```js
-const { Client } = require('discord.js');
-const client = new Client({ ws: { intents: ['GUILDS', 'GUILD_MESSAGES'] } });
-```
-
-::: warning
-Note that discord.js relies heavily on caching to provide its functionality. Some methods that seem unrelated might stop working if certain events do not arrive.
-
-Please make sure to provide the list of gateway intents and partials you use in your Client constructor when asking for support on our [Discord server](https://discord.gg/bRCvFy9) or [GitHub repository](https://github.com/discordjs/discord.js).
-:::
-
 ## The Intents Bitfield
 
 Discord.js provides a utility structure <docs-link path="class/Intents">`Intents`</docs-link> which you can use to modify bitfields easily. The class also features static attributes for all (`Intents.ALL`), privileged (`Intents.PRIVILEGED`), and non-privileged (`Intents.NON_PRIVILEGED`) intents.
 
-These primarily serve as templates. While using them directly is possible, we strongly discourage you from using them that way. Instead, think about which events your bot strictly needs access to based on the functionality you want it to provide.
+These primarily serve as templates. While using them directly is possible, we strongly discourage you from doing so. Instead, think about which events your bot strictly needs access to based on the functionality you want it to provide.
 
 You can use the `.add()` and `.remove()` methods to add or remove flags (Intent string literals representing a certain bit) and modify the bitfield. You can provide single flags as well as an array or bitfield. To use a set of intents as a template you can pass it to the constructor. A few approaches are demonstrated below (note that the empty constructor `new Intents()` creates an empty Intents instance, representing no intents or the bitfield `0`):
 
@@ -76,7 +86,7 @@ const otherIntents2 = new Intents(32509);
 otherIntents2.remove(4096, 512);
 ```
 
-If you want to view the built flags you can utilize the `.toArray()`, `.serialize()` and `.missing()` methods. The first returns an array of flags represented in this bitfield, the second an object mapping all possible flag values to a boolean, based on their representation in this bitfield. The third method can view the flags not represented (you use it by passing a bitfield of specific intents to check for).
+If you want to view the built flags you can utilize the `.toArray()` and `.serialize()` methods. The first returns an array of flags represented in this bitfield, the second an object mapping all possible flag values to a boolean, based on their representation in this bitfield.
 
 ## More on Bitfields
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- be more explicit about how to read discord developer docs to figure out intents
- reword to prefer applications instead of bot
- replace invite link with vanity
- remove explicit mention of #missing (not all that useful if you don't have a very specific use case)
- reorder sections to better fit required reading order
- closes #675