### PR TITLE
fix: typo by escaping character

### DIFF
--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -294,7 +294,7 @@ else if (command === 'deletetag') {
 	// equivalent to: DELETE from tags WHERE name = ?;
 	const rowCount = await Tags.destroy({ where: { name: tagName } });
 
-	if (!rowCount) return interaction.reply('That tag doesn't exist.');
+	if (!rowCount) return interaction.reply('That tag doesn\'t exist.');
 
 	return interaction.reply('Tag deleted.');
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `'` must be escaped here as the string is enclosed between it so it must be escaped, an alternative is to make it "does not" 