### PR TITLE
Fixed readDirSync path

### DIFF
--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -159,7 +159,7 @@ This next step is how to dynamically retrieve your command files. The [`fs.readd
 
 ```js {2,4-9}
 client.commands = new Collection();
-const commandFiles = fs.readdirSync(path.join(__dirname, './commands')).filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(path.join(__dirname, 'commands')).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -179,7 +179,7 @@ const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');
 
 const commands = [];
-const commandFiles = readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -152,7 +152,7 @@ client.commands = new Collection();
 We recommend attaching a `.commands` property to your client instance so that you can access your commands in other files. The rest of the examples in this guide will follow this convention.
 
 ::: tip
-[`fs`](https://nodejs.org/api/fs.html) is Node's native file system module. <DocsLink section="collection" path="class/Collection" /> is a class that extends JavaScript's native [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) class, and includes more extensive, useful functionality.
+[`fs`](https://nodejs.org/api/fs.html) is Node's native file system module. <DocsLink section="collection" path="class/Collection" /> is a class that extends JavaScript's native [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) class, and includes more extensive, useful functionality. [`path`](https://nodejs.org/api/path.html) allows for various formating of a uri path.
 :::
 
 This next step is how to dynamically retrieve your command files. The [`fs.readdirSync()`](https://nodejs.org/api/fs.html#fs_fs_readdirsync_path_options) method will return an array of all the file names in a directory, e.g. `['ping.js', 'beep.js']`. To ensure only command files get returned, use `Array.filter()` to leave out any non-JavaScript files from the array. With that array, loop over it and dynamically set your commands to the `client.commands` Collection.

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -179,7 +179,7 @@ const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');
 
 const commands = [];
-const commandFiles = fs.readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(path.join(__dirname, './commands')).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -152,7 +152,7 @@ client.commands = new Collection();
 We recommend attaching a `.commands` property to your client instance so that you can access your commands in other files. The rest of the examples in this guide will follow this convention.
 
 ::: tip
-[`fs`](https://nodejs.org/api/fs.html) is Node's native file system module. <DocsLink section="collection" path="class/Collection" /> is a class that extends JavaScript's native [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) class, and includes more extensive, useful functionality. [`path`](https://nodejs.org/api/path.html) allows for various formating of a uri path.
+[`fs`](https://nodejs.org/api/fs.html) is Node's native file system module, and  [`path`](https://nodejs.org/api/path.html) is used for working with file and directory paths. <DocsLink section="collection" path="class/Collection" /> is a class that extends JavaScript's native [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) class, and includes more extensive, useful functionality.
 :::
 
 This next step is how to dynamically retrieve your command files. The [`fs.readdirSync()`](https://nodejs.org/api/fs.html#fs_fs_readdirsync_path_options) method will return an array of all the file names in a directory, e.g. `['ping.js', 'beep.js']`. To ensure only command files get returned, use `Array.filter()` to leave out any non-JavaScript files from the array. With that array, loop over it and dynamically set your commands to the `client.commands` Collection.

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -140,7 +140,7 @@ In your `index.js` file, make these additions:
 
 ```js {1-2,7}
 const fs = require('fs');
-const path = require("path");
+const path = require('path');
 const { Client, Collection, Intents } = require('discord.js');
 const { token } = require('./config.json');
 

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -173,7 +173,7 @@ Use the same approach for your `deploy-commands.js` file, but instead `.push()` 
 
 ```js {1,7,9-12}
 const fs = require('fs');
-const path = require("path");
+const path = require('path');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -140,6 +140,7 @@ In your `index.js` file, make these additions:
 
 ```js {1-2,7}
 const fs = require('fs');
+const path = require("path");
 const { Client, Collection, Intents } = require('discord.js');
 const { token } = require('./config.json');
 
@@ -158,7 +159,7 @@ This next step is how to dynamically retrieve your command files. The [`fs.readd
 
 ```js {2,4-9}
 client.commands = new Collection();
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(path.join(__dirname, './commands')).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);
@@ -172,12 +173,13 @@ Use the same approach for your `deploy-commands.js` file, but instead `.push()` 
 
 ```js {1,7,9-12}
 const fs = require('fs');
+const path = require("path");
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');
 
 const commands = [];
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -44,7 +44,7 @@ const fs = require('fs');
 const path = require("path");
 
 const commands = [];
-const commandFiles = readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
 
 // Place your client and guild ids here
 const clientId = '123456789012345678';

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -41,9 +41,10 @@ const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { token } = require('./config.json');
 const fs = require('fs');
+const path = require("path");
 
 const commands = [];
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
 
 // Place your client and guild ids here
 const clientId = '123456789012345678';

--- a/guide/interactions/registering-slash-commands.md
+++ b/guide/interactions/registering-slash-commands.md
@@ -44,7 +44,7 @@ const fs = require('fs');
 const path = require("path");
 
 const commands = [];
-const commandFiles = fs.readdirSync(path.join(__dirname, "./commands")).filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(path.join(__dirname, './commands')).filter(file => file.endsWith('.js'));
 
 // Place your client and guild ids here
 const clientId = '123456789012345678';


### PR DESCRIPTION
It's a simple fix where in the guide, while creating the command handler, `fs.readdirSync('./commands')` throws `Error: ENOENT: no such file or directory, scandir './commands'`

Added `path.join(__dirname, "./commands")` to command handler in the guide.