### PR TITLE
Changing a method on the example 

### DIFF
--- a/guide/interactions/slash-command-permissions.md
+++ b/guide/interactions/slash-command-permissions.md
@@ -76,7 +76,7 @@ await command.permissions.add({ permissions });
 
 ## Bulk update permissions
 
-If you have a lot of commands, you likely want to update their permissions in one go instead of one-by-one. For this approach, you can use `GuildApplicationCommandManager#setPermissions`:
+If you have a lot of commands, you likely want to update their permissions in one go instead of one-by-one. For this approach, you can use `ApplicationCommandPermissionsManager#set`:
 
 <!-- eslint-skip -->
 

--- a/guide/interactions/slash-command-permissions.md
+++ b/guide/interactions/slash-command-permissions.md
@@ -76,7 +76,7 @@ await command.permissions.add({ permissions });
 
 ## Bulk update permissions
 
-If you have a lot of commands, you likely want to update their permissions in one go instead of one-by-one. For this approach, you can use `ApplicationCommandPermissionsManager#set`:
+If you have a lot of commands, you likely want to update their permissions in one go instead of one-by-one. For this approach, you can use `ApplicationCommandPermissionsManager#set()` method:
 
 <!-- eslint-skip -->
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Chaning **GuildApplicationCommandManager#setPermissions** see [this](https://discord.js.org/#/docs/main/stable/class/GuildApplicationCommandManager)
to **ApplicationCommandPermissionsManager#set** see [this](https://discord.js.org/#/docs/main/stable/class/ApplicationCommandPermissionsManager)
Because **GuildApplicationCommandManager#setPermissions** is not a thing(anymore)
and its **ApplicationCommandPermissionsManager#set** that used on the example `await client.guilds.cache.get('123456789012345678')?.commands.permissions.set({ fullPermissions });`
