### PR TITLE
fix(faq): Retrieve the user with `.fetch()` instead.

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -119,8 +119,10 @@ channel.send('content');
 
 ### How do I DM a specific user?
 
+<!-- eslint-skip -->
+
 ```js
-const user = client.users.cache.get('id');
+const user = await client.users.fetch('id');
 user.send('content');
 ```
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fetches user from API if user isn't present in cache.

Resolves #961.
