### PR TITLE
fix: Corrected a typo in OAuth guide

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -172,7 +172,7 @@ if (localStorage.getItem('oauth-state') !== atob(decodeURIComponent(state))) {
 ```
 
 ::: tip
-Don't forgo security for a tiny bit of convenience!
+Don't forget security for a tiny bit of convenience!
 :::
 
 ### Authorization code grant flow


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaced "forgo" with "forget" in the OAuth guide, it's an small typo but worth of correcting it