### PR TITLE
feat: Mention install discord-api-types in registering slash commands

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -14,9 +14,7 @@ Guild application commands are only available in the guild they were created in,
 
 In this section, we'll be using a script that is usable in conjunction with the slash command handler from the [command handling](/command-handling/) section.
 
-First off, install the [discord.js REST module](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) by running `npm install @discordjs/rest` in your terminal.
-
-Then, install the [Discord API Types](https://github.com/discordjs/discord-api-types) package by running `npm install discord-api-types` in your terminal.
+First off, install the [`@discord.js/rest`](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) and [`discord-api-types`](https://github.com/discordjs/discord-api-types/) by running `npm install @discordjs/rest discord-api-types ` in your terminal.
 
 <!-- eslint-skip -->
 

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -16,6 +16,8 @@ In this section, we'll be using a script that is usable in conjunction with the 
 
 First off, install the [discord.js REST module](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) by running `npm install @discordjs/rest` in your terminal.
 
+Then, install the [Discord API Types](https://github.com/discordjs/discord-api-types) package by running `npm install discord-api-types` in your terminal.
+
 <!-- eslint-skip -->
 
 ```js


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As per the PR being merged in discordjs/discord.js#6354, this PR makes the same change to the guide, because as explained in that PR, it will stop people trying to install `discord-api-types/v9` in their terminal, and explicitly states to install `discord-api-types`