### PR TITLE
Update Deprecated Method in Embeds Discord.js Guide (setFooter)

### DIFF
--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -77,7 +77,7 @@ const exampleEmbed = new MessageEmbed()
 	.addField('Inline field title', 'Some value here', true)
 	.setImage('https://i.imgur.com/AfFp7pu.png')
 	.setTimestamp()
-	.setFooter('Some footer text here', 'https://i.imgur.com/AfFp7pu.png');
+	.setFooter({text: 'Some footer text here', iconURL: 'https://i.imgur.com/AfFp7pu.png'});
 
 channel.send({ embeds: [exampleEmbed] });
 ```


### PR DESCRIPTION
Updated the old, deprecated `setFooter` method with the new method.