### PR TITLE
Useless part of the code was removed

### DIFF
--- a/guide/interactions/buttons.md
+++ b/guide/interactions/buttons.md
@@ -185,15 +185,13 @@ The `MessageComponentInteraction` class provides an `update()` method to update 
 
 <!-- eslint-skip -->
 
-```js {6-8}
+```js {6}
 const filter = i => i.customId === 'primary' && i.user.id === '122157285790187530';
 
 const collector = interaction.channel.createMessageComponentCollector({ filter, time: 15000 });
 
 collector.on('collect', async i => {
-	if (i.customId === 'primary') {
-		await i.update({ content: 'A button was clicked!', components: [] });
-	}
+	await i.update({ content: 'A button was clicked!', components: [] });
 });
 
 collector.on('end', collected => console.log(`Collected ${collected.size} items`));


### PR DESCRIPTION
I have edited the following code from [this article](https://discordjs.guide/interactions/buttons.html#updating-the-button-message):
```js
const filter = i => i.customId === 'primary' && i.user.id === '122157285790187530';

const collector = interaction.channel.createMessageComponentCollector({ filter, time: 15000 });

collector.on('collect', async i => {
	if (i.customId === 'primary') {
		await i.update({ content: 'A button was clicked!', components: [] });
	}
});
```
When creating the collector, the `filter` function was used, because of which the collector will only collect components whose `customId` is `'primary'`. Therefore, the additional check `if (i.customId === 'primary')` is useless here.