### PR TITLE
fix: error commands folder not found because wrong path

### DIFF
--- a/code-samples/creating-your-bot/command-handling/deploy-commands.js
+++ b/code-samples/creating-your-bot/command-handling/deploy-commands.js
@@ -4,7 +4,7 @@ const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');
 
 const commands = [];
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(`${__dirname}/commands`).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -158,7 +158,7 @@ This next step is how to dynamically retrieve your command files. The [`fs.readd
 
 ```js {2,4-9}
 client.commands = new Collection();
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(`${__dirname}/commands`).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);
@@ -177,7 +177,7 @@ const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');
 
 const commands = [];
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = fs.readdirSync(`${__dirname}/commands`).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	const command = require(`./commands/${file}`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I build my app under `MyRootApp/src` folder, so if I only use './commands' it gives me an error, so I fix this by adding __dirname variable so that I can find the folder path dynamically