### PR TITLE
Fix typo

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -14,7 +14,7 @@ Guild application commands are only available in the guild they were created in,
 
 In this section, we'll be using a script that is usable in conjunction with the slash command handler from the [command handling](/command-handling/) section.
 
-First off, install the [`@discord.js/rest`](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) and [`discord-api-types`](https://github.com/discordjs/discord-api-types/) by running `npm install @discordjs/rest discord-api-types ` in your terminal.
+First off, install the [`@discordjs/rest`](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) and [`discord-api-types`](https://github.com/discordjs/discord-api-types/) by running `npm install @discordjs/rest discord-api-types ` in your terminal.
 
 <!-- eslint-skip -->
 


### PR DESCRIPTION
In the description of how to register guild commands was the package `@discordjs/rest` mentioned. But it was written like so: `@discord.js/rest`, even tho it doesn't have a dot in discordjs.

**Please describe the changes this PR makes and why it should be merged:**
It changes a typo that could confuse others while they use this guide.
