### PR TITLE
fix(interactions): Use subcommand (group) casing

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -115,8 +115,8 @@ As shown in the options example above, you can specify the `type` of an `Applica
 Refer to the Discord API documentation for detailed explanations on the [`SUB_COMMAND` and `SUB_COMMAND_GROUP` option types](https://discord.com/developers/docs/interactions/slash-commands#subcommands-and-subcommand-groups).
 :::
 
-* `SUB_COMMAND` sets the option to be a sub-command
-* `SUB_COMMAND_GROUP` sets the option to be a sub-command-group
+* `SUB_COMMAND` sets the option to be a subcommand
+* `SUB_COMMAND_GROUP` sets the option to be a subcommand group
 * `STRING` sets the option to require a string value
 * `INTEGER` sets the option to require an integer value
 * `BOOLEAN` sets the option to require a boolean value


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Per discordjs/discord.js/pull/6204, "subcommand" and "subcommand group" should be preferred and should be consistent here in the guide! Although not quite sure why it was initially "sub-command-group".