### PR TITLE
refactor: use lowercase discord.js everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 	<img src="guide/images/branding/banner-blurple-small.png" title="discord.js Guide" alt="discord.js Guide" />
 </div>
 
-# discord.js Guide
+# Discord.js Guide
 
 Imagine a guide... that explores the many possibilities for your [discord.js](https://github.com/discordjs/discord.js) bot.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-	<img src="guide/images/branding/banner-blurple-small.png" title="Discord.js Guide" alt="Discord.js Guide" />
+	<img src="guide/images/branding/banner-blurple-small.png" title="discord.js Guide" alt="discord.js Guide" />
 </div>
 
-# Discord.js Guide
+# discord.js Guide
 
 Imagine a guide... that explores the many possibilities for your [discord.js](https://github.com/discordjs/discord.js) bot.
 

--- a/guide/.vuepress/config.ts
+++ b/guide/.vuepress/config.ts
@@ -8,7 +8,7 @@ const config = defineUserConfig<DefaultThemeOptions, ViteBundlerOptions>({
 	templateDev: path.join(__dirname, 'templates', 'index.dev.html'),
 	templateSSR: path.join(__dirname, 'templates', 'index.ssr.html'),
 	lang: 'en-US',
-	title: 'Discord.js Guide',
+	title: 'discord.js Guide',
 	description: 'Imagine a guide... that explores the many possibilities for your discord.js bot.',
 	head: [
 		['meta', { charset: 'utf-8' }],
@@ -16,7 +16,7 @@ const config = defineUserConfig<DefaultThemeOptions, ViteBundlerOptions>({
 		['link', { rel: 'icon', href: '/favicon.png' }],
 		['meta', { name: 'theme-color', content: '#3eaf7c' }],
 		['meta', { name: 'twitter:card', content: 'summary' }],
-		['meta', { property: 'og:title', content: 'Discord.js Guide' }],
+		['meta', { property: 'og:title', content: 'discord.js Guide' }],
 		['meta', { property: 'og:description', content: 'Imagine a guide... that explores the many possibilities for your discord.js bot.' }],
 		['meta', { property: 'og:type', content: 'website' }],
 		['meta', { property: 'og:url', content: 'https://discordjs.guide/' }],

--- a/guide/creating-your-bot/creating-commands.md
+++ b/guide/creating-your-bot/creating-commands.md
@@ -145,7 +145,7 @@ client.on('interactionCreate', async interaction => {
 		<template #interactions>
 			<DiscordInteraction profile="user" :command="true">server</DiscordInteraction>
 		</template>
-		Server name: Discord.js Guide
+		Server name: discord.js Guide
 		<br />
 		Total members: 2
 	</DiscordMessage>

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -1,6 +1,6 @@
 # Parsing mentions
 
-Discord.js is already geared to help you handle mentions using `message.mentions`.
+discord.js is already geared to help you handle mentions using `message.mentions`.
 However, there are situations where using `message.mentions` can lead to a few problems, in which case you may want to parse them on your own.  
 For example, you cannot tell where the mention is located in the message's content, or if the same user/role/channel was mentioned more than once.
 

--- a/guide/miscellaneous/parsing-mention-arguments.md
+++ b/guide/miscellaneous/parsing-mention-arguments.md
@@ -1,6 +1,6 @@
 # Parsing mentions
 
-discord.js is already geared to help you handle mentions using `message.mentions`.
+Discord.js is already geared to help you handle mentions using `message.mentions`.
 However, there are situations where using `message.mentions` can lead to a few problems, in which case you may want to parse them on your own.  
 For example, you cannot tell where the mention is located in the message's content, or if the same user/role/channel was mentioned more than once.
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The main site ([discord.js.org](https://discord.js.org)) uses lowercase discord.js, and so does the server. This pull request changes all "Discord.js" instances to "discord.js". I have no idea if this is going to break anything as getting up a local version didn't work for me, so the deploy preview is my friend :D

Deploy Preview: https://deploy-preview-1015--discordjs-guide.netlify.app/
Update: I think everything worked! 🎉
