### PR TITLE
chore(permissions-extended): Add in missing elevated permissions

### DIFF
--- a/guide/popular-topics/permissions-extended.md
+++ b/guide/popular-topics/permissions-extended.md
@@ -29,7 +29,7 @@ If the guild owner enables the server's two-factor authentication option, everyo
 Check out [Discord's help article](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication) if you need assistance with this.
 
 The permissions assigned to these actions are called "elevated permissions" and are: 
-`KICK_MEMBERS`, `BAN_MEMBERS`, `ADMINISTRATOR`, `MANAGE_CHANNELS`, `MANAGE_GUILD`, `MANAGE_MESSAGES`, `MANAGE_ROLES`, `MANAGE_WEBHOOKS` and `MANAGE_EMOJIS`.
+`KICK_MEMBERS`, `BAN_MEMBERS`, `ADMINISTRATOR`, `MANAGE_CHANNELS`, `MANAGE_GUILD`, `MANAGE_MESSAGES`, `MANAGE_ROLES`, `MANAGE_WEBHOOKS`, `MANAGE_THREADS`, and `MANAGE_EMOJIS_AND_STICKERS`.
 
 ## Implicit permissions
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This is just a small PR to add in the `MANAGE_THREADS` permission and rename `MANAGE_EMOJIS` to `MANAGE_EMOJIS_AND_STICKERS` in the elevated permissions section of the permissions-extended page.