### PR TITLE
fix: async function in advanced deployment example

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -188,18 +188,20 @@ const commands = client.commands.map(({ execute, ...data }) => data);
 
 const rest = new REST({ version: '9' }).setToken(token);
 
-try {
-	console.log('Started refreshing application (/) commands');
+(async () => {
+	try {
+		console.log('Started refreshing application (/) commands');
 
-	await rest.put(
-		Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
-		{ body: commands },
-	);
+		await rest.put(
+			Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
+			{ body: commands },
+		);
 
-	console.log('Sucessfully reloaded application (/) commands.');
-} catch (error) {
-	console.error(error);
-}
+		console.log('Sucessfully reloaded application (/) commands.');
+	} catch (error) {
+		console.error(error);
+	}
+})()
 ```
 
 Running this script will register all your commands to the guild of which the id was passed in above.

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -201,7 +201,7 @@ const rest = new REST({ version: '9' }).setToken(token);
 	} catch (error) {
 		console.error(error);
 	}
-})()
+})();
 ```
 
 Running this script will register all your commands to the guild of which the id was passed in above.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changes the advanced deployment code in the guide to use an async function, since TLA only works in es6 modules, and it would throw an error otherwise, and also for consistency with discordjs/discord.js#6250