### PR TITLE
fix(interactions): use cmd opt resolver & add missing option type

### DIFF
--- a/code-samples/command-handling/file-setup/13/commands/avatar.js
+++ b/code-samples/command-handling/file-setup/13/commands/avatar.js
@@ -9,7 +9,7 @@ module.exports = {
 		},
 	],
 	async execute(interaction) {
-		const { user } = interaction.options.get('target') ?? {};
+		const user = interaction.options.getUser('target');
 		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);
 		return interaction.reply(`Your avatar: ${interaction.user.displayAvatarURL({ dynamic: true })}`);
 	},

--- a/code-samples/command-handling/file-setup/13/commands/kick.js
+++ b/code-samples/command-handling/file-setup/13/commands/kick.js
@@ -11,7 +11,7 @@ module.exports = {
 	],
 
 	async execute(interaction) {
-		const { user } = interaction.options.get('target');
+		const user = interaction.options.getUser('target');
 		return interaction.reply({ content: `You wanted to kick: ${user.username}`, ephemeral: true });
 	},
 };

--- a/code-samples/command-handling/file-setup/13/commands/options-info.js
+++ b/code-samples/command-handling/file-setup/13/commands/options-info.js
@@ -10,7 +10,7 @@ module.exports = {
 	],
 
 	async execute(interaction) {
-		const { value } = interaction.options.get('input') ?? {};
+		const value = interaction.options.getString('input');
 		if (value) return interaction.reply(`The options value is: \`${value}\``);
 		return interaction.reply('No option was provided!');
 	},

--- a/code-samples/command-handling/file-setup/13/commands/prune.js
+++ b/code-samples/command-handling/file-setup/13/commands/prune.js
@@ -11,7 +11,7 @@ module.exports = {
 	],
 
 	async execute(interaction) {
-		const { value: amount } = interaction.options.get('amount');
+		const amount = interaction.options.getInteger('amount');
 
 		if (amount <= 1 || amount > 100) {
 			return interaction.reply({ content: 'You need to input a number between 1 and 99.', ephemeral: true });

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -119,7 +119,7 @@ Refer to the Discord API documentation for detailed explanations on the [`SUB_CO
 * `SUB_COMMAND_GROUP` sets the option to be a sub-command-group
 * `STRING` sets the option to require a string value
 * `INTEGER` sets the option to require an integer value
-* `NUMBER` sets the option to require an integer value
+* `NUMBER` sets the option to require a decimal (also known as a floating point) value
 * `BOOLEAN` sets the option to require a boolean value
 * `USER` sets the option to require a user or snowflake as value
 * `CHANNEL` sets the option to require a channel or snowflake as value

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -119,6 +119,7 @@ Refer to the Discord API documentation for detailed explanations on the [`SUB_CO
 * `SUB_COMMAND_GROUP` sets the option to be a sub-command-group
 * `STRING` sets the option to require a string value
 * `INTEGER` sets the option to require an integer value
+* `NUMBER` sets the option to require an integer value
 * `BOOLEAN` sets the option to require a boolean value
 * `USER` sets the option to require a user or snowflake as value
 * `CHANNEL` sets the option to require a channel or snowflake as value

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -275,7 +275,7 @@ console.log([string, integer, boolean, user, member, channel, role, mentionable]
 ```
 
 ::: tip
-If you want the snowflake of a structure instead, grab it via `get()` and access the snowflake it via the `value` property. Note that you should use `const { value: name } = ...` here to [destructure and rename](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the value obtained from the <DocsLink path="typedef/CommandInteractionOption">`CommandInteractionOption`</DocsLink> structure to avoid identifier name conflicts.
+If you want the Snowflake of a structure instead, grab the option via `get()` and access the Snowflake via the `value` property. Note that you should use `const { value: name } = ...` here to [destructure and rename](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the value obtained from the <DocsLink path="typedef/CommandInteractionOption">`CommandInteractionOption`</DocsLink> structure to avoid identifier name conflicts.
 :::
 
 ## Fetching and deleting responses

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -263,7 +263,7 @@ You can `get()` these options from the `CommandInteractionOptionResolver` as sho
 ```js
 const string = interaction.options.getString('input');
 const integer = interaction.options.getInteger('int');
-const number = interaction.options.getInteger('num');
+const number = interaction.options.getNumber('num');
 const boolean = interaction.options.getBoolean('choice');
 const user = interaction.options.getUser('target');
 const member = interaction.options.getMember('target');

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -269,9 +269,9 @@ const user = interaction.options.getUser('target');
 const member = interaction.options.getMember('target');
 const channel = interaction.options.getChannel('destination');
 const role = interaction.options.getRole('muted');
-const mentionable = interaction.options.getRole('mentionable');
+const mentionable = interaction.options.getMentionable('mentionable');
 
-console.log([string, integer, boolean, user, member, channel, role]);
+console.log([string, integer, boolean, user, member, channel, role, mentionable]);
 ```
 
 ::: tip

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -220,9 +220,14 @@ const data = {
 			type: 'STRING',
 		},
 		{
-			name: 'num',
+			name: 'int',
 			description: 'Enter an integer',
 			type: 'INTEGER',
+		},
+		{
+			name: 'num',
+			description: 'Enter a number',
+			type: 'NUMBER',
 		},
 		{
 			name: 'choice',
@@ -244,26 +249,33 @@ const data = {
 			description: 'Select a role',
 			type: 'ROLE',
 		},
+		{
+			name: 'mentionable',
+			description: 'Mention something',
+			type: 'MENTIONABLE',
+		},
 	],
 };
 ```
 
-You can `get()` these options from the `CommandInteraction#options` Collection:
+You can `get()` these options from the `CommandInteractionOptionResolver` as shown below:
 
 ```js
-const { value: string } = interaction.options.get('input');
-const { value: integer } = interaction.options.get('num');
-const { value: boolean } = interaction.options.get('choice');
-const { user } = interaction.options.get('target');
-const { member } = interaction.options.get('input');
-const { channel } = interaction.options.get('destination');
-const { role } = interaction.options.get('muted');
+const string = interaction.options.getString('input');
+const integer = interaction.options.getInteger('int');
+const number = interaction.options.getInteger('num');
+const boolean = interaction.options.getBoolean('choice');
+const user = interaction.options.getUser('target');
+const member = interaction.options.getMember('target');
+const channel = interaction.options.getChannel('destination');
+const role = interaction.options.getRole('muted');
+const mentionable = interaction.options.getRole('mentionable');
 
 console.log([string, integer, boolean, user, member, channel, role]);
 ```
 
 ::: tip
-If you want the snowflake of a structure instead, access it via the `value` property. Note that we use `const { value: name } = ...` here to [destructure and rename](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the value obtained from the <DocsLink path="typedef/CommandInteractionOption">`CommandInteractionOption`</DocsLink> structure to avoid identifier name conflicts.
+If you want the snowflake of a structure instead, grab it via `get()` and access the snowflake it via the `value` property. Note that you should use `const { value: name } = ...` here to [destructure and rename](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the value obtained from the <DocsLink path="typedef/CommandInteractionOption">`CommandInteractionOption`</DocsLink> structure to avoid identifier name conflicts.
 :::
 
 ## Fetching and deleting responses


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR updates the examples to use the commandinteractionresolver methods and adds the missing number option type.