### PR TITLE
fix(interactions): Fix broken links

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -3,7 +3,7 @@
 Discord provides developers with the option to create client-integrated slash commands. In this section, we'll cover how to register these commands using discord.js!
 
 ::: tip
-If you already have slash commands set-up for your application and want to learn how to respond to them, refer to [the following page](/interactions/replying-to-slash-commands/).
+If you already have slash commands set-up for your application and want to learn how to respond to them, refer to [the following page](/interactions/replying-to-slash-commands.md).
 :::
 
 ## Global commands

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -3,7 +3,7 @@
 Discord provides developers the option to create client-integrated slash commands. In this section, we'll cover how to respond to these commands using discord.js!
 
 ::: tip
-You need at least one slash command registered on your application to continue with the instructions on this page. If you haven't done that yet, refer to [the previous page](/interactions/registering-slash-commands/).
+You need at least one slash command registered on your application to continue with the instructions on this page. If you haven't done that yet, refer to [the previous page](/interactions/registering-slash-commands.md).
 :::
 
 ## Receiving interactions


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Two links in the slash commands pages lead to 404s due to bad URLs. This fixes the URLs to lead to the right pages.