### PR TITLE
feat: replace 'canvas' with '@napi-rs/canvas'

### DIFF
--- a/code-samples/popular-topics/canvas/13/index.js
+++ b/code-samples/popular-topics/canvas/13/index.js
@@ -1,5 +1,7 @@
 const { Client, Intents, MessageAttachment } = require('discord.js');
-const Canvas = require('canvas');
+const { createCanvas, Image } = require('@napi-rs/canvas');
+const { readFile } = require('fs/promises');
+const { fetch } = require('undici');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
@@ -22,10 +24,12 @@ client.on('interactionCreate', async interaction => {
 	if (!interaction.isCommand()) return;
 
 	if (interaction.commandName === 'profile') {
-		const canvas = Canvas.createCanvas(700, 250);
+		const canvas = createCanvas(700, 250);
 		const context = canvas.getContext('2d');
 
-		const background = await Canvas.loadImage('./wallpaper.jpg');
+		const background = await readFile('./wallpaper.jpg');
+		const backgroundImage = new Image();
+		backgroundImage.src = background;
 		context.drawImage(background, 0, 0, canvas.width, canvas.height);
 
 		context.strokeStyle = '#0099ff';
@@ -44,10 +48,12 @@ client.on('interactionCreate', async interaction => {
 		context.closePath();
 		context.clip();
 
-		const avatar = await Canvas.loadImage(interaction.user.displayAvatarURL({ format: 'jpg' }));
+		const avatarRes = await fetch(interaction.user.displayAvatarURL({ format: 'jpg' }));
+		const avatar = new Image()
+		avatar.src = Buffer.from(await avatarRes.arrayBuffer());
 		context.drawImage(avatar, 25, 25, 200, 200);
 
-		const attachment = new MessageAttachment(canvas.toBuffer(), 'profile-image.png');
+		const attachment = new MessageAttachment(canvas.toBuffer('image/png'), 'profile-image.png');
 
 		interaction.reply({ files: [attachment] });
 	}

--- a/code-samples/popular-topics/canvas/13/index.js
+++ b/code-samples/popular-topics/canvas/13/index.js
@@ -1,7 +1,7 @@
 const { Client, Intents, MessageAttachment } = require('discord.js');
 const { createCanvas, Image } = require('@napi-rs/canvas');
 const { readFile } = require('fs/promises');
-const { fetch } = require('undici');
+const { request } = require('undici');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
@@ -48,9 +48,9 @@ client.on('interactionCreate', async interaction => {
 		context.closePath();
 		context.clip();
 
-		const avatarRes = await fetch(interaction.user.displayAvatarURL({ format: 'jpg' }));
+		const { body } = await request(interaction.user.displayAvatarURL({ format: 'jpg' }));
 		const avatar = new Image()
-		avatar.src = Buffer.from(await avatarRes.arrayBuffer());
+		avatar.src = Buffer.from(await body.arrayBuffer());
 		context.drawImage(avatar, 25, 25, 200, 200);
 
 		const attachment = new MessageAttachment(canvas.toBuffer('image/png'), 'profile-image.png');

--- a/code-samples/popular-topics/canvas/13/index.js
+++ b/code-samples/popular-topics/canvas/13/index.js
@@ -49,7 +49,7 @@ client.on('interactionCreate', async interaction => {
 		context.clip();
 
 		const { body } = await request(interaction.user.displayAvatarURL({ format: 'jpg' }));
-		const avatar = new Image()
+		const avatar = new Image();
 		avatar.src = Buffer.from(await body.arrayBuffer());
 		context.drawImage(avatar, 25, 25, 200, 200);
 

--- a/guide/popular-topics/canvas.md
+++ b/guide/popular-topics/canvas.md
@@ -14,7 +14,7 @@ Be sure that you're familiar with things like [async/await](/additional-info/asy
 
 ## Package installation
 
-After installing all the necessary software, run the following command in your terminal:
+Run the following command in your terminal:
 
 :::: code-group
 ::: code-group-item npm

--- a/guide/popular-topics/canvas.md
+++ b/guide/popular-topics/canvas.md
@@ -141,15 +141,15 @@ client.on('interactionCreate', async interaction => {
 A bit plain, right? Fear not, for you have a bit more to do until you reach completion. Since this guide page's goal is focused more on actual code than design, let's place a basic square-shaped avatar for now on the left side of the image. In the interest of coverage, you will also make it a circle afterward.
 
 ```js {5-9}
-const { fetch } = require('undici');
+const { request } = require('undici');
 
 client.on('interactionCreate', async interaction => {
 	// ...
 	context.strokeRect(0, 0, canvas.width, canvas.height);
 
-	const avatarRes = await fetch(interaction.user.displayAvatarURL({ format: 'jpg' }));
+	const { body } = await request(interaction.user.displayAvatarURL({ format: 'jpg' }));
 	const avatar = new Canvas.Image();
-	avatar.src = Buffer.from(await avatarRes.arrayBuffer());
+	avatar.src = Buffer.from(await body.arrayBuffer());
 
 	// Draw a shape onto the main canvas
 	context.drawImage(avatar, 25, 0, 200, canvas.height);
@@ -164,9 +164,9 @@ It works well, but the avatar image itself seems a bit stretched out. Let's reme
 ```js {5-6}
 client.on('interactionCreate', async interaction => {
 	// ...
-	const avatarRes = await fetch(interaction.user.displayAvatarURL({ format: 'jpg' }));
+	const { body } = await request(interaction.user.displayAvatarURL({ format: 'jpg' }));
 	const avatar = new Image();
-	avatar.src = Buffer.from(await avatarRes.arrayBuffer());
+	avatar.src = Buffer.from(await body.arrayBuffer());
 
 	// Move the image downwards vertically and constrain its height to 200, so that it's square
 	context.drawImage(avatar, 25, 25, 200, 200);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[@napi-rs/canvas](https://www.npmjs.com/package/@napi-rs/canvas) is similar to canvas but does not rely on postinstallation scripts (no node-gyp!!) which makes it much more useful for new developers or basically anyone that has ever tried debugging why a node-gyp error occurs. It supplies the same canvas api, along with some non-spec compliant apis such as `canvas.toBuffer(?mimeType)` that `canvas` has.

I'm unsure if this change is wanted but not having to deal with node-gyp anymore seems like a huge win IMO. 👍 

## Pros
- No post installation script, no build tools needed, etc...
- Less dependencies (faster start up for beginners, less time installing packages)
- Faster (doubt this really matters as this guide is aimed at beginners)

## Cons
- No `Canvas.loadImage` method, this is replaced by either using `readFile` from `fs/promises` for local files and with `undici` for third-party files. So I guess this PR depends on #1036?