### PR TITLE
create a subsection in Threads for send via webhook

### DIFF
--- a/guide/popular-topics/threads.md
+++ b/guide/popular-topics/threads.md
@@ -167,7 +167,7 @@ await thread.members.remove('140214425276776449');
 
 ## Sending messages to threads with webhooks
 
-It's possible for a webhook built on the parent channel to send messages to the channel's threads. For the purpose of this example, it is assumed a single webhook already exists for that channel. If you wish to learn more about webhooks, see our [webhook guide](/popular-topics/webhooks.md).
+It is possible for a webhook built on the parent channel to send messages to the channel's threads. For the purpose of this example, it is assumed a single webhook already exists for that channel. If you wish to learn more about webhooks, see our [webhook guide](/popular-topics/webhooks.md).
 
 ```js
 const webhooks = await channel.fetchWebhooks();


### PR DESCRIPTION
This addresses #914
The example is perhaps a little too long? I could see a valid argument made to simplify this by removing the requires, login, and listener; however it seems more apt to have in my mind.

I am also uncertain if my linking to the webhook page is done properly, do I link to the .md or .html file?

I also personally do not see the point in adding a link to this in the webhooks page, but can easily add it if it's deemed necessary.
