### PR TITLE
feat(components): Refactor the DocsLink component

### DIFF
--- a/.vscode/guide.code-snippets
+++ b/.vscode/guide.code-snippets
@@ -57,14 +57,14 @@
 		"prefix": ["docs", "djs-docs"],
 		"description": "version sensitive link to the discord.js documentation",
 		"body": [
-			"<DocsLink path=\"${1:class/Client}\">${2:some link text}</DocsLink>"
+			"<DocsLink path=\"${1:class/Client}\" />"
 		]
 	},
 	"docs-collection": {
 		"prefix": ["docs-collection", "coll-docs"],
 		"description": "link to the discord.js collections",
 		"body": [
-			"<DocsLink section=\"collection\" path=\"${1:class/Collection?scrollTo=partition}\">${2:some link text}</DocsLink>"
+			"<DocsLink section=\"collection\" path=\"${1:class/Collection?scrollTo=partition}\" type=\"method\" />"
 		]
 	}
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,21 +300,26 @@ These components feature messages, mentions, embeds, interactions, and more. You
 On pages where links to the discord.js documentation are used, you can use the `<DocsLink>` component. Since the discord.js documentation is split into different categories and branches, the component allows you to supply the necessary info accordingly. The only required prop is `path`.
 
 ```md
-Main docs, branch version inherited from branch selector, `class/Client`:
-<DocsLink path="class/Client">Link text</DocsLink>
-<!-- Becomes: https://discord.js.org/#/docs/main/v11/class/Client -->
+Main docs, default branch, `class/Client`:
+<DocsLink path="class/Client" />
+<DocsLink path="class/Client">`Client`</DocsLink>
+<!-- [`Client`](https://discord.js.org/#/docs/main/stable/class/Client) -->
 
-Main docs, stable branch (becomes "v12" due to the aliases set in `.vuepress/mixins/branches.js`), `class/Client`:
-<DocsLink branch="stable" path="class/Client">Link text</DocsLink>
-<!-- Becomes: https://discord.js.org/#/docs/main/v12/class/Client -->
+Events, methods, and static properties:
+<DocsLink path="class/Client?scrollTo=e-ready" />
+<DocsLink path="class/Intents?scrollTo=s-FLAGS" />
+<DocsLink path="class/Interaction?scrollTo=isCommand" type="method" />
+<!-- [`Client#event:ready`](https://discord.js.org/#/docs/main/stable/class/Client) -->
+<!-- [`Intents.FLAGS`](https://discord.js.org/#/docs/main/stable/class/Intents?scrollTo=s-FLAGS) -->
+<!-- [`Interaction#isCommand()`](https://discord.js.org/#/docs/main/stable/class/Interaction?scrollTo=isCommand) -->
 
-Main docs, reply-prefix branch, `class/Client`:
-<DocsLink section="main" branch="reply-prefix" path="class/Client">Link text</DocsLink>
-<!-- Becomes: https://discord.js.org/#/docs/main/reply-prefix/class/Client -->
+Main docs, v12 branch, `class/Client`:
+<DocsLink section="main" branch="v12" path="class/Client" />
+<!-- [`Client`](https://discord.js.org/#/docs/main/v12/class/Client) -->
 
 Collection docs, main branch (no `branch` prop set), `class/Collection?scrollTo=partition`:
-<DocsLink section="collection" path="class/Collection?scrollTo=partition">Link text</DocsLink>
-<!-- Becomes: https://discord.js.org/#/docs/collection/main/class/Collection?scrollTo=partition -->
+<DocsLink section="collection" path="class/Collection?scrollTo=partition" type="method" />
+<!-- [`Collection#partition()`](https://discord.js.org/#/docs/collection/main/class/Collection?scrollTo=partition) -->
 ```
 
 If the `section` prop is set to `main` (or omitted) and the `branch` prop is omitted, the `branch` prop will default to the version the user has set via the site's branch selector dropdown and update accordingly. If `section` is set to anything else and `branch` is omitted, the `branch` prop will default to `'main'`.

--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -9,7 +9,7 @@ import { computed, defineProps } from 'vue';
 
 const baseURL = 'https://discord.js.org/#/docs';
 const docsSections = ['main', 'collection', 'rpc'];
-const docsPathRegex = /\w+\/(\w+)(?:\?scrollTo=(\w+))?/;
+const docsPathRegex = /\w+\/(\w+)(?:\?scrollTo=(.+))?/;
 
 const props = defineProps({
 	section: {
@@ -21,6 +21,10 @@ const props = defineProps({
 		type: String,
 		required: true,
 	},
+	type: {
+		type: String,
+		'default': 'property',
+	},
 });
 
 const link = computed(() => {
@@ -31,7 +35,19 @@ const link = computed(() => {
 
 const linkText = computed(() => {
 	const [, file, property] = props.path.match(docsPathRegex);
+
 	if (!property) return file;
-	return `${file}#${property}`;
+
+	const isStatic = property.startsWith('s-');
+	const isEvent = property.startsWith('e-');
+	const [character, name, methodCharacters] = [
+		isStatic ? '.' : '#',
+		isStatic
+			? property.replace('s-', '')
+			: isEvent ? property.replace('e-', 'event:') : property,
+		props.type === 'method' ? '()' : '',
+	];
+
+	return `${file}${character}${name}${methodCharacters}`;
 });
 </script>

--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -1,6 +1,6 @@
 <template>
 	<a :href="link" target="_blank" rel="noopener noreferrer">
-		<slot></slot><OutboundLink />
+		<slot><code>{{ linkText }}</code></slot><OutboundLink />
 	</a>
 </template>
 
@@ -9,6 +9,7 @@ import { computed, defineProps } from 'vue';
 
 const baseURL = 'https://discord.js.org/#/docs';
 const docsSections = ['main', 'collection', 'rpc'];
+const docsPathRegex = /\w+\/(\w+)(?:\?scrollTo=(\w+))?/;
 
 const props = defineProps({
 	section: {
@@ -26,5 +27,11 @@ const link = computed(() => {
 	const guideSection = docsSections.find(section => section === props.section) || docsSections[0];
 	const branch = guideSection === 'main' ? 'stable' : props.branch || 'main';
 	return `${baseURL}/${guideSection}/${branch}/${props.path}`;
+});
+
+const linkText = computed(() => {
+	const [, file, property] = props.path.match(docsPathRegex);
+	if (!property) return file;
+	return `${file}#${property}`;
 });
 </script>

--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -81,7 +81,7 @@ client.commands = new Collection();
 :::
 
 ::: tip
-If you aren't exactly sure what Collections are, they're a class that extend JavaScript's native Map class and include more extensive, useful functionality. You can read about Maps [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), and see all the available Collection methods <DocsLink section="collection" path="class/Collection">here</DocsLink>.
+If you aren't exactly sure what <DocsLink section="collection" path="class/Collection"><code>Collection</code>s</DocsLink> are, they're a class that extend JavaScript's native [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) class and include more extensive, useful functionality.
 :::
 
 This next step is how you'll dynamically retrieve all your newly created command files. The [`fs.readdirSync()`](https://nodejs.org/api/fs.html#fs_fs_readdirsync_path_options) method will return an array of all the file names in a directory, e.g. `['ping.js', 'beep.js']`. To ensure only command files get returned, use `Array.filter()` to leave out any non-JavaScript files from the array. With that array, you can loop over it and dynamically set your commands to the Collection you made above.

--- a/guide/creating-your-bot/adding-more-commands.md
+++ b/guide/creating-your-bot/adding-more-commands.md
@@ -122,7 +122,7 @@ That would display both the server name _and_ the amount of members in it.
 Of course, you can modify this to your liking. You may also want to display the date the server was created or the server's region. You would do those in the same manner–use `interaction.guild.createdAt` or `interaction.guild.region`, respectively.
 
 ::: tip
-Want a list of all the properties you can access and all the methods you can call on a server? Refer to <DocsLink path="class/Guild">the discord.js documentation site</DocsLink>!
+Refer to the <DocsLink path="class/Guild" /> documentation for a list of all the properties you can access and all the methods you can call on a server!
 :::
 
 ### User info command
@@ -162,7 +162,7 @@ This will display the command author's **username** (not nickname, if they have 
 </DiscordMessages>
 
 ::: tip
-`interaction.user` refers to the user who sent the command. For a full list of all the properties and methods for the user object, check out <DocsLink path="class/User">the documentation page for it</DocsLink>.
+`interaction.user` refers to the user who sent the command. Check out the <DocsLink path="class/User" /> documentation page for a full list of all the properties and methods for the user object.
 :::
 
 And there you have it! As you can see, it's quite simple to add additional commands.

--- a/guide/event-handling/README.md
+++ b/guide/event-handling/README.md
@@ -1,6 +1,6 @@
 # Event handling
 
-Node.js uses an event-driven architecture, making it possible to execute code when a specific event occurs. The discord.js library takes full advantage of this. You can visit <DocsLink path="class/Client">the discord.js documentation site</DocsLink> to see the full list of `Client` events.
+Node.js uses an event-driven architecture, making it possible to execute code when a specific event occurs. The discord.js library takes full advantage of this. You can visit the <DocsLink path="class/Client" /> documentation to see the full list of events.
 
 Here's the base code we'll be using:
 

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -277,7 +277,7 @@ console.log([string, integer, boolean, user, member, channel, role, mentionable]
 ```
 
 ::: tip
-If you want the Snowflake of a structure instead, grab the option via `get()` and access the Snowflake via the `value` property. Note that you should use `const { value: name } = ...` here to [destructure and rename](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the value obtained from the <DocsLink path="typedef/CommandInteractionOption">`CommandInteractionOption`</DocsLink> structure to avoid identifier name conflicts.
+If you want the Snowflake of a structure instead, grab the option via `get()` and access the Snowflake via the `value` property. Note that you should use `const { value: name } = ...` here to [destructure and rename](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the value obtained from the <DocsLink path="typedef/CommandInteractionOption" /> structure to avoid identifier name conflicts.
 :::
 
 ### Subcommands

--- a/guide/popular-topics/audit-logs.md
+++ b/guide/popular-topics/audit-logs.md
@@ -11,7 +11,7 @@ It is crucial that you first understand two details about audit logs:
 2) There is no event which triggers when an audit log is created.
 :::
 
-Let's start by glancing at the `fetchAuditLogs` method and how to work with it. Like many discord.js methods, it returns a Promise containing the GuildAuditLogs object. In most cases, only the `entries` property will be of interest, as it holds a collection of GuildAuditLogsEntry objects, and consequently, the information you usually want. You can always take a look at the options <DocsLink path="class/Guild?scrollTo=fetchAuditLogs">in the discord.js docs</DocsLink>.
+Let's start by glancing at the <DocsLink path="class/Guild?scrollTo=fetchAuditLogs" type="method" /> method and how to work with it. Like many discord.js methods, it returns a Promise containing the <DocsLink path="class/GuildAuditLogs" /> object. In most cases, only the `entries` property will be of interest, as it holds a collection of <DocsLink path="class/GuildAuditLogsEntry" /> objects, and consequently, the information you usually want. You can always take a look at the options 
 
 The following examples will explore a straightforward case for some auditLog types. Some basic error handling is performed, but these code segments are by no means foolproof and are meant to teach you how fetching audit logs work. You will most likely need to expand on the examples based on your own goals for a rigorous system.
 

--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -2,11 +2,7 @@
 
 ## Message collectors
 
-Collectors are useful to enable your bot to obtain *additional* input after the first command was sent. An example would be initiating a quiz, where the bot will "await" a correct response from somebody.
-
-::: tip
-You can read the docs for the Collector class <DocsLink path="class/Collector">here</DocsLink>.
-:::
+<p><DocsLink path="class/Collector"><code>Collector</code>s</DocsLink> are useful to enable your bot to obtain *additional* input after the first command was sent. An example would be initiating a quiz, where the bot will "await" a correct response from somebody.</p>
 
 ### Basic message collector
 
@@ -43,11 +39,7 @@ The benefit of using an event-based collector over `.awaitMessages()` (its promi
 
 ### Await messages
 
-Using `.awaitMessages()` can be easier if you understand Promises, and it allows you to have cleaner code overall. It is essentially identical to `.createMessageCollector()`, except promisified. However, the drawback of using this method is that you cannot do things before the Promise is resolved or rejected, either by an error or completion. However, it should do for most purposes, such as awaiting the correct response in a quiz. Instead of taking their example, let's set up a basic quiz command using the `.awaitMessages()` feature.
-
-::: tip
-You can read the docs for the `.awaitMessages()` method <DocsLink path="class/TextChannel?scrollTo=awaitMessages">here</DocsLink>.
-:::
+Using <DocsLink path="class/TextChannel?scrollTo=awaitMessages" type="method" /> can be easier if you understand Promises, and it allows you to have cleaner code overall. It is essentially identical to <DocsLink path="class/TextChannel?scrollTo=createMessageCollector" type="method" />, except promisified. However, the drawback of using this method is that you cannot do things before the Promise is resolved or rejected, either by an error or completion. However, it should do for most purposes, such as awaiting the correct response in a quiz. Instead of taking their example, let's set up a basic quiz command using the `.awaitMessages()` feature.
 
 First, you'll need some questions and answers to choose from, so here's a basic set:
 
@@ -98,11 +90,7 @@ The filter looks for messages that match one of the answers in the array of poss
 
 ### Basic reaction collector
 
-These work quite similarly to message collectors, except that you apply them on a message rather than a channel. The following is an example taken from the documentation, with slightly better variable names for clarification. The filter will check for the 👍 emoji–in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
-
-::: tip
-You can read the docs for the `.createReactionCollector()` method <DocsLink path="class/Message?scrollTo=createReactionCollector">here</DocsLink>.
-:::
+These work quite similarly to message collectors, except that you apply them on a message rather than a channel. This example uses the <DocsLink path="class/Message?scrollTo=createReactionCollector" type="method" /> method. The filter will check for the 👍 emoji–in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
 
 ```js
 const filter = (reaction, user) => {
@@ -122,11 +110,7 @@ collector.on('end', collected => {
 
 ### Await reactions
 
-As before, these work almost the same as a reaction collector, except it is Promise-based. The same differences apply as with channel collectors.
-
-::: tip
-You can read the docs for the `.awaitReactions()` method <DocsLink path="class/Message?scrollTo=awaitReactions">here</DocsLink>.
-:::
+<p><DocsLink path="class/Message?scrollTo=awaitReactions" type="method" /> works almost the same as a reaction collector, except it is Promise-based. The same differences apply as with channel collectors.</p>
 
 ```js
 const filter = (reaction, user) => {

--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -54,7 +54,7 @@ Here is an example of how an embed may look. We will go over embed construction 
 
 ## Using the embed constructor
 
-discord.js features the <DocsLink path="class/MessageEmbed">`MessageEmbed`</DocsLink> utility class for easy construction and manipulation of embeds.
+discord.js features the <DocsLink path="class/MessageEmbed" /> utility class for easy construction and manipulation of embeds.
 
 ```js
 // at the top of your file
@@ -86,7 +86,7 @@ channel.send({ embeds: [exampleEmbed] });
 You don't need to include all the elements showcased above. If you want a simpler embed, leave some out.
 :::
 
-The `.setColor()` method accepts an integer, HEX color string, an array of RGB values or specific color strings. You can find a list of them at <DocsLink path="typedef/ColorResolvable">the discord.js documentation</DocsLink>.
+The `.setColor()` method accepts a <DocsLink path="typedef/ColorResolvable" />, e.g. an integer, HEX color string, an array of RGB values or specific color strings.
 
 To add a blank field to the embed, you can use `.addField('\u200b', '\u200b')`.
 
@@ -176,7 +176,7 @@ if (message.author.bot) {
 
 ## Attaching images
 
-You can upload images with your embedded message and use them as source for embed fields that support image urls by constructing a <DocsLink path="class/MessageAttachment">MessageAttachment</DocsLink> from them to send as message option alongside the embed. The attachment parameter takes a BufferResolvable or Stream including the URL to an external image.
+You can upload images with your embedded message and use them as source for embed fields that support image urls by constructing a <DocsLink path="class/MessageAttachment" /> from them to send as message option alongside the embed. The attachment parameter takes a BufferResolvable or Stream including the URL to an external image.
 
 You can then reference and use the images inside the embed itself with `attachment://fileName.extension`.
 

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -30,7 +30,7 @@ const id = <interaction>.options.get('target')?.value;
 ```
 
 ::: tip
-Because you cannot ping a user who isn't in the server, you have to pass in the user id. To do this, we use a <DocsLink path="typedef/CommandInteractionOption">`CommandInteractionOption`</DocsLink>. See [here](/interactions/replying-to-slash-commands.html#parsing-options) for more information on this topic.
+Because you cannot ping a user who isn't in the server, you have to pass in the user id. To do this, we use a <DocsLink path="typedef/CommandInteractionOption" />. See [here](/interactions/replying-to-slash-commands.html#parsing-options) for more information on this topic.
 :::
 
 ### How do I kick a user?

--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -27,7 +27,7 @@ To include permission checks like `ADMINISTRATOR` or `MANAGE_GUILD`, keep readin
 * Permission: The ability to execute a certain action in Discord
 * Overwrite: Rule on a channel to modify the permissions for a member or role
 * Bit field: Binary representation of Discord permissions 
-* Flag: Human readable string in MACRO_CASE (e.g., `'KICK_MEMBERS'`) that refers to a position in the permission bit field. You can find a list of all valid flags in the <DocsLink path="class/Permissions?scrollTo=s-FLAGS">discord.js documentation</DocsLink>
+* Flag: Human readable string in MACRO_CASE (e.g., `'KICK_MEMBERS'`) that refers to a position in the permission bit field. You can find a list of all valid flags on the <DocsLink path="class/Permissions?scrollTo=s-FLAGS" /> page
 * Base Permissions: Permissions for roles the member has, set on the guild level
 * Final Permissions: Permissions for a member or role, after all overwrites are applied
 
@@ -55,7 +55,7 @@ Note that flag names are literal. Although `VIEW_CHANNEL` grants access to view 
 
 ### Creating a role with permissions
 
-Alternatively you can provide permissions as a property of the <DocsLink path="typedef/CreateRoleOptions">CreateRoleOptions</DocsLink> typedef during role creation as an array of flag strings or a permission number:
+Alternatively you can provide permissions as a property of the <DocsLink path="typedef/CreateRoleOptions" /> typedef during role creation as an array of flag strings or a permission number:
 
 ```js
 const { Permissions } = require('discord.js');
@@ -65,7 +65,7 @@ guild.roles.create({ name: 'Mod', permissions: [Permissions.FLAGS.MANAGE_MESSAGE
 
 ### Checking member permissions
 
-To know if one of a member's roles has a permission enabled, you can use the `.has()` method of the GuildMember's <DocsLink path="class/GuildMember?scrollTo=permissions">`permissions`</DocsLink> and provide a permission flag, array, or number to check for. You can also specify if you want to allow the `ADMINISTRATOR` permission or the guild owner status to override this check with the following parameters.
+To know if one of a member's roles has a permission enabled, you can use the `.has()` method on <DocsLink path="class/GuildMember?scrollTo=permissions" /> and provide a permission flag, array, or number to check for. You can also specify if you want to allow the `ADMINISTRATOR` permission or the guild owner status to override this check with the following parameters.
 
 ```js
 const { Permissions } = require('discord.js');
@@ -101,7 +101,7 @@ As you have likely already seen in your desktop client, channel overwrites have 
 
 ### Adding overwrites
 
-To add a permission overwrite for a role or guild member, you access the channel's <DocsLink path="class/TextChannel?scrollTo=permissionOverwrites">PermissionOverwriteManager</DocsLink> and use the `.create()` method. The first parameter is the target of the overwrite, either a Role or User object (or its respective resolvable), and the second is a <DocsLink path="typedef/PermissionOverwriteOptions">PermissionOverwriteOptions</DocsLink> object.
+To add a permission overwrite for a role or guild member, you access the channel's <DocsLink path="class/TextChannel?scrollTo=permissionOverwrites">`PermissionOverwriteManager`</DocsLink> and use the `.create()` method. The first parameter is the target of the overwrite, either a Role or User object (or its respective resolvable), and the second is a <DocsLink path="typedef/PermissionOverwriteOptions" /> object.
 
 Let's add an overwrite to lock everyone out of the channel. The guild ID doubles as the role id for the default role `@everyone` as demonstrated below:
 
@@ -131,7 +131,7 @@ guild.channels.create('new-channel', {
 
 ### Editing overwrites
 
-To edit permission overwrites on the channel with a provided set of new overwrites, you can use the `.edit()` method. This method allows passing an array or Collection of <DocsLink path="class/PermissionOverwrites">PermissionOverwrites</DocsLink>.
+To edit permission overwrites on the channel with a provided set of new overwrites, you can use the `.edit()` method. This method allows passing an array or Collection of <DocsLink path="class/PermissionOverwrites" />.
 
 ```js
 channel.permissionOverwrites.edit([
@@ -148,7 +148,7 @@ channel.permissionOverwrites.edit([
 
 ### Replacing overwrites
 
-To replace all permission overwrites on the channel with a provided set of new overwrites, you can use the `.set()` method. This is extremely handy if you want to copy a channel's full set of overwrites to another one, as this method also allows passing an array or Collection of <DocsLink path="class/PermissionOverwrites">PermissionOverwrites</DocsLink>.
+To replace all permission overwrites on the channel with a provided set of new overwrites, you can use the `.set()` method. This is extremely handy if you want to copy a channel's full set of overwrites to another one, as this method also allows passing an array or Collection of <DocsLink path="class/PermissionOverwrites" />.
 
 ```js
 // copying overwrites from another channel
@@ -194,7 +194,7 @@ channel.lockPermissions()
 
 ### Permissions after overwrites
 
-There are two utility methods to easily determine the final permissions for a guild member or role in a specific channel: `.permissionsFor()` on the <DocsLink path="class/GuildChannel?scrollTo=permissionsFor">GuildChannel</DocsLink> class and `.permissionsIn()` on the <DocsLink path="GuildMember?scrollTo=permissionsIn">GuildMember</DocsLink> and <DocsLink path="class/Role?scrollTo=permissionsIn">Role</DocsLink> classes. Both return a <DocsLink path="class/Permissions">Permissions</DocsLink> object.
+There are two utility methods to easily determine the final permissions for a guild member or role in a specific channel: <DocsLink path="class/GuildChannel?scrollTo=permissionsFor" type="method" /> and <DocsLink path="class/GuildMember?scrollTo=permissionsIn" type="method" /> - <DocsLink path="class/Role?scrollTo=permissionsIn" type="method" />. All return a <DocsLink path="class/Permissions" /> object.
 
 To check your bot's permissions in the channel the command was used in, you could use something like this:
 
@@ -217,7 +217,7 @@ If you want to know how to work with the returned Permissions objects, keep read
 
 ## The Permissions object
 
-The <DocsLink path="class/Permissions">Permissions</DocsLink> object is a discord.js class containing a permissions bit field and a bunch of utility methods to manipulate it easily.
+The <DocsLink path="class/Permissions" /> object is a discord.js class containing a permissions bit field and a bunch of utility methods to manipulate it easily.
 Remember that using these methods will not manipulate permissions, but rather create a new instance representing the changed bit field.
 
 ### Displaying permission flags
@@ -259,7 +259,7 @@ const { Permissions } = require('discord.js');
 const permissions = new Permissions(268550160n);
 ```
 
-You can also use this approach for other <DocsLink path="typedef/PermissionResolvable">PermissionResolvable</DocsLink>s like flag arrays or flags.
+You can also use this approach for other <DocsLink path="typedef/PermissionResolvable" />s like flag arrays or flags.
 
 ```js
 const { Permissions } = require('discord.js');

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -377,7 +377,7 @@ message.reactions.removeAll()
 
 ### Removing reactions by emoji
 
-Removing reactions by emoji is easily done by using <DocsLink path="class/MessageReaction?scrollTo=remove">`MessageReaction.remove()`</DocsLink>.
+Removing reactions by emoji is easily done by using <DocsLink path="class/MessageReaction?scrollTo=remove" type="method" />.
 
 ```js
 message.reactions.cache.get('123456789012345678').remove()
@@ -387,7 +387,7 @@ message.reactions.cache.get('123456789012345678').remove()
 ### Removing reactions by user
 
 ::: tip
-If you are not familiar with <DocsLink section="collection" path="class/Collection?scrollTo=filter">`Collection.filter()`</DocsLink> and [`Map.has()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) take the time to understand what they do and then come back.
+If you are not familiar with <DocsLink section="collection" path="class/Collection?scrollTo=filter" type="method" /> and [`Map.has()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) take the time to understand what they do and then come back.
 :::
 
 Removing reactions by a user is not as straightforward as removing by emoji or removing all reactions. The API does not provide a method for selectively removing the reactions of a user. This means you will have to iterate through reactions that include the user and remove them.

--- a/guide/popular-topics/webhooks.md
+++ b/guide/popular-topics/webhooks.md
@@ -19,7 +19,7 @@ Bots receive webhook messages in a text channel as usual. You can detect if a we
 if (message.webhookId) return;
 ```
 
-If you would like to get the webhook object that sent the message, you can use <DocsLink path="class/Message?scrollTo=fetchWebhook">`Message#fetchWebhook`</DocsLink>.
+If you would like to get the webhook object that sent the message, you can use <DocsLink path="class/Message?scrollTo=fetchWebhook" type="method" />.
 
 ## Fetching webhooks
 
@@ -29,17 +29,17 @@ Webhook fetching will always make use of collections and Promises. If you do not
 
 ### Fetching all webhooks of a guild
 
-If you would like to get all webhooks of a guild you can use <DocsLink path="class/Guild?scrollTo=fetchWebhooks">`Guild#fetchWebhooks()`</DocsLink>. This will return a Promise which will resolve into a Collection of `Webhook`s.
+If you would like to get all webhooks of a guild you can use <DocsLink path="class/Guild?scrollTo=fetchWebhooks" type="method">. This will return a Promise which will resolve into a Collection of `Webhook`s.
 
 ### Fetching webhooks of a channel
 
-Webhooks belonging to a channel can be fetched using <DocsLink path="class/TextChannel?scrollTo=fetchWebhooks">`TextChannel#fetchWebhooks()`</DocsLink>. This will return a Promise which will resolve into a Collection of `Webhook`s. A collection will be returned even if the channel contains a single webhook. If you are certain the channel contains a single webhook, you can use <DocsLink section="collection" path="class/Collection?scrollTo=first">`Collection#first()`</DocsLink> on the Collection to get the webhook.
+Webhooks belonging to a channel can be fetched using <DocsLink path="class/TextChannel?scrollTo=fetchWebhooks" type="method" />. This will return a Promise which will resolve into a Collection of `Webhook`s. A collection will be returned even if the channel contains a single webhook. If you are certain the channel contains a single webhook, you can use <DocsLink section="collection" path="class/Collection?scrollTo=first" type="method" /> on the Collection to get the webhook.
 
 ### Fetching a single webhook
 
 #### Using client
 
-You can fetch a specific webhook using its `id` with <DocsLink path="class/Client?scrollTo=fetchWebhook">`Client#fetchWebhook()`</DocsLink>. You can obtain the webhook id by looking at its link, the number after `https://discord.com/api/webhooks/` is the `id`, and the part after that is the `token`.
+You can fetch a specific webhook using its `id` with <DocsLink path="class/Client?scrollTo=fetchWebhook" type="method" />. You can obtain the webhook id by looking at its link, the number after `https://discord.com/api/webhooks/` is the `id`, and the part after that is the `token`.
 
 #### Using the WebhookClient constructor
 
@@ -73,7 +73,7 @@ Once you are there, click on the `Create Webhook` / `New Webhook` button; this w
 
 ### Creating webhooks with discord.js
 
-Webhooks can be created with the <DocsLink path="class/TextChannel?scrollTo=createWebhook">`TextChannel#createWebhook()`</DocsLink> method.
+Webhooks can be created with the <DocsLink path="class/TextChannel?scrollTo=createWebhook" type="method" /> method.
 
 ```js
 channel.createWebhook('Some-username', {
@@ -85,7 +85,7 @@ channel.createWebhook('Some-username', {
 
 ## Editing webhooks
 
-You can edit Webhooks and WebhookClients to change their name, avatar, and channel using <DocsLink path="class/Webhook?scrollTo=edit">`Webhook#edit()`</DocsLink>.
+You can edit Webhooks and WebhookClients to change their name, avatar, and channel using <DocsLink path="class/Webhook?scrollTo=edit" type="method" />.
 
 ```js
 webhook.edit({
@@ -103,7 +103,7 @@ Webhooks can send messages to text channels, as well as fetch, edit, and delete 
 
 ### Sending messages
 
-Webhooks, like bots, can send up to 10 embeds per message. They can also send attachments and normal content. The <DocsLink path="class/Webhook?scrollTo=send">`Webhook#send()`</DocsLink> method used to send to a webhook is very similar to the method used for sending to a text channel. Webhooks can also choose how the username and avatar will appear when they send the message.
+Webhooks, like bots, can send up to 10 embeds per message. They can also send attachments and normal content. The <DocsLink path="class/Webhook?scrollTo=send" type="method" /> method used to send to a webhook is very similar to the method used for sending to a text channel. Webhooks can also choose how the username and avatar will appear when they send the message.
 
 Example using a WebhookClient:
 
@@ -159,7 +159,7 @@ client.login(token);
 
 ### Fetching messages
 
-You can use <DocsLink path="class/Webhook?scrollTo=fetchMessage">`Webhook#fetchMessage()`</DocsLink> to fetch messages previously sent by the Webhook.
+You can use <DocsLink path="class/Webhook?scrollTo=fetchMessage" type="method" /> to fetch messages previously sent by the Webhook.
 
 <!-- eslint-skip -->
 
@@ -169,7 +169,7 @@ const message = await webhookClient.fetchMessage('123456789012345678');
 
 ### Editing messages
 
-You can use <DocsLink path="class/Webhook?scrollTo=editMessage">`Webhook#editMessage()`</DocsLink> to edit messages previously sent by the Webhook.
+You can use <DocsLink path="class/Webhook?scrollTo=editMessage" type="method" /> to edit messages previously sent by the Webhook.
 
 <!-- eslint-skip -->
 
@@ -184,7 +184,7 @@ const message = await webhook.editMessage('123456789012345678', {
 
 ### Deleting messages
 
-You can use <DocsLink path="class/Webhook?scrollTo=deleteMessage">`Webhook#deleteMessage()`</DocsLink> to delete messages previously sent by the Webhook.
+You can use <DocsLink path="class/Webhook?scrollTo=deleteMessage" type="method" /> to delete messages previously sent by the Webhook.
 
 <!-- eslint-skip -->
 

--- a/guide/sharding/README.md
+++ b/guide/sharding/README.md
@@ -68,7 +68,7 @@ Let's say your bot is in a total of 3,600 guilds. Using the recommended shard co
 
 ## FetchClientValues
 
-One of the most common sharding utility methods you'll be using is <DocsLink path="class/ShardClientUtil?scrollTo=fetchClientValues">Shard#fetchClientValues</DocsLink>. This method retrieves a property on the Client object of all shards.
+One of the most common sharding utility methods you'll be using is <DocsLink path="class/ShardClientUtil?scrollTo=fetchClientValues" type="method" />. This method retrieves a property on the Client object of all shards.
 
 Take the following snippet of code:
 
@@ -109,7 +109,7 @@ client.on('interactionCreate', interaction => {
 
 ## BroadcastEval
 
-Next, check out another handy sharding method known as <DocsLink path="class/ShardClientUtil?scrollTo=broadcastEval">`Shard#broadcastEval`</DocsLink>. This method makes all of the shards evaluate a given method, which recieves a `client` and a `context` argument. The `client` argument refers to the Client object of the shard evaluating it. You can read about the `context` argument [here](/sharding/additional-information.md#eval-arguments).
+Next, check out another handy sharding method known as <DocsLink path="class/ShardClientUtil?scrollTo=broadcastEval" type="method" />. This method makes all of the shards evaluate a given method, which recieves a `client` and a `context` argument. The `client` argument refers to the Client object of the shard evaluating it. You can read about the `context` argument [here](/sharding/additional-information.md#eval-arguments).
 
 ```js
 client.shard

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -29,14 +29,14 @@ manager.spawn()
 
 As the property names imply, the `_eval` property is what the shard is attempting to evaluate, and the `_result` property is the output of said evaluation. However, these properties are only guaranteed if a _shard_ is sending a message. There will also be an `_error` property, should the evaluation have thrown an error.
 
-You can also send messages via `process.send('hello')`, which would not contain the same information. This is why the `.message` property's type is declared as `*` <DocsLink path="class/Shard?scrollTo=e-message">in the discord.js documentation</DocsLink>.
+You can also send messages via `process.send('hello')`, which would not contain the same information. This is why the `.message` property's type is declared as `*` in the <DocsLink path="class/Shard?scrollTo=e-message" /> documentation.
 
 ## Specific shards
 
 There might be times where you want to target a specific shard. An example would be to kill a specific shard that isn't working as intended. You can achieve this by taking the following snippet (in a command, preferably):
 
 ::: tip
-In discord.js v13, <DocsLink path="class/ShardClientUtil?scrollTo=ids">`client.shard`</DocsLink> can hold multiple ids. If you use the default sharding manager, the `.ids` array will only have one entry.
+In discord.js v13, <DocsLink path="class/ShardClientUtil?scrollTo=ids">`Client#shard`</DocsLink> can hold multiple ids. If you use the default sharding manager, the `.ids` array will only have one entry.
 :::
 
 ```js
@@ -45,7 +45,7 @@ client.shard.broadcastEval(c => {
 });
 ```
 
-If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <DocsLink path="class/ShardClientUtil?scrollTo=broadcastEval">Shard#broadcastEval</DocsLink> sends a message to **all** shards, so you have to check if it's on the shard you want.
+If you're using something like [PM2](http://pm2.keymetrics.io/) or [Forever](https://github.com/foreverjs/forever), this is an easy way to restart a specific shard. Remember, <DocsLink path="class/ShardClientUtil?scrollTo=broadcastEval" type="method" /> sends a message to **all** shards, so you have to check if it's on the shard you want.
 
 ## `ShardingManager#shardArgs` and `ShardingManager#execArgv`
 
@@ -87,7 +87,7 @@ function funcName(c, { arg }) {
 client.shard.broadcastEval(funcName, { context: { arg: 'arg' } });
 ```
 
-The <DocsLink path="typedef/BroadcastEvalOptions">`BroadcastEvalOptions`</DocsLink> typedef was introduced in discord.js v13 as the second parameter in `.broadcastEval()`.
+The <DocsLink path="typedef/BroadcastEvalOptions" /> typedef was introduced in discord.js v13 as the second parameter in `.broadcastEval()`.
 It accepts two properties: `shard` and `context`. The `context` property will be sent as the second argument to your function.
 
 In this small snippet, an argument is passed to the `funcName` function through this parameter.

--- a/guide/sharding/extended.md
+++ b/guide/sharding/extended.md
@@ -26,7 +26,7 @@ client.on('interactionCreate', interaction => {
 This will never work for a channel that lies on another shard. So, let's remedy this.
 
 ::: tip
-In discord.js v13, <DocsLink path="class/ShardClientUtil?scrollTo=ids">`client.shard`</DocsLink> can hold multiple ids. If you use the default sharding manager, the `.ids` array will only have one entry.
+In discord.js v13, <DocsLink path="class/ShardClientUtil?scrollTo=ids">`Client#shard`</DocsLink> can hold multiple ids. If you use the default sharding manager, the `.ids` array will only have one entry.
 :::
 
 ```js {4-13}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This updates the `<DocsLink>` component to accept a self-closing tag variant, making it easier to refer to classes and typedefs, keeping a consistent style wherever applicable. It now also formats text for events, methods, and static properties.

```html
<DocsLink path="class/Client" />
<DocsLink path="class/Client?scrollTo=e-ready" />
<DocsLink path="class/Intents?scrollTo=s-FLAGS" />
<DocsLink path="class/Interaction?scrollTo=isCommand" type="method" />
```

Results in:

```md
[`Client`](https://discord.js.org/#/docs/main/stable/class/Client)
[`Client#event:ready`](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-ready)
[`Intents.FLAGS`](https://discord.js.org/#/docs/main/stable/class/Intents?scrollTo=s-FLAGS)
[`Interaction#isCommand()`](https://discord.js.org/#/docs/main/stable/class/Interaction?scrollTo=isCommand)
```

This PR also updates the usage of the `<DocsLink>` component around all the pages. There are a few more pages that could eventually make use of this component in various places.