### PR TITLE
feat(rest-api): use native URLSearchParams class for Urban Dictionary sample

### DIFF
--- a/code-samples/additional-info/rest-api/13/index.js
+++ b/code-samples/additional-info/rest-api/13/index.js
@@ -20,7 +20,7 @@ client.on('interactionCreate', async interaction => {
 		interaction.reply({ files: [file] });
 	} else if (commandName === 'urban') {
 		const term = interaction.options.getString('term');
-		const query = new URLSearchParams({ term }).toString();
+		const query = new URLSearchParams({ term });
 
 		const { list } = await fetch(`https://api.urbandictionary.com/v0/define?${query}`).then(response => response.json());
 

--- a/code-samples/additional-info/rest-api/13/index.js
+++ b/code-samples/additional-info/rest-api/13/index.js
@@ -1,6 +1,5 @@
 const { Client, Intents, MessageEmbed } = require('discord.js');
 const fetch = require('node-fetch');
-const querystring = require('querystring');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
@@ -21,7 +20,7 @@ client.on('interactionCreate', async interaction => {
 		interaction.reply({ files: [file] });
 	} else if (commandName === 'urban') {
 		const term = interaction.options.getString('term');
-		const query = querystring.stringify({ term });
+		const query = new URLSearchParams({ term }).toString();
 
 		const { list } = await fetch(`https://api.urbandictionary.com/v0/define?${query}`).then(response => response.json());
 

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -107,7 +107,7 @@ client.on('interactionCreate', async interaction => {
 });
 ```
 
-Here, we use JavaScript's native [URLSearchParams class](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to create a [query string](https://en.wikipedia.org/wiki/Query_string) for the URL so that the Urban Dictionary server can parse it and know what to search. Afterwards, we call `toString()` for it to become a string.
+Here, we use JavaScript's native [URLSearchParams class](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to create a [query string](https://en.wikipedia.org/wiki/Query_string) for the URL so that the Urban Dictionary server can parse it and know what to search.
 
 If you were to do `/urban hello world`, then the URL would become https://api.urbandictionary.com/v0/define?term=hello%20world since the string gets encoded.
 

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -99,7 +99,7 @@ client.on('interactionCreate', async interaction => {
 	// ...
 	if (commandName === 'urban') {
 		const term = interaction.options.getString('term');
-		const query = new URLSearchParams({ term }).toString();
+		const query = new URLSearchParams({ term });
 
 		const { list } = await fetch(`https://api.urbandictionary.com/v0/define?${query}`)
 			.then(response => response.json());

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -94,13 +94,12 @@ Urban Dictionary's API is available at https://api.urbandictionary.com/v0/define
 First, you're going to need to fetch data from the API. To do this, you'd do:
 
 ```js {1,5-11}
-const querystring = require('querystring');
 // ...
 client.on('interactionCreate', async interaction => {
 	// ...
 	if (commandName === 'urban') {
 		const term = interaction.options.getString('term');
-		const query = querystring.stringify({ term });
+		const query = new URLSearchParams({ term }).toString();
 
 		const { list } = await fetch(`https://api.urbandictionary.com/v0/define?${query}`)
 			.then(response => response.json());
@@ -108,7 +107,7 @@ client.on('interactionCreate', async interaction => {
 });
 ```
 
-Here, we use Node's native [querystring module](https://nodejs.org/api/querystring.html) to create a [query string](https://en.wikipedia.org/wiki/Query_string) for the URL so that the Urban Dictionary server can parse it and know what to search.
+Here, we use JavaScript's native [URLSearchParams class](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to create a [query string](https://en.wikipedia.org/wiki/Query_string) for the URL so that the Urban Dictionary server can parse it and know what to search. Afterwards, we call `toString()` for it to become a string.
 
 If you were to do `/urban hello world`, then the URL would become https://api.urbandictionary.com/v0/define?term=hello%20world since the string gets encoded.
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
See https://nodejs.org/api/querystring.html. The query-string module is considered legacy and therefore not recommended to use, even if it has not yet been deprecated. The `URLSearchParams` class can also achieve the same thing in this context and is tested to work (v16.6.x).