### PR TITLE
Fix: Update the invite link structure and explanation

### DIFF
--- a/guide/preparations/adding-your-bot-to-servers.md
+++ b/guide/preparations/adding-your-bot-to-servers.md
@@ -25,17 +25,9 @@ If you get an error message saying "Bot requires a code grant", then head over i
 
 ## Creating and using your invite link
 
-To create your invite link you need to go in the `OAuth2` page of your app.
+To create an invite link, head back to the [My Apps](https://discord.com/developers/applications/me) page under the "Applications" section, click on your bot application, and open the OAuth2 page.
 
-Head back to the [My Apps](https://discord.com/developers/applications/me) page under the "Applications" section once again and click on your bot application, then go in the `OAuth2` section and do the following steps: 
-
-* In lower part of the page you can find a section named "SCOPES", in this section there are a bunch of check boxes, you need to select `bot` and `applications.commands`.
-* When you click on the `bot` scope a new section named "BOT PERMISSIONS" will appear, in this new section you can find new check boxes that rappresent the permission your bot will have in the server. Select all the permissions your bot need.
-* Then just click the `Copy` button in the "SCOPES" section
-
-::: tip
-If you want to grant all permissions to your bot just select `Administrator`.
-:::
+At the bottom of the page, you'll find Discord's OAuth2 URL generator. Select the `bot` and `applications.commands` options. Once you select the `bot` option, a list of permissions will appear, allowing you to configure the permissions your bot needs.
 
 To use this link just paste it in the browser and hit enter, you shuld see something like this (with your bot's username and avatar):
 

--- a/guide/preparations/adding-your-bot-to-servers.md
+++ b/guide/preparations/adding-your-bot-to-servers.md
@@ -9,18 +9,15 @@ Before you're able to see your bot in your own (or other) servers, you'll need t
 The basic version of one such link looks like this:
 
 ```
-https://discord.com/oauth2/authorize?client_id=123456789012345678&scope=bot+applications.commands
+https://discord.com/api/oauth2/authorize?client_id=123456789012345678&permissions=8&scope=bot%20applications.commands
 ```
 
 The structure of the url is quite simple:
 
 * The first part is just Discord's standard structure for authorizing an OAuth2 application (such as your bot application) for entry to a Discord server.
-* The second part that says `client_id=...` is to specify _which_ application you want to authorize. You'll need to replace this part with your client's ID to create a valid invite link. 
-* Lastly, the third part, which says `scope=bot+applications.commands`, specifies that you want to add this application as a Discord bot, with the ability to create Slash Commands.
-
-::: tip
-A `permissions` parameter also exists to restrict or guarantee the permission your bot will have on the server you are adding it to. For ease of use, it is recommended to use [this](https://discordapi.com/permissions.html) website.
-:::
+* The second part that says `client_id=...` is to specify _which_ application you want to authorize. You'll need to replace this part with your client's ID to create a valid invite link.
+* The third part, the one with `permissions=...`, describe what permissions your bot will have on the server you are adding it to.
+* Lastly, the fourth part, which says `scope=bot%20applications.commands`, specifies that you want to add this application as a Discord bot, with the ability to create Slash Commands.
 
 ::: warning
 If you get an error message saying "Bot requires a code grant", then head over into your application's settings and disable the "Require OAuth2 Code Grant" option. You usually shouldn't enable this checkbox unless you know why you need to.
@@ -28,9 +25,19 @@ If you get an error message saying "Bot requires a code grant", then head over i
 
 ## Creating and using your invite link
 
-As mentioned above, you'll need to replace the `client_id` parameter with your client's ID to generate your invite link. To find your app's ID, head back to the [My Apps](https://discord.com/developers/applications/me) page under the "Applications" section once again and click on your bot application.
+To create your invite link you need to go in the `OAuth2` page of your app.
 
-Insert your app's ID into the link template, and then access it in your browser. You should see something like this (with your bot's username and avatar):
+Head back to the [My Apps](https://discord.com/developers/applications/me) page under the "Applications" section once again and click on your bot application, then go in the `OAuth2` section and do the following steps: 
+
+* In lower part of the page you can find a section named "SCOPES", in this section there are a bunch of check boxes, you need to select `bot` and `applications.commands`.
+* When you click on the `bot` scope a new section named "BOT PERMISSIONS" will appear, in this new section you can find new check boxes that rappresent the permission your bot will have in the server. Select all the permissions your bot need.
+* Then just click the `Copy` button in the "SCOPES" section
+
+::: tip
+If you want to grant all permissions to your bot just select `Administrator`.
+:::
+
+To use this link just paste it in the browser and hit enter, you shuld see something like this (with your bot's username and avatar):
 
 ![Bot Authorization page](./images/bot-auth-page.png)
 

--- a/guide/preparations/adding-your-bot-to-servers.md
+++ b/guide/preparations/adding-your-bot-to-servers.md
@@ -29,7 +29,7 @@ To create an invite link, head back to the [My Apps](https://discord.com/develop
 
 At the bottom of the page, you'll find Discord's OAuth2 URL generator. Select the `bot` and `applications.commands` options. Once you select the `bot` option, a list of permissions will appear, allowing you to configure the permissions your bot needs.
 
-To use this link just paste it in the browser and hit enter, you shuld see something like this (with your bot's username and avatar):
+Grab the link via the "Copy" button and enter it in your browser. You should see something like this (with your bot's username and avatar):
 
 ![Bot Authorization page](./images/bot-auth-page.png)
 

--- a/guide/preparations/adding-your-bot-to-servers.md
+++ b/guide/preparations/adding-your-bot-to-servers.md
@@ -9,7 +9,7 @@ Before you're able to see your bot in your own (or other) servers, you'll need t
 The basic version of one such link looks like this:
 
 ```
-https://discord.com/api/oauth2/authorize?client_id=123456789012345678&permissions=8&scope=bot%20applications.commands
+https://discord.com/api/oauth2/authorize?client_id=123456789012345678&permissions=0&scope=bot%20applications.commands
 ```
 
 The structure of the url is quite simple:


### PR DESCRIPTION
The template link provided by the guide uses a different template than the one provided by discord's OAuth2 app page, so I modified it to use the one provided by discord. I also updated the URL part by part of the parsing by adding the explanation of the authorization part and I completely rewrote the link building part so that it explains hot to do it with OAuth2 page.

I think this is an easier and more reliable way to generate the invite link