### PR TITLE
Specify GUILD_VOICE_STATES intent requirement

### DIFF
--- a/guide/voice/voice-connections.md
+++ b/guide/voice/voice-connections.md
@@ -60,7 +60,7 @@ if (subscription) {
 ::: warning
 **Voice connections can be subscribed to one audio player at most.** If you try to subscribe to another audio player while already subscribed to one, the current audio player is unsubscribed and replaced with the new one.
 
-It is also worth noting that the **GUILD_VOICE_STATES** [gateway intent](https://discordjs.guide/popular-topics/intents.html#gateway-intents) is required. Without it, the connection will permanently stay in the `signalling` state, and you'll be unable to play audio.
+It is also worth noting that the **GUILD_VOICE_STATES** [gateway intent](/popular-topics/intents.md#gateway-intents) is required. Without it, the connection will permanently stay in the `signalling` state, and you'll be unable to play audio.
 :::
 
 ## Life cycle

--- a/guide/voice/voice-connections.md
+++ b/guide/voice/voice-connections.md
@@ -59,6 +59,8 @@ if (subscription) {
 
 ::: warning
 **Voice connections can be subscribed to one audio player at most.** If you try to subscribe to another audio player while already subscribed to one, the current audio player is unsubscribed and replaced with the new one.
+
+It is also worth noting that the **GUILD_VOICE_STATES** [gateway intent](https://discordjs.guide/popular-topics/intents.html#gateway-intents) is required. Without it, the connection will permanently stay in the `signalling` state, and you'll be unable to play audio.
 :::
 
 ## Life cycle


### PR DESCRIPTION
**Please describe the changes this PR makes:**
This PR adds a quick message to the warning area of the "Playing Audio" header in the Voice Connections page to specify that the GUILD_VOICE_STATES gateway intent is required to play audio. 

**Please describe why this PR should be merged:**
I think this PR should be merged as this would solve some confusion in the future. I had this problem for a while until finding this Reddit post: https://www.reddit.com/r/Discordjs/comments/pprpit/voice_connection_stuck_in_the_signalling_state/
