### PR TITLE
fix: Patch broken link to Audio Resources page

### DIFF
--- a/guide/voice/audio-player.md
+++ b/guide/voice/audio-player.md
@@ -36,7 +36,7 @@ player.stop();
 
 ### Playing audio
 
-You can create [audio resources](./audio-resources) and then play them on an audio player.
+You can create [audio resources](./audio-resources.md) and then play them on an audio player.
 
 ```js
 const resource = createAudioResource('/home/user/voice/track.mp3');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the broken link on the voice page to audio resources, as previously it would lead to a 404 upon click.