### PR TITLE
fix(slash-command-permissions): missing await

### DIFF
--- a/guide/interactions/slash-command-permissions.md
+++ b/guide/interactions/slash-command-permissions.md
@@ -33,7 +33,7 @@ Now you have successfully denied the user whose `id` you used access to this app
 ::: tip
 If you want to update permissions for a global command instead, your `command` variable would be:
 ```js
-const command = client.application?.commands.fetch('123456789012345678');
+const command = await client.application?.commands.fetch('123456789012345678');
 ```
 :::
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
[`<ApplicationCommandManager>#fetch()`](https://discord.js.org/#/docs/main/main/class/ApplicationCommandManager?scrollTo=fetch) returns a Promise