### PR TITLE
fix: typo in "Advanced deployment" example

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -197,7 +197,7 @@ const rest = new REST({ version: '9' }).setToken(token);
 			{ body: commands },
 		);
 
-		console.log('Sucessfully reloaded application (/) commands.');
+		console.log('Successfully reloaded application (/) commands.');
 	} catch (error) {
 		console.error(error);
 	}

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -190,7 +190,7 @@ const rest = new REST({ version: '9' }).setToken(token);
 
 (async () => {
 	try {
-		console.log('Started refreshing application (/) commands');
+		console.log('Started refreshing application (/) commands.');
 
 		await rest.put(
 			Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Typo in the example. Should say "successfully". 