### PR TITLE
fix(ShardingManager): renamed `launch` event to `shardCreate`

### DIFF
--- a/code-samples/sharding/getting-started/11/index.js
+++ b/code-samples/sharding/getting-started/11/index.js
@@ -1,5 +1,5 @@
 const { ShardingManager } = require('discord.js');
 const manager = new ShardingManager('./bot.js', { token: 'your-token-goes-here' });
 
-manager.on('launch', shard => console.log(`Launched shard ${shard.id}`));
+manager.on('shardCreate', shard => console.log(`Launched shard ${shard.id}`));
 manager.spawn();


### PR DESCRIPTION
The `ShardingManager` EventEmitter does not have an event called `launch`,
so I replaced it with the correct one which is `shardCreate`.

https://github.com/discordjs/discord.js/blob/master/src/sharding/ShardingManager.js#L163