### PR TITLE
Fix code example on Permissions

### DIFF
--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -44,7 +44,7 @@ Base permissions are set on roles, not the guild member itself. To change them, 
 ```js
 const { Permissions } = require('discord.js');
 
-guild.roles.everyone.setPermissions([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNELS]);
+guild.roles.everyone.setPermissions([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL]);
 ```
 
 Any permission not referenced in the flag array or bit field is not granted to the role. 


### PR DESCRIPTION
Example code uses `FLAGS.VIEW_CHANNELS` instead of `FLAGS.VIEW_CHANNEL`, where the property VIEW_CHANNELS from Permissions.FLAGS is nonexistent.
