### PR TITLE
fix: Update `guildBanAdd` parameters to version 13

### DIFF
--- a/guide/popular-topics/audit-logs.md
+++ b/guide/popular-topics/audit-logs.md
@@ -126,7 +126,7 @@ client.on('guildBanAdd', async ban => {
 	const banLog = fetchedLogs.entries.first();
 
 	// Perform a coherence check to make sure that there's *something*
-	if (!banLog) return console.log(`${user.tag} was banned from ${guild.name} but no audit log could be found.`);
+	if (!banLog) return console.log(`${ban.user.tag} was banned from ${ban.guild.name} but no audit log could be found.`);
 
 	// Now grab the user object of the person who banned the member
 	// Also grab the target of this action to double-check things
@@ -135,9 +135,9 @@ client.on('guildBanAdd', async ban => {
 	// Update the output with a bit more information
 	// Also run a check to make sure that the log returned was for the same banned member
 	if (target.id === user.id) {
-		console.log(`${user.tag} got hit with the swift hammer of justice in the guild ${guild.name}, wielded by the mighty ${executor.tag}`);
+		console.log(`${ban.user.tag} got hit with the swift hammer of justice in the guild ${ban.guild.name}, wielded by the mighty ${executor.tag}`);
 	} else {
-		console.log(`${user.tag} got hit with the swift hammer of justice in the guild ${guild.name}, audit log fetch was inconclusive.`);
+		console.log(`${ban.user.tag} got hit with the swift hammer of justice in the guild ${ban.guild.name}, audit log fetch was inconclusive.`);
 	}
 });
 ```

--- a/guide/popular-topics/audit-logs.md
+++ b/guide/popular-topics/audit-logs.md
@@ -109,16 +109,16 @@ client.on('guildMemberRemove', async member => {
 The logic for this will be very similar to the above kick example, except that this time, the `guildBanAdd` event will be used.
 
 ```js
-client.on('guildBanAdd', async (guild, user) => {
-	console.log(`${user.tag} got hit with the swift hammer of justice in the guild ${guild.name}.`);
+client.on('guildBanAdd', async ban => {
+	console.log(`${ban.user} got hit with the swift hammer of justice in the guild ${ban.guild.name}.`);
 });
 ```
 
 As was the case in the previous examples, you can see what happened, to whom it happened, but not who executed the action. Enter once again audit logs fetching limited to 1 entry and only the `MEMBER_BAN_ADD` type. The `guildBanAdd` listener then becomes:
 
 ```js {2-7,9-10,12-14,16-22}
-client.on('guildBanAdd', async (guild, user) => {
-	const fetchedLogs = await guild.fetchAuditLogs({
+client.on('guildBanAdd', async ban => {
+	const fetchedLogs = await ban.guild.fetchAuditLogs({
 		limit: 1,
 		type: 'MEMBER_BAN_ADD',
 	});

--- a/guide/popular-topics/audit-logs.md
+++ b/guide/popular-topics/audit-logs.md
@@ -110,7 +110,7 @@ The logic for this will be very similar to the above kick example, except that t
 
 ```js
 client.on('guildBanAdd', async ban => {
-	console.log(`${ban.user} got hit with the swift hammer of justice in the guild ${ban.guild.name}.`);
+	console.log(`${ban.user.tag} got hit with the swift hammer of justice in the guild ${ban.guild.name}.`);
 });
 ```
 

--- a/guide/popular-topics/audit-logs.md
+++ b/guide/popular-topics/audit-logs.md
@@ -134,7 +134,7 @@ client.on('guildBanAdd', async ban => {
 
 	// Update the output with a bit more information
 	// Also run a check to make sure that the log returned was for the same banned member
-	if (target.id === user.id) {
+	if (target.id === ban.user.id) {
 		console.log(`${ban.user.tag} got hit with the swift hammer of justice in the guild ${ban.guild.name}, wielded by the mighty ${executor.tag}`);
 	} else {
 		console.log(`${ban.user.tag} got hit with the swift hammer of justice in the guild ${ban.guild.name}, audit log fetch was inconclusive.`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `guildBanAdd` event's parameters still used version 12's parameters!