### PR TITLE
chore(.github): update invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discord server
-    url: https://discord.gg/bRCvFy9
+    url: https://discord.gg/djs
     about: Visit our Discord server for questions and support requests.
   - name: Guide discussion boards
     url: https://github.com/discordjs/discord.js/discussions


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This updates the invite link in the `config.yml` file to the new vanity URL. It allows users to use a more updated link and use a shorter version.