### PR TITLE
Added Intents.FLAGS.GUILD_MESSAGES as an option

### DIFF
--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -10,7 +10,7 @@ Here are the base files and code we'll be using:
 const { Client, Intents } = require('discord.js');
 const { token } = require('./config.json');
 
-const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
+const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
 client.once('ready', () => {
 	console.log('Ready!');
@@ -123,7 +123,7 @@ const fs = require('fs');
 const { Client, Collection, Intents } = require('discord.js');
 const { token } = require('./config.json');
 
-const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
+const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
 client.commands = new Collection();
 ```


### PR DESCRIPTION
Added `Intents.FLAGS.GUILD_MESSAGES` as an intent option so that we can send messages through the BOT

With only `Intents.FLAGS.GUILD`, the BOT isn't able to send messages back to the Server. Adding the `Intents.FLAGS.GUILD_MESSAGES` as an option intent gets the job done

Kindly consider this change,
Thanking you
@GNVageesh