### PR TITLE
fix: small grammer mistake

### DIFF
--- a/guide/preparations/README.md
+++ b/guide/preparations/README.md
@@ -12,7 +12,7 @@ On Windows, it's as simple as installing any other program. Download the latest 
 
 On macOS, either:
 
-- Download the latest version [the Node.js website](https://nodejs.org/), open the package installer, and follow the instructions
+- Download the latest version from [the Node.js website](https://nodejs.org/), open the package installer, and follow the instructions
 - Use a package manager like [Homebrew](https://brew.sh/) with the command `brew install node`
 
 On Linux, you can consult [this page](https://nodejs.org/en/download/package-manager/) to determine how you should install Node.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
> Download the latest version the Node.js website...

This does not makes sense as you can't download the latest version of *the node.js* **website**, while its clear that its nodejs which is to be installed here, adding a from just makes more sense and is also used above in the installation section for windows.

> ...Download the latest version **from** the Node.js website, open the downloaded file, and follow the steps from the installer.