### PR TITLE
changed node-fetch install instructions

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -188,7 +188,7 @@ app.get('/', (request, response) => {
 });
 ```
 
-Now you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten these, head over to [your applications](https://discord.com/developers/applications) and get them. You can use [`node-fetch`](https://www.npmjs.com/package/node-fetch) to make requests to Discord; you can install it with `npm i node-fetch`.
+Now you have to exchange this code with Discord for an access token. To do this, you need your `client_id` and `client_secret`. If you've forgotten these, head over to [your applications](https://discord.com/developers/applications) and get them. You can use [`node-fetch`](https://www.npmjs.com/package/node-fetch) to make requests to Discord; you can install it with `npm i node-fetch@2`.
 
 Require `node-fetch` and make your request.
 


### PR DESCRIPTION
The node-fetch module is not importable through require() because it's a ESM module. Thus requiring node-fetch won't work. The creators of node-fetch offer another module that is importable like a commonJS module through require().
Reference: https://github.com/node-fetch/node-fetch#commonjs

**Please describe the changes this PR makes and why it should be merged:**
