### PR TITLE
fix: replace babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     },
     "homepage": "https://discordjs.guide",
     "devDependencies": {
+        "@babel/eslint-parser": "^7.15.8",
         "@vuepress/plugin-docsearch": "^2.0.0-beta.24",
         "@vuepress/plugin-google-analytics": "^2.0.0-beta.24",
-        "babel-eslint": "^10.0.1",
         "eslint": "^7.18.0",
         "eslint-config-sora": "^3.1.0",
-        "eslint-plugin-markdown": "^1.0.0",
+        "eslint-plugin-markdown": "^2.2.1",
         "eslint-plugin-vue": "^7.5.0",
         "vuepress-vite": "^2.0.0-beta.24"
     },


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

According to the following quote:

> npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.