### PR TITLE
feat(Webhooks): use new webhook constructor syntax

### DIFF
--- a/code-samples/popular-topics/webhooks/13/using-WebhookClient.js
+++ b/code-samples/popular-topics/webhooks/13/using-WebhookClient.js
@@ -1,7 +1,7 @@
 const { MessageEmbed, WebhookClient } = require('discord.js');
 const { webhookId, webhookToken } = require('./config.json');
 
-const webhookClient = new WebhookClient(webhookId, webhookToken);
+const webhookClient = new WebhookClient({ id: webhookId, token: webhookToken });
 
 const embed = new MessageEmbed()
 	.setTitle('Some Title')

--- a/guide/popular-topics/webhooks.md
+++ b/guide/popular-topics/webhooks.md
@@ -48,7 +48,9 @@ If you are not using a bot client, you can get a webhook by creating a new insta
 ```js
 const webhookClient = new WebhookClient({ id: 'id', token: 'token' });
 ```
-or
+
+You can also pass in just a `url`:
+
 ```js
 const webhookClient = new WebhookClient({ url: 'https://discord.com/api/webhooks/id/token' });
 ```

--- a/guide/popular-topics/webhooks.md
+++ b/guide/popular-topics/webhooks.md
@@ -43,10 +43,14 @@ You can fetch a specific webhook using its `id` with <DocsLink path="class/Clien
 
 #### Using the WebhookClient constructor
 
-If you are not using a bot client, you can get a webhook by creating a new instance of `WebhookClient` and passing the `id` and `token` into the constructor. These credentials do not require you to have a bot application, but it also offers limited information instead of fetching it using an authorized client.
+If you are not using a bot client, you can get a webhook by creating a new instance of `WebhookClient` and passing the `id` and `token` or just the `url` into the constructor. These credentials do not require you to have a bot application, but it also offers limited information instead of fetching it using an authorized client.
 
 ```js
-const webhookClient = new WebhookClient('id', 'token');
+const webhookClient = new WebhookClient({ id: 'id', token: 'token' });
+```
+or
+```js
+const webhookClient = new WebhookClient({ url: 'https://discord.com/api/webhooks/id/token' });
 ```
 
 ## Creating webhooks
@@ -105,7 +109,7 @@ Example using a WebhookClient:
 const { MessageEmbed, WebhookClient } = require('discord.js');
 const { webhookId, webhookToken } = require('./config.json');
 
-const webhookClient = new WebhookClient(webhookId, webhookToken);
+const webhookClient = new WebhookClient({ id: webhookId, token: webhookToken });
 
 const embed = new MessageEmbed()
 	.setTitle('Some Title')

--- a/guide/popular-topics/webhooks.md
+++ b/guide/popular-topics/webhooks.md
@@ -43,7 +43,7 @@ You can fetch a specific webhook using its `id` with <DocsLink path="class/Clien
 
 #### Using the WebhookClient constructor
 
-If you are not using a bot client, you can get a webhook by creating a new instance of `WebhookClient` and passing the `id` and `token` or just the `url` into the constructor. These credentials do not require you to have a bot application, but it also offers limited information instead of fetching it using an authorized client.
+If you are not using a bot client, you can get a webhook by creating a new instance of `WebhookClient` and passing the `id` and `token` into the constructor. These credentials do not require you to have a bot application, but it also offers limited information instead of fetching it using an authorized client.
 
 ```js
 const webhookClient = new WebhookClient({ id: 'id', token: 'token' });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Per [PR 6192](https://github.com/discordjs/discord.js/pull/6192) in the discord.js repo, webhook constructors now only accepts an object property, which in turn can contain either id + token or url. This doesn't update the message parts (see #740 for that), and I didn't place it there either because this has a different scope. The guide and samples are changed.