### PR TITLE
changes-in-v13 - TextChannel.sendTyping() typo

### DIFF
--- a/guide/additional-info/changes-in-v13.md
+++ b/guide/additional-info/changes-in-v13.md
@@ -712,7 +712,7 @@ This means the user no longer needs to pass defaults to fill each positional par
 
 #### TextChannel#stopTyping
 
-These methods have both been replaced by a singular `TextChanel.sendTyping()`. This method automatically stops typing after 10 seconds, or when a message is sent.
+These methods have both been replaced by a singular `TextChannel.sendTyping()`. This method automatically stops typing after 10 seconds, or when a message is sent.
 
 ### User
 


### PR DESCRIPTION
TextChanel.sendTyping() -> TextChannel.sendTyping()

**Please describe the changes this PR makes and why it should be merged:**
Just a typo, in https://discordjs.guide/additional-info/changes-in-v13.html under TextChannel, forgot an "n" in `TextChannel.sendTyping()`

**BEFORE**
These methods have both been replaced by a singular `TextChanel.sendTyping()`. This method automatically stops typing after 10 seconds, or when a message is sent.

**AFTER**
These methods have both been replaced by a singular `TextChannel.sendTyping()`. This method automatically stops typing after 10 seconds, or when a message is sent.