### PR TITLE
Update Playing music from YouTube section to require `GUILD_VOICE_STATES` intent

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -342,6 +342,11 @@ player.on(AudioPlayerStatus.Idle, () => connection.destroy());
 You can learn more about these methods in the [voice section of this guide](/voice)!
 :::
 
+::: warning
+This only works correctly if you have the `GUILD_VOICE_STATES` intent enabled for your application and client.
+If you want to learn more about intents, check out [this dedicated guide on intents](/popular-topics/intents.md)!
+:::
+
 ### Why do some emojis behave weirdly?
 
 If you've tried using [the usual method of retrieving unicode emojis](/popular-topics/reactions.md#unicode-emojis), you may have noticed that some characters don't provide the expected results. Here's a short snippet that'll help with that issue. You can toss this into a file of its own and use it anywhere you need! Alternatively feel free to simply copy-paste the characters from below:


### PR DESCRIPTION
Without the `GUILD_VOICE_STATES` intent, the bot account joins the specified voice channel, but is stuck in the **Signalling** state, never advancing to the **Connecting** or **Ready** state. Without this connection, the bot player switches to Idle immediately after `play` is called since there are no connections to play audio to. Adding this intent warning will greatly help developers who may not otherwise know where their code went wrong (like I certainly did).