### PR TITLE
fix: set node-fetch install version to 2.6.5

### DIFF
--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -13,17 +13,17 @@ To install node-fetch, run the following command:
 :::: code-group
 ::: code-group-item npm
 ```sh:no-line-numbers
-npm install node-fetch
+npm install node-fetch@2.6.5
 ```
 :::
 ::: code-group-item yarn
 ```sh:no-line-numbers
-yarn add node-fetch
+yarn add node-fetch@2.6.5
 ```
 :::
 ::: code-group-item pnpm
 ```sh:no-line-numbers
-pnpm add node-fetch
+pnpm add node-fetch@2.6.5
 ```
 :::
 ::::


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
node-fetch v3 allows only esm code, to use require the version must be 2.6.5 (latest subversion of 2)