### PR TITLE
fix(DocsLink): using discord.js instead of main in docs section

### DIFF
--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -8,13 +8,13 @@
 import { computed } from 'vue';
 
 const baseURL = 'https://discord.js.org/#/docs';
-const docsSections = ['main', 'collection', 'rpc'];
+const docsSections = ['discord.js', 'collection', 'rpc'];
 const docsPathRegex = /\w+\/(\w+)(?:\?scrollTo=(.+))?/;
 
 const props = defineProps({
 	section: {
 		type: String,
-		'default': 'main',
+		'default': 'discord.js',
 	},
 	branch: String,
 	path: {
@@ -29,7 +29,7 @@ const props = defineProps({
 
 const link = computed(() => {
 	const guideSection = docsSections.find(section => section === props.section) || docsSections[0];
-	const branch = guideSection === 'main' ? 'stable' : props.branch || 'main';
+	const branch = guideSection === 'discord.js' ? 'stable' : props.branch || 'discord.js';
 	return `${baseURL}/${guideSection}/${branch}/${props.path}`;
 });
 

--- a/guide/.vuepress/config.ts
+++ b/guide/.vuepress/config.ts
@@ -39,7 +39,7 @@ const config = defineUserConfig<DefaultThemeOptions, ViteBundlerOptions>({
 			},
 			{
 				text: 'Documentation',
-				link: 'https://discord.js.org/#/docs/main/stable/general/welcome',
+				link: 'https://discord.js.org/#/docs/',
 			},
 		],
 		themePlugins: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Change `main` to `discord.js`, because when using `main` section the documentation website loads infinitely.