### PR TITLE
fix: missing thread event

### DIFF
--- a/guide/additional-info/changes-in-v13.md
+++ b/guide/additional-info/changes-in-v13.md
@@ -81,7 +81,7 @@ Refer to the [message components](/interactions/buttons.html) section of this gu
 
 discord.js now has support for threads! Threads are a new type of sub-channel that can be used to help separate conversations into a more meaningful flow.
 
-This introduces the `ThreadManager` class, which can be found as `TextChannel#threads`, in addition to `ThreadChannel`, `ThreadMemberManager`, and `ThreadMember`. There are also five new events: `threadCreate`, `threadDelete`, `threadListSync`, `threadMemberUpdate`, and `threadMembersUpdate`.
+This introduces the `ThreadManager` class, which can be found as `TextChannel#threads`, in addition to `ThreadChannel`, `ThreadMemberManager`, and `ThreadMember`. There are also five new events: `threadCreate`, `threadUpdate`, `threadDelete`, `threadListSync`, `threadMemberUpdate`, and `threadMembersUpdate`.
 
 Refer to the [threads](/popular-topics/threads.html) section of this guide to get started.
 


### PR DESCRIPTION
As raised in [#guide-discussion](https://canary.discord.com/channels/222078108977594368/682245563193884710/893718836350709781) one of the thread events was missing from this list.