### PR TITLE
fix(collectors): typo in awaitMessageComponent

### DIFF
--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -176,7 +176,7 @@ const filter = i => {
 	return i.user.id === interaction.user.id;
 };
 
-message.awaitMessageComponents({ filter, componentType: 'SELECT_MENU', time: 60000 })
+message.awaitMessageComponent({ filter, componentType: 'SELECT_MENU', time: 60000 })
 	.then(interaction => interaction.editReply(`You selected ${interaction.values.join(', ')}!`))
 	.catch(err => console.log(`No interactions were collected.`));
 ```


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just fixes a typo in the `awaitMessageComponents` method which should be `awaitMessageComponent`