### PR TITLE
Fix for SQL example on Sequelize guide

### DIFF
--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -111,7 +111,7 @@ To do that in Sequelize, you define a model based on this structure, as shown be
 ```js
 /*
  * equivalent to: CREATE TABLE tags(
- * name VARCHAR(255),
+ * name VARCHAR(255) UNIQUE,
  * description TEXT,
  * username VARCHAR(255),
  * usage_count  INT NOT NULL DEFAULT 0


### PR DESCRIPTION
* fix SQL query examples

* name VARCHAR(255) UNIQUE

**Please describe the changes this PR makes and why it should be merged:**
I believe this would make this line equivalent to the Sequelize code since the "name" is not unique on the SQL example.