### PR TITLE
chore: update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 - 2020 Sanctuary
+Copyright (c) 2017 - 2021 Sanctuary
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This updates the year stated in the `LICENSE`, specifically to -2021, since the guide is still being (co-)developed by Sanc. No core guide changes.