### PR TITLE
Typo: Removes extra space after codeblock

### DIFF
--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -14,7 +14,7 @@ Guild application commands are only available in the guild they were created in,
 
 In this section, we'll be using a script that is usable in conjunction with the slash command handler from the [command handling](/creating-your-bot/command-handling.md) section.
 
-First off, install the [`@discordjs/rest`](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) and [`discord-api-types`](https://github.com/discordjs/discord-api-types/) by running `npm install @discordjs/rest discord-api-types ` in your terminal.
+First off, install the [`@discordjs/rest`](https://github.com/discordjs/discord.js-modules/blob/main/packages/rest/) and [`discord-api-types`](https://github.com/discordjs/discord-api-types/) by running `npm install @discordjs/rest discord-api-types` in your terminal.
 
 <!-- eslint-skip -->
 


### PR DESCRIPTION
Removes extra space after an inline codeblock.
Before: if your application has the `applications.commands ` scope authorized.
After: if your application has the `application.commands` scope authorized.

**Please describe the changes this PR makes and why it should be merged:**
See above, just a typo fix.