### PR TITLE
Add note about stoping pm2 app

### DIFF
--- a/guide/improving-dev-environment/pm2.md
+++ b/guide/improving-dev-environment/pm2.md
@@ -55,6 +55,7 @@ The `pm2 start` command can take more optional parameters, but only these two ar
 Once the process launches with pm2, you can run `pm2 monit` to monitor all console outputs from the processes started by pm2. This accounts for any `console.log()` in your code or outputted errors.
 
 In a similar fashion to how you start the process, running `pm2 stop` will stop the current process without removing it from PM2's interface:
+
 ```sh:no-line-numbers
 pm2 stop your-app-name.js
 ```


### PR DESCRIPTION
It's a very small addition but it seemed odd to have no mention of how to stop it (despite it being somewhat obvious).

An argument could be made to add a little more in that running `start app-name` will now work without needing the file name; but I'm not sure if that's worth adding.
