### PR TITLE
fix(Interactions): rename defer to deferReply

### DIFF
--- a/guide/interactions/buttons.md
+++ b/guide/interactions/buttons.md
@@ -174,7 +174,7 @@ For a detailed guide on receiving message components via collectors, please refe
 The `MessageComponentInteraction` class provides the same methods as the `CommandInteraction` class. These methods behave equally:
 - `reply()`
 - `editReply()`
-- `defer()`
+- `deferReply()`
 - `fetchReply()`
 - `deleteReply()`
 - `followUp()`

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -113,7 +113,7 @@ client.on('interactionCreate', async interaction => {
 
 As previously mentioned, you have three seconds to respond to an interaction before its token becomes invalid. But what if you have a command that performs a task which takes longer than three seconds before being able to reply?
 
-In this case, you can make use of the `CommandInteraction#defer()` method, which triggers the `<application> is thinking...` message and also acts as initial response. This allows you 15 minutes to complete your tasks before responding.
+In this case, you can make use of the `CommandInteraction#deferReply()` method, which triggers the `<application> is thinking...` message and also acts as initial response. This allows you 15 minutes to complete your tasks before responding.
 <!--- here either display the is thinking message via vue-discord-message or place a screenshot -->
 
 ```js {7-9}
@@ -123,7 +123,7 @@ client.on('interactionCreate', async interaction => {
 	if (!interaction.isCommand()) return;
 
 	if (interaction.commandName === 'ping') {
-		await interaction.defer();
+		await interaction.deferReply();
 		await wait(4000);
 		await interaction.editReply('Pong!');
 	}
@@ -137,7 +137,7 @@ You can also pass an `ephemeral` flag to the `InteractionDeferOptions`:
 <!-- eslint-skip -->
 
 ```js
-await interaction.defer({ ephemeral: true });
+await interaction.deferReply({ ephemeral: true });
 ```
 
 ## Follow-ups

--- a/guide/interactions/select-menus.md
+++ b/guide/interactions/select-menus.md
@@ -145,7 +145,7 @@ For a detailed guide on receiving message components via collectors, please refe
 The `MessageComponentInteraction` class provides the same methods as the `CommandInteraction` class. These methods behave equally:
 - `reply()`
 - `editReply()`
-- `defer()`
+- `deferReply()`
 - `fetchReply()`
 - `deleteReply()`
 - `followUp()`


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR renames all instances of `defer` to `deferReply` as per recent commit to djs