### PR TITLE
Update autocomplete.md

### DIFF
--- a/guide/interactions/autocomplete.md
+++ b/guide/interactions/autocomplete.md
@@ -37,7 +37,7 @@ The <DocsLink path="class/AutocompleteInteraction" /> class provides the <DocsLi
 
 ### Sending results
 
-Using <DocsLink path="class/AutocompleteInteraction?scrollTo=respond" /> you can submit an array of <DocsLink path="typedef/ApplicationCommandOptionChoice" /> objects. Passing an empty array will show "No options match your search" for the user.
+Using <DocsLink path="class/AutocompleteInteraction?scrollTo=respond" /> you can submit an array of <DocsLink path="typedef/ApplicationCommandOptionChoiceData" /> objects. Passing an empty array will show "No options match your search" for the user.
 
 The <DocsLink path="class/CommandInteractionOptionResolver?scrollTo=getFocused" /> method returns the currently focused option's value. This value is used to filter the choices presented. To only display options starting with the focused value you can use the `Array#filter()` method. By using `Array#map()`, you can transform the array into an array of <DocsLink path="typedef/ApplicationCommandOptionChoice" /> objects.
 


### PR DESCRIPTION
Line 40, it is having a link to https://discord.js.org/#/docs/main/stable/typedef/ApplicationCommandOptionChoice which is wrong .
as per the https://discord.js.org/#/docs/main/stable/class/AutocompleteInteraction?scrollTo=respond , it should have the link to https://discord.js.org/#/docs/main/stable/typedef/ApplicationCommandOptionChoiceData

**Please describe the changes this PR makes and why it should be merged:**

Line 40, it is having a link to [ApplicationCommandOptionChoice](https://discord.js.org/#/docs/main/stable/typedef/ApplicationCommandOptionChoice) which is wrong.
As per the [AutocompleteInteraction#respond](https://discord.js.org/#/docs/main/stable/class/AutocompleteInteraction?scrollTo=respond) , it should have the link to [ApplicationCommandOptionChoiceData](https://discord.js.org/#/docs/main/stable/typedef/ApplicationCommandOptionChoiceData)

i forgot to done one more change in line 42, in line 42 to also same change needs to be done