### PR TITLE
fix: remove mentioning of prefix usage

### DIFF
--- a/guide/creating-your-bot/adding-more-commands.md
+++ b/guide/creating-your-bot/adding-more-commands.md
@@ -26,7 +26,7 @@ const { token } = require('./config.json');
 client.login(token);
 ```
 
-From now on, if you change the prefix or token in your `config.json` file, it'll change in your bot file as well. You'll be using the prefix variable a lot soon.
+From now on, if you change the token in your `config.json` file, it'll change in your bot file as well.
 
 ::: tip
 If you aren't familiar with some of this syntax, it may be ES6 syntax. If it does confuse you, you should check out [this guide page](/additional-info/es6-syntax.md) before continuing.

--- a/guide/creating-your-bot/configuration-files.md
+++ b/guide/creating-your-bot/configuration-files.md
@@ -34,7 +34,7 @@ Now you can simply do `client.login(token)` to login!
 
 ## Storing additional data
 
-As previously mentioned, you'll probably want to store more than just your token and prefix at one point or another. If you're going to store more data, add another key/value pair to the list!
+As previously mentioned, you'll probably want to store more than just your token at one point or another. If you're going to store more data, add another key/value pair to the list!
 
 ```json
 {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In this context of the guide, prefixes are not used, needless to say, slash commands are the ones here.