### PR TITLE
Correct code group syntax in OAuth2 Page

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -190,26 +190,21 @@ To install undici, run the following command:
 
 :::: code-group
 ::: code-group-item npm
-
 ```sh:no-line-numbers
 npm install undici
 ```
-
 :::
 ::: code-group-item yarn
-
 ```sh:no-line-numbers
 yarn add undici
 ```
-
 :::
 ::: code-group-item pnpm
-
 ```sh:no-line-numbers
 pnpm add undici
 ```
-
 :::
+::::
 
 Require `undici` and make your request.
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The syntax for the code group located in the [OAuth2](https://discordjs.guide/oauth2/) guide was malformed which led to the rest of the page not being loaded.

This pull request resolves #1167.