### PR TITLE
fix: capitalisation CodeCademy -> Codecademy

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -21,7 +21,7 @@ If you don't know JavaScript but would like to learn about it, here are a few li
 
 * [Eloquent JavaScript, a free online book](http://eloquentjavascript.net/)
 * [JavaScript.info, a modern javascript tutorial](https://javascript.info/)
-* [CodeCademy's interactive JavaScript course](https://www.codecademy.com/learn/learn-javascript)
+* [Codecademy's interactive JavaScript course](https://www.codecademy.com/learn/learn-javascript)
 * [Nodeschool, for both JavaScript and Node.js lessons](https://nodeschool.io/)
 * [MDN's JavaScript guide and full documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 * [Google, your best friend](https://google.com)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes the capitalization error CodeCademy to Codecademy.