### PR TITLE
fix(sidebar): remove outdated voice-related links

### DIFF
--- a/guide/.vuepress/sidebar.ts
+++ b/guide/.vuepress/sidebar.ts
@@ -159,11 +159,6 @@ export default {
 			text: 'Voice',
 			children: [
 				'/voice/',
-				'/voice/understanding-voice.md',
-				'/voice/the-basics.md',
-				'/voice/voice-broadcasts.md',
-				'/voice/optimisation-and-troubleshooting.md',
-				'/voice/receiving-audio.md',
 			],
 		},
 		{

--- a/guide/.vuepress/sidebar.ts
+++ b/guide/.vuepress/sidebar.ts
@@ -46,12 +46,6 @@ export default {
 			],
 		},
 		{
-			text: 'Getting Started',
-			children: [
-				'/voice/',
-			],
-		},
-		{
 			text: 'Library',
 			children: [
 				'/voice/life-cycles.md',

--- a/guide/.vuepress/sidebar.ts
+++ b/guide/.vuepress/sidebar.ts
@@ -150,12 +150,6 @@ export default {
 			],
 		},
 		{
-			text: 'Voice',
-			children: [
-				'/voice/',
-			],
-		},
-		{
 			text: 'Improving Your Dev Environment',
 			children: [
 				'/improving-dev-environment/pm2.md',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Except the 1st one, all of these result to a 404 because of the voice rewrite PR making way for a dedicated section for voice. It removes the outdated sidebar links.

(I realized this was committed directly to `v13-prep` on my end so I'll re-fork again when needed.)