### PR TITLE
fix(popular-topics): `memberMention` with `memberNicknameMention`

### DIFF
--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -66,11 +66,11 @@ const relative = time(date, 'R');
 The Formatters also contain various methods to format Snowflakes into mentions.
 
 ```js
-const { userMention, memberMention, channelMention, roleMention } = require('@discordjs/builders');
+const { userMention, memberNicknameMention, channelMention, roleMention } = require('@discordjs/builders');
 const id = '123456789012345678';
 
 const user = userMention(id);
-const nickname = memberMention(id);
+const nickname = memberNicknameMention(id);
 const channel = channelMention(id);
 const role = roleMention(id);
 ```


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Replaces the method `memberMention` with `memberNicknameMention`.