### PR TITLE
fix(preparations): capitalise app names

### DIFF
--- a/guide/preparations/README.md
+++ b/guide/preparations/README.md
@@ -35,8 +35,8 @@ On Windows, either:
 - Press `Win + R` and run `cmd.exe`, and then `cd` into your project directory
 
 On macOS, either:
-- Open launchpad or spotlight and search for "terminal"
-- In your "Applications" folder, under "Utilities", open the terminal app
+- Open Launchpad or Spotlight and search for "Terminal"
+- In your "Applications" folder, under "Utilities", open the Terminal app
 
 On Linux, you can quickly open the terminal with `Ctrl + Alt + T`.
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR capitalises the following app names for macOS:

- Launchpad
- Spotlight (Search)
- Terminal