### PR TITLE
chore: Fix a typo (Discords => Discord's)

### DIFF
--- a/guide/popular-topics/permissions-extended.md
+++ b/guide/popular-topics/permissions-extended.md
@@ -26,7 +26,7 @@ Placing an overwrite to allow `SEND_MESSAGES` on a role will result in members w
 ## Elevated permissions
 
 If the guild owner enables the server's two-factor authentication option, everyone executing a specific subset of actions will need to have 2FA enabled on their account. As bots do not have 2FA themselves, you, as the application owner, will need to enable it on your account for your bot to work on those servers.
-Check out [Discords help article](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) if you need assistance with this.
+Check out [Discord's help article](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) if you need assistance with this.
 
 The permissions assigned to these actions are called "elevated permissions" and are: 
 `KICK_MEMBERS`, `BAN_MEMBERS`, `ADMINISTRATOR`, `MANAGE_CHANNELS`, `MANAGE_GUILD`, `MANAGE_MESSAGES`, `MANAGE_ROLES`, `MANAGE_WEBHOOKS` and `MANAGE_EMOJIS`.


### PR DESCRIPTION
This PR fixes a typo in the guide. "Discords" is incorrect, it should be "Discord's".