### PR TITLE
fix: replace broken link

### DIFF
--- a/guide/whats-new.md
+++ b/guide/whats-new.md
@@ -56,7 +56,7 @@ All content has been updated to use discord.js v13 syntax. The v12 version of th
 
 - Commando: Removed, to be replaced with a guide on [Sapphire](https://github.com/discordjs/guide/pull/711)
 - [Voice](/voice/): Rewritten to use the [`@discordjs/voice`](https://github.com/discordjs/voice) package
-- [Command handling](/command-handling/): Updated to use slash commands
+- [Command handling](/creating-your-bot/command-handling.md/): Updated to use slash commands
 	- Obsolete sections removed
 - `client.on('message')` snippets updated to `client.on('interactionCreate')`
 	- [Message content will become a new priviledged intent in April 2022](https://support-dev.discord.com/hc/en-us/articles/4404772028055)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `Command Handling` hyperlink redirects to the old path, leading to a 404 error code, This PR replaces the old link with the new one.
