### PR TITLE
feat(faq): use optional chaining to access status

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -246,7 +246,7 @@ A User represents a global Discord user, and a GuildMember represents a Discord 
 ```js
 // First use guild.members.fetch to make sure all members are cached
 guild.members.fetch().then(fetchedMembers => {
-	const totalOnline = fetchedMembers.filter(member => member.presence.status === 'online');
+	const totalOnline = fetchedMembers.filter(member => member.presence?.status === 'online');
 	// Now you have a collection with all online member objects in the totalOnline variable
 	console.log(`There are currently ${totalOnline.size} members online in this guild!`);
 });

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -245,7 +245,7 @@ A User represents a global Discord user, and a GuildMember represents a Discord 
 
 ```js
 // First use guild.members.fetch to make sure all members are cached
-guild.members.fetch().then(fetchedMembers => {
+guild.members.fetch({ withPresences: true }).then(fetchedMembers => {
 	const totalOnline = fetchedMembers.filter(member => member.presence?.status === 'online');
 	// Now you have a collection with all online member objects in the totalOnline variable
 	console.log(`There are currently ${totalOnline.size} members online in this guild!`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since uncached presences would make `member.presence` return `null` i think this bit should be modified to use optional chaining and deal with that to avoid accessing null
