### PR TITLE
fix(Interactions): rename last remaining defer to deferReply

### DIFF
--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -130,7 +130,7 @@ client.on('interactionCreate', async interaction => {
 });
 ```
 
-If you have a command that performs longer tasks, be sure to call `defer()` as early as possible.
+If you have a command that performs longer tasks, be sure to call `deferReply()` as early as possible.
 
 You can also pass an `ephemeral` flag to the `InteractionDeferOptions`:
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The previous PR was merged quickly without reviews and one single instance of `defer()` managed to skip through, this is hereby corrected to `deferReply()`.