### PR TITLE
chore: Update `.setFooter()` usage

### DIFF
--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -77,7 +77,7 @@ const exampleEmbed = new MessageEmbed()
 	.addField('Inline field title', 'Some value here', true)
 	.setImage('https://i.imgur.com/AfFp7pu.png')
 	.setTimestamp()
-	.setFooter('Some footer text here', 'https://i.imgur.com/AfFp7pu.png');
+	.setFooter({ text: 'Some footer text here', iconURL: 'https://i.imgur.com/AfFp7pu.png' });
 
 channel.send({ embeds: [exampleEmbed] });
 ```


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`MessageEmbed#setFooter()` now takes a sole object.