### PR TITLE
Change button "custom_id" to "customId"

### DIFF
--- a/guide/interactions/buttons.md
+++ b/guide/interactions/buttons.md
@@ -246,5 +246,5 @@ Currently there are five different button styles available:
 </DiscordMessages>
 
 ::: warning
-Only `LINK` buttons can have a `url`. `LINK` buttons _cannot_ have a `custom_id` and _do not_ send an interaction event when clicked.
+Only `LINK` buttons can have a `url`. `LINK` buttons _cannot_ have a `customId` and _do not_ send an interaction event when clicked.
 :::


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This changes this warning's usage of `custom_id` to `customId` for consistency. 
`custom_id` might no longer exist too, but I'm not sure about that and this should be changed regardless.
