### PR TITLE
feat(permissions): add deployment cause for missing access

### DIFF
--- a/guide/popular-topics/permissions-extended.md
+++ b/guide/popular-topics/permissions-extended.md
@@ -51,6 +51,7 @@ Causes for "Missing Access":
 - Text Channels require `VIEW_CHANNEL` as detailed above.
 - Voice Channels require `CONNECT` in the same way.
 - Reacting to a message requires `READ_MESSAGE_HISTORY` in the channel the message was sent.
+- When deploying slash commands: Enable the `applications.commands` scope (for more information see the [adding your bot](/preparations/adding-your-bot-to-servers) section).
 :::
 
 ## Limitations and oddities


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

With slash commands, a new cause for `Missing Access` has arrived. While this doesn't really fit into the "permissions" section, as it doesn't deal with permission checks, it is technically a permission and access-based API error and should probably be added under this heading, so it can easily be found via tags and guide search.