### PR TITLE
fix: "foollowing" -> "following"

### DIFF
--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -1,7 +1,7 @@
 # Builders
 
 discord.js provides the [`@discordjs/builders`](https://github.com/discordjs/builders) package which contains a variety of utilities you can use when writing your Discord bot.
-To install the package, run the foollowing command in your terminal:
+To install the package, run the following command in your terminal:
 
 :::: code-group
 ::: code-group-item npm


### PR DESCRIPTION
Fix a typo in the [`popular-topics/builders`](https://discordjs.guide/popular-topics/builders.html) page
> foollowing -> following
