### PR TITLE
fix: change config token code example to match repo

### DIFF
--- a/guide/creating-your-bot/configuration-files.md
+++ b/guide/creating-your-bot/configuration-files.md
@@ -30,7 +30,7 @@ const { token } = require('./config.json');
 
 Next, copy your token from the `client.login('your-token-goes-here')` line and paste into the `config.json` file. Make sure to keep it between the double-quotes.
 
-Now you can simply do `client.login(config.token)` to login!
+Now you can simply do `client.login(token)` to login!
 
 ## Storing additional data
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes the code example in the guide for logging in a client with a token from a config file, to be consistent with the guide's code repo.