### PR TITLE
fix: typo in TextChannel

### DIFF
--- a/guide/additional-info/changes-in-v13.md
+++ b/guide/additional-info/changes-in-v13.md
@@ -712,7 +712,7 @@ This means the user no longer needs to pass defaults to fill each positional par
 
 #### TextChannel#stopTyping
 
-These methods have both been replaced by a singular `TextChanel.sendTyping()`. This method automatically stops typing after 10 seconds, or when a message is sent.
+These methods have both been replaced by a singular `TextChannel.sendTyping()`. This method automatically stops typing after 10 seconds, or when a message is sent.
 
 ### User
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this changes the typo in `TextChanel` to `TextChannel`