### PR TITLE
Typo correction: interation -> interaction

### DIFF
--- a/guide/creating-your-bot/creating-commands.md
+++ b/guide/creating-your-bot/creating-commands.md
@@ -96,7 +96,7 @@ You only need to run `node deploy-commands.js` once. You should only run it agai
 
 Once you've registered your commands, you can listen for interactions via <DocsLink path="class/Client?scrollTo=e-interactionCreate" /> in your `index.js` file.
 
-You should first check if an interation is a command via <DocsLink path="class/Interaction?scrollTo=isCommand" type="method">`.isCommand()`</DocsLink>, and then check the <DocsLink path="class/CommandInteraction?scrollTo=commandName">`.commandName`</DocsLink> property to know which command it is. You can respond to interactions with <DocsLink path="class/CommandInteraction?scrollTo=reply">`.reply()`</DocsLink>.
+You should first check if an interaction is a command via <DocsLink path="class/Interaction?scrollTo=isCommand" type="method">`.isCommand()`</DocsLink>, and then check the <DocsLink path="class/CommandInteraction?scrollTo=commandName">`.commandName`</DocsLink> property to know which command it is. You can respond to interactions with <DocsLink path="class/CommandInteraction?scrollTo=reply">`.reply()`</DocsLink>.
 
 ```js {5-17}
 client.once('ready', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This is just correcting a spelling mistake in the documentation:

* `interation` should be `interaction`.