### PR TITLE
refactor: use the `node:` protocol

### DIFF
--- a/code-samples/.eslintrc.js
+++ b/code-samples/.eslintrc.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
 	'extends': path.join(__dirname, '..', '.eslintrc.js'),

--- a/code-samples/creating-your-bot/command-handling/deploy-commands.js
+++ b/code-samples/creating-your-bot/command-handling/deploy-commands.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('node:fs');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');

--- a/code-samples/creating-your-bot/command-handling/index.js
+++ b/code-samples/creating-your-bot/command-handling/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('node:fs');
 const { Client, Collection, Intents } = require('discord.js');
 const { token } = require('./config.json');
 

--- a/code-samples/creating-your-bot/event-handling/index.js
+++ b/code-samples/creating-your-bot/event-handling/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('node:fs');
 const { Client, Intents } = require('discord.js');
 const { token } = require('./config.json');
 

--- a/code-samples/popular-topics/permissions/13/index.js
+++ b/code-samples/popular-topics/permissions/13/index.js
@@ -1,4 +1,4 @@
-const util = require('util');
+const util = require('node:util');
 const { Client, Intents, Formatters, Permissions } = require('discord.js');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });

--- a/guide/.eslintrc.js
+++ b/guide/.eslintrc.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
 	'extends': path.join(__dirname, '..', '.eslintrc.js'),

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -139,7 +139,7 @@ If you need to access your client instance from inside a command file, you can a
 In your `index.js` file, make these additions:
 
 ```js {1-2,7}
-const fs = require('fs');
+const fs = require('node:fs');
 const { Client, Collection, Intents } = require('discord.js');
 const { token } = require('./config.json');
 
@@ -171,7 +171,7 @@ for (const file of commandFiles) {
 Use the same approach for your `deploy-commands.js` file, but instead `.push()` to the `commands` array with the JSON data for each command.
 
 ```js {1,7,9-12}
-const fs = require('fs');
+const fs = require('node:fs');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');

--- a/guide/interactions/buttons.md
+++ b/guide/interactions/buttons.md
@@ -206,7 +206,7 @@ In addition to deferring an interaction response, you can defer the button, whic
 <!-- eslint-skip -->
 
 ```js {7-9}
-const wait = require('util').promisify(setTimeout);
+const wait = require('node:util').promisify(setTimeout);
 
 // ...
 

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -40,7 +40,7 @@ pnpm add @discordjs/rest discord-api-types
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { token } = require('./config.json');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const commands = [];
 const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
@@ -176,4 +176,3 @@ const data = new SlashCommandBuilder()
 			.setName('server')
 			.setDescription('Info about the server'));
 ```
-

--- a/guide/interactions/replying-to-slash-commands.md
+++ b/guide/interactions/replying-to-slash-commands.md
@@ -96,7 +96,7 @@ After the initial response, an interaction token is valid for 15 minutes, so thi
 :::
 
 ```js {1,8-9}
-const wait = require('util').promisify(setTimeout);
+const wait = require('node:util').promisify(setTimeout);
 
 client.on('interactionCreate', async interaction => {
 	if (!interaction.isCommand()) return;
@@ -117,7 +117,7 @@ In this case, you can make use of the `CommandInteraction#deferReply()` method, 
 <!--- here either display the is thinking message via vue-discord-message or place a screenshot -->
 
 ```js {7-9}
-const wait = require('util').promisify(setTimeout);
+const wait = require('node:util').promisify(setTimeout);
 
 client.on('interactionCreate', async interaction => {
 	if (!interaction.isCommand()) return;

--- a/guide/interactions/select-menus.md
+++ b/guide/interactions/select-menus.md
@@ -169,7 +169,7 @@ client.on('interactionCreate', async interaction => {
 Additionally to deferring the response of the interaction, you can defer the menu, which will trigger a loading state and then revert back to its original state:
 
 ```js {1,6-10}
-const wait = require('util').promisify(setTimeout);
+const wait = require('node:util').promisify(setTimeout);
 
 client.on('interactionCreate', async interaction => {
 	if (!interaction.isSelectMenu()) return;

--- a/guide/voice/audio-resources.md
+++ b/guide/voice/audio-resources.md
@@ -9,8 +9,8 @@ Audio resources contain audio that can be played by an audio player to voice con
 There are many ways to create an audio resource. Below are some example scenarios:
 
 ```js
-const { createReadStream } = require('fs');
-const { join } = require('path');
+const { createReadStream } = require('node:fs');
+const { join } = require('node:path');
 const { createAudioResource, StreamType } = require('@discordjs/voice');
 
 // Basic, default options are:
@@ -102,7 +102,7 @@ The reason for this is that you can remove FFmpeg from the process of streaming 
 Both of the examples below will skip the FFmpeg component of the pipeline to improve performance.
 
 ```js
-const { createReadStream } = require('fs');
+const { createReadStream } = require('node:fs');
 const { createAudioResource, StreamType } = require('@discordjs/voice');
 
 let resource = createAudioResource(createReadStream('my_file.ogg'), {
@@ -127,7 +127,7 @@ advance what type of audio stream you'll be playing.
 This is achieved by probing a small chunk of the beginning of the audio stream to see if it is suitable for demuxing:
 
 ```js
-const { createReadStream } = require('fs');
+const { createReadStream } = require('node:fs');
 const { demuxProbe, createAudioResource } = require('@discordjs/voice');
 
 async function probeAndCreateResource(readableStream) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Use the `node:` protocol in all the `require()` calls that import a built-in node module.

I found all imports of fs, util and path, let me know if you find some other imported node module...