### PR TITLE
feat(Builders): add builders page to popular-topics

### DIFF
--- a/guide/.vuepress/sidebar.ts
+++ b/guide/.vuepress/sidebar.ts
@@ -78,6 +78,7 @@ export default {
 				'/popular-topics/faq.md',
 				'/popular-topics/threads.md',
 				'/popular-topics/embeds.md',
+				'/popular-topics/builders.md',
 				'/popular-topics/reactions.md',
 				'/popular-topics/collectors.md',
 				'/popular-topics/permissions.md',

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -1,7 +1,7 @@
 # Builders
 
-Discord.js provides a `builders` package which contains a variety of builders and utilities you can use when writing your Discord bot.
-To install the package run `npm i @discordjs/builders` in your terminal.
+Discord.js provides a `builders` package which contains a variety of utilities you can use when writing your Discord bot.
+To install the package run `npm install @discordjs/builders` in your terminal.
 
 ## Formatters
 
@@ -12,16 +12,16 @@ Formatters are a set of utility functions which format input strings into the gi
 The Formatters provide functions to format strings into all the different Markdown styles supported by Discord.
 
 ```js
-const { Formatters } = require('@discordjs/builders');
+const { bold, italic, strikethrough, spoiler, quote, blockQuote, underscore } = require('@discordjs/builders');
 const string = 'Hello!';
 
-const bold = Formatters.bold(string);
-const italic = Formatters.italic(string);
-const strikethrough = Formatters.strikethrough(string);
-const spoiler = Formatters.spoiler(string);
-const quote = Formatters.quote(string);
-const blockquote = Formatters.blockQuote(string);
-const underscore = Formatters.underscore(string);
+const boldString = bold(string);
+const italicString = italic(string);
+const strikethroughString = strikethrough(string);
+const spoilerString = spoiler(string);
+const quoteString = quote(string);
+const blockquoteString = blockQuote(string);
+const underscoreString = underscore(string);
 ```
 
 ### Links

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -1,0 +1,132 @@
+# Builders
+
+Discord.js provides a `builders` package which contains a variety of builders and utilities you can use when writing your Discord bot.
+To install the package run `npm i @discordjs/builders` in your terminal.
+
+## Formatters
+
+Formatters are a set of utility functions which format input strings into the given format.
+
+### Basic Markdown
+
+The Formatters provide functions to format strings into all the different Markdown styles supported by Discord.
+
+```js
+const { Formatters } = require('@discordjs/builders');
+const string = 'Hello!';
+
+const bold = Formatters.bold(string);
+const italic = Formatters.italic(string);
+const strikethrough = Formatters.strikethrough(string);
+const spoiler = Formatters.spoiler(string);
+const quote = Formatters.quote(string);
+const blockquote = Formatters.blockQuote(string);
+const underscore = Formatters.underscore(string);
+```
+
+### Links
+
+There's also two method to format hypelinks. `Formatters#hyperlink()` will format the url into a masked markdown link and `Formatters#hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
+
+```js {2,4-5}
+const { Formatters } = require('@discordjs/builders');
+const url = 'https://discord.js.org/';
+
+const link = Formatters.hyperlink(url);
+const hiddenembed = Formatters.hideLinkEmbed(url);
+```
+
+### Codeblocks
+
+You can use `Formatters#inlineCode()` and `Formatters#codeBlock()` to turn a string into an inline codeblock or a regular codeblock with or without syntax highlighting.
+
+```js {2,4-6}
+const { Formatters } = require('@discordjs/builders');
+const jsstring = 'const value = true;';
+
+const inline = Formatters.inlineCode(jsstring);
+const codeblock = Formatters.codeBlock(jsstring);
+const highlighted = Formatters.codeBlock('js', jsstring);
+```
+
+### Timestamps
+
+With `Formatters#time()` you can format UNIX timestamps and dates into a Discord timestring.
+
+```js {2,4-5}
+const { Formatters } = require('@discordjs/builders');
+const date = new Date();
+
+const time = Formatters.time(date);
+const relative = Formatters.time(date, 'R');
+```
+
+### Mentions
+
+The Formatters also contain various methods to fromat Snowflakes into mentions.
+
+```js {2,4-7}
+const { Formatters } = require('@discordjs/builders');
+const id = '123456789012345678';
+
+const user = Formatters.userMention(id);
+const nickname = Formatters.memberMention(id);
+const channel = Formatters.channelMention(id);
+const role = Formatters.roleMention(id);
+```
+
+## Slash command builders
+
+The slash command builders are a set of utility methods to quickly build slash commands without having to manually construct objects.
+
+### Commands
+
+First we'll build a simple slash command using the builder and save the raw data to a variable, which can then later be used to send the data to the Discord API.
+
+```js
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+// Create a slash command builder
+const command = new SlashCommandBuilder().setName('ping').setDescription('Replies with Pong!');
+
+// Get the raw data that can be sent to Discord
+const rawData = command.toJSON();
+```
+
+### Options
+
+This is a command with a user option.
+
+```js {4-6}
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+const command = new SlashCommandBuilder()
+	.setName('info')
+	.setDescription('Get info about a user!')
+	.addUserOption(option => option.setName('user').setDescription('The user'));
+
+const rawData = command.toJSON();
+```
+
+### Subcommands
+
+And this is a command containing two subcommands.
+
+```js {6-14}
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+const command = new SlashCommandBuilder()
+	.setName('info')
+	.setDescription('Get info about a user or a server!')
+	.addSubCommand(subCommand =>
+		subCommand
+			.setName('user')
+			.setDescription('Info about a user')
+			.addUserOption(option => option.setName('target').setDescription('The user')))
+	.addSubCommand(subCommand =>
+		subCommand
+			.setName('server')
+			.setDescription('Info about the server'));
+
+const rawData = command.toJSON();
+```

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -63,7 +63,7 @@ const relative = Formatters.time(date, 'R');
 
 ### Mentions
 
-The Formatters also contain various methods to fromat Snowflakes into mentions.
+The Formatters also contain various methods to format Snowflakes into mentions.
 
 ```js {2,4-7}
 const { Formatters } = require('@discordjs/builders');

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -5,7 +5,7 @@ To install the package, run `npm install @discordjs/builders` in your terminal.
 
 ## Formatters
 
-Formatters are a set of utility functions which format input strings into the given format.
+Formatters are a set of utility functions that format input strings into the given format.
 
 ### Basic Markdown
 

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -1,6 +1,6 @@
 # Builders
 
-discord.js provides a `builders` package which contains a variety of utilities you can use when writing your Discord bot.
+discord.js provides the [`@discordjs/builders`](https://github.com/discordjs/builders) package which contains a variety of utilities you can use when writing your Discord bot.
 To install the package, run `npm install @discordjs/builders` in your terminal.
 
 ## Formatters
@@ -36,9 +36,9 @@ const link = hyperlink(url);
 const hiddenEmbed = hideLinkEmbed(url);
 ```
 
-### Codeblocks
+### Code blocks
 
-You can use `inlineCode()` and `codeBlock()` to turn a string into an inline codeblock or a regular codeblock with or without syntax highlighting.
+You can use `inlineCode()` and `codeBlock()` to turn a string into an inline code block or a regular code block with or without syntax highlighting.
 
 ```js
 const { inlineCode, codeBlock } = require('@discordjs/builders');
@@ -51,7 +51,7 @@ const highlighted = codeBlock('js', jsString);
 
 ### Timestamps
 
-With `time()` you can format UNIX timestamps and dates into a Discord timestring.
+With `time()`, you can format UNIX timestamps and dates into a Discord time string.
 
 ```js
 const { time } = require('@discordjs/builders');

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -1,7 +1,7 @@
 # Builders
 
-Discord.js provides a `builders` package which contains a variety of utilities you can use when writing your Discord bot.
-To install the package run `npm install @discordjs/builders` in your terminal.
+discord.js provides a `builders` package which contains a variety of utilities you can use when writing your Discord bot.
+To install the package, run `npm install @discordjs/builders` in your terminal.
 
 ## Formatters
 
@@ -12,23 +12,23 @@ Formatters are a set of utility functions which format input strings into the gi
 The Formatters provide functions to format strings into all the different Markdown styles supported by Discord.
 
 ```js
-const { bold, italic, strikethrough, spoiler, quote, blockQuote, underscore } = require('@discordjs/builders');
+const { bold, italic, strikethrough, underscore, spoiler, quote, blockQuote } = require('@discordjs/builders');
 const string = 'Hello!';
 
 const boldString = bold(string);
 const italicString = italic(string);
 const strikethroughString = strikethrough(string);
+const underscoreString = underscore(string);
 const spoilerString = spoiler(string);
 const quoteString = quote(string);
 const blockquoteString = blockQuote(string);
-const underscoreString = underscore(string);
 ```
 
 ### Links
 
-There are also two methods to format hyperlinks. `hyperlink()` will format the URL into a masked markdown link and `hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
+There are also two methods to format hyperlinks. `hyperlink()` will format the URL into a masked markdown link, and `hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
 
-```js {2,4-5}
+```js
 const { hyperlink, hideLinkEmbed } = require('@discordjs/builders');
 const url = 'https://discord.js.org/';
 
@@ -40,7 +40,7 @@ const hiddenEmbed = hideLinkEmbed(url);
 
 You can use `inlineCode()` and `codeBlock()` to turn a string into an inline codeblock or a regular codeblock with or without syntax highlighting.
 
-```js {2,4-6}
+```js
 const { inlineCode, codeBlock } = require('@discordjs/builders');
 const jsString = 'const value = true;';
 
@@ -53,7 +53,7 @@ const highlighted = codeBlock('js', jsString);
 
 With `time()` you can format UNIX timestamps and dates into a Discord timestring.
 
-```js {2,4-5}
+```js
 const { time } = require('@discordjs/builders');
 const date = new Date();
 
@@ -65,8 +65,8 @@ const relative = time(date, 'R');
 
 The Formatters also contain various methods to format Snowflakes into mentions.
 
-```js {2,4-7}
-const { userMention, membermention, channelMention, roleMention } = require('@discordjs/builders');
+```js
+const { userMention, memberMention, channelMention, roleMention } = require('@discordjs/builders');
 const id = '123456789012345678';
 
 const user = userMention(id);
@@ -77,19 +77,16 @@ const role = roleMention(id);
 
 ## Slash command builders
 
-The slash command builder is a utility class to quickly build slash commands without having to manually construct objects.
+The slash command builder is a utility class to build slash commands without having to manually construct objects.
 
 ### Commands
 
-First we'll build a simple slash command using the builder and save the raw data to a variable, which can then later be used to send the data to the Discord API.
+Here's a simple slash command using the builder. You can collect your commands data and use it to register slash commands.
 
 ```js
-const { SlashCommandBuilder } = require('@discordjs/builders');
-
-// Create a slash command builder
 const command = new SlashCommandBuilder().setName('ping').setDescription('Replies with Pong!');
 
-// Get the raw data that can be sent to Discord
+// Raw data that can be used to register a slash command
 const rawData = command.toJSON();
 ```
 
@@ -97,24 +94,18 @@ const rawData = command.toJSON();
 
 This is a command with a user option.
 
-```js {4-6}
-const { SlashCommandBuilder } = require('@discordjs/builders');
-
+```js {4}
 const command = new SlashCommandBuilder()
 	.setName('info')
 	.setDescription('Get info about a user!')
 	.addUserOption(option => option.setName('user').setDescription('The user'));
-
-const rawData = command.toJSON();
 ```
 
 ### Subcommands
 
-And this is a command containing two subcommands.
+This is a command containing two subcommands.
 
-```js {6-14}
-const { SlashCommandBuilder } = require('@discordjs/builders');
-
+```js {4-12}
 const command = new SlashCommandBuilder()
 	.setName('info')
 	.setDescription('Get info about a user or a server!')
@@ -127,6 +118,4 @@ const command = new SlashCommandBuilder()
 		subcommand
 			.setName('server')
 			.setDescription('Info about the server'));
-
-const rawData = command.toJSON();
 ```

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -84,6 +84,8 @@ The slash command builder is a utility class to build slash commands without hav
 Here's a simple slash command using the builder. You can collect your commands data and use it to register slash commands.
 
 ```js
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
 const command = new SlashCommandBuilder().setName('ping').setDescription('Replies with Pong!');
 
 // Raw data that can be used to register a slash command

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -26,7 +26,7 @@ const underscore = Formatters.underscore(string);
 
 ### Links
 
-There's also two method to format hypelinks. `Formatters#hyperlink()` will format the url into a masked markdown link and `Formatters#hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
+There are also two methods to format hyperlinks. `Formatters#hyperlink()` will format the URL into a masked markdown link and `Formatters#hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
 
 ```js {2,4-5}
 const { Formatters } = require('@discordjs/builders');

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -33,7 +33,7 @@ const { hyperlink, hideLinkEmbed } = require('@discordjs/builders');
 const url = 'https://discord.js.org/';
 
 const link = hyperlink(url);
-const hiddenembed = hideLinkEmbed(url);
+const hiddenEmbed = hideLinkEmbed(url);
 ```
 
 ### Codeblocks
@@ -42,11 +42,11 @@ You can use `inlineCode()` and `codeBlock()` to turn a string into an inline cod
 
 ```js {2,4-6}
 const { inlineCode, codeBlock } = require('@discordjs/builders');
-const jsstring = 'const value = true;';
+const jsString = 'const value = true;';
 
-const inline = inlineCode(jsstring);
-const codeblock = codeBlock(jsstring);
-const highlighted = codeBlock('js', jsstring);
+const inline = inlineCode(jsString);
+const codeblock = codeBlock(jsString);
+const highlighted = codeBlock('js', jsString);
 ```
 
 ### Timestamps
@@ -118,13 +118,13 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const command = new SlashCommandBuilder()
 	.setName('info')
 	.setDescription('Get info about a user or a server!')
-	.addSubCommand(subCommand =>
-		subCommand
+	.addSubcommand(subcommand =>
+		subcommand
 			.setName('user')
 			.setDescription('Info about a user')
 			.addUserOption(option => option.setName('target').setDescription('The user')))
-	.addSubCommand(subCommand =>
-		subCommand
+	.addSubcommand(subcommand =>
+		subcommand
 			.setName('server')
 			.setDescription('Info about the server'));
 

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -26,39 +26,39 @@ const underscoreString = underscore(string);
 
 ### Links
 
-There are also two methods to format hyperlinks. `Formatters#hyperlink()` will format the URL into a masked markdown link and `Formatters#hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
+There are also two methods to format hyperlinks. `hyperlink()` will format the URL into a masked markdown link and `hideLinkEmbed()` will wrap the URL in `<>`, preventing it from embedding.
 
 ```js {2,4-5}
-const { Formatters } = require('@discordjs/builders');
+const { hyperlink, hideLinkEmbed } = require('@discordjs/builders');
 const url = 'https://discord.js.org/';
 
-const link = Formatters.hyperlink(url);
-const hiddenembed = Formatters.hideLinkEmbed(url);
+const link = hyperlink(url);
+const hiddenembed = hideLinkEmbed(url);
 ```
 
 ### Codeblocks
 
-You can use `Formatters#inlineCode()` and `Formatters#codeBlock()` to turn a string into an inline codeblock or a regular codeblock with or without syntax highlighting.
+You can use `inlineCode()` and `codeBlock()` to turn a string into an inline codeblock or a regular codeblock with or without syntax highlighting.
 
 ```js {2,4-6}
-const { Formatters } = require('@discordjs/builders');
+const { inlineCode, codeBlock } = require('@discordjs/builders');
 const jsstring = 'const value = true;';
 
-const inline = Formatters.inlineCode(jsstring);
-const codeblock = Formatters.codeBlock(jsstring);
-const highlighted = Formatters.codeBlock('js', jsstring);
+const inline = inlineCode(jsstring);
+const codeblock = codeBlock(jsstring);
+const highlighted = codeBlock('js', jsstring);
 ```
 
 ### Timestamps
 
-With `Formatters#time()` you can format UNIX timestamps and dates into a Discord timestring.
+With `time()` you can format UNIX timestamps and dates into a Discord timestring.
 
 ```js {2,4-5}
-const { Formatters } = require('@discordjs/builders');
+const { time } = require('@discordjs/builders');
 const date = new Date();
 
-const time = Formatters.time(date);
-const relative = Formatters.time(date, 'R');
+const timeString = time(date);
+const relative = time(date, 'R');
 ```
 
 ### Mentions
@@ -66,13 +66,13 @@ const relative = Formatters.time(date, 'R');
 The Formatters also contain various methods to format Snowflakes into mentions.
 
 ```js {2,4-7}
-const { Formatters } = require('@discordjs/builders');
+const { userMention, membermention, channelMention, roleMention } = require('@discordjs/builders');
 const id = '123456789012345678';
 
-const user = Formatters.userMention(id);
-const nickname = Formatters.memberMention(id);
-const channel = Formatters.channelMention(id);
-const role = Formatters.roleMention(id);
+const user = userMention(id);
+const nickname = memberMention(id);
+const channel = channelMention(id);
+const role = roleMention(id);
 ```
 
 ## Slash command builders

--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -77,7 +77,7 @@ const role = roleMention(id);
 
 ## Slash command builders
 
-The slash command builders are a set of utility methods to quickly build slash commands without having to manually construct objects.
+The slash command builder is a utility class to quickly build slash commands without having to manually construct objects.
 
 ### Commands
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As discussed in the dev corner, this PR adds a page to the popular topics section showcasing the usage of the @discordjs/builders package.