### PR TITLE
fix(misc): make parsing mention arguments more resilient

### DIFF
--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -89,7 +89,7 @@ const { MessageMentions: { USERS_PATTERN } } = require('discord.js');
 
 function getUserFromMention(mention) {
 	// The id is the first and only match found by the RegEx.
-	const matches = mention.match(USERS_PATTERN);
+	const matches = USERS_PATTERN.exec(mention);
 
 	// If supplied variable was not a mention, matches will be null instead of an array.
 	if (!matches) return;

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -89,7 +89,7 @@ const { MessageMentions: { USERS_PATTERN } } = require('discord.js');
 
 function getUserFromMention(mention) {
 	// The id is the first and only match found by the RegEx.
-	const matches = mention.matchAll(USERS_PATTERN).next().value
+	const matches = mention.matchAll(USERS_PATTERN).next().value;
 
 	// If supplied variable was not a mention, matches will be null instead of an array.
 	if (!matches) return;

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -89,7 +89,7 @@ const { MessageMentions: { USERS_PATTERN } } = require('discord.js');
 
 function getUserFromMention(mention) {
 	// The id is the first and only match found by the RegEx.
-	const matches = USERS_PATTERN.exec(mention);
+	const matches = mention.matchAll(USERS_PATTERN).next().value
 
 	// If supplied variable was not a mention, matches will be null instead of an array.
 	if (!matches) return;


### PR DESCRIPTION
fixes USERS_PATTERN regex return

This expression
```ts
const matches = mention.match(USERS_PATTERN);
```
may return the match without the actual id. This might cause confusion, as `matches[1]` does not exist.
We need to `exec` on that regex to include the capture groups: 
```ts
USERS_PATTERN.exec(mention)
```
which always returns the id found, if any

