### PR TITLE
fix(popular-topics): remove extra space at the manipulating permissions code block

### DIFF
--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -344,7 +344,7 @@ console.log(permissions.has(Permissions.FLAGS.KICK_MEMBERS));
 
 permissions.remove(Permissions.FLAGS.KICK_MEMBERS);
 console.log(permissions.has(Permissions.FLAGS.KICK_MEMBERS));
-// output : false
+// output: false
 ```
 
 You can utilize these methods to adapt permissions or overwrites without touching the other flags. To achieve this, you can get the existing permissions for a role, manipulating the bit field as described above and passing the changed bit field to `role.setPermissions()`.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There is an extra space, which makes it not consistent with the other comments. Perhaps the smallest change.
