### PR TITLE
fix(sequelize): data type of `item_id`

### DIFF
--- a/code-samples/sequelize/currency/13/models/UserItems.js
+++ b/code-samples/sequelize/currency/13/models/UserItems.js
@@ -1,7 +1,7 @@
 module.exports = (sequelize, DataTypes) => {
 	return sequelize.define('user_item', {
 		user_id: DataTypes.STRING,
-		item_id: DataTypes.STRING,
+		item_id: DataTypes.INTEGER,
 		amount: {
 			type: DataTypes.INTEGER,
 			allowNull: false,

--- a/guide/sequelize/currency.md
+++ b/guide/sequelize/currency.md
@@ -76,7 +76,7 @@ The next file will be `UserItems.js`, the junction table.
 module.exports = (sequelize, DataTypes) => {
 	return sequelize.define('user_item', {
 		user_id: DataTypes.STRING,
-		item_id: DataTypes.STRING,
+		item_id: DataTypes.INTEGER,
 		amount: {
 			type: DataTypes.INTEGER,
 			allowNull: false,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The default primary key (`id`) generated by Sequelize is of type `INTEGER`, and `item_id` here uses the `id` value of items in the currency shop.

Resolves #742 