### PR TITLE
fix(useful-packages): fix pino-pretty script example

### DIFF
--- a/guide/miscellaneous/useful-packages.md
+++ b/guide/miscellaneous/useful-packages.md
@@ -208,7 +208,7 @@ We recommend you set `pino-pretty` up in a package script in your `package.json`
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"start": "node .",
 		"lint": "eslint .",
-		"dev": "node . | pino-pretty -i pid,hostname -t yyyy-mm-dd HH:MM:ss"
+		"dev": "node . | pino-pretty -i pid,hostname -t 'yyyy-mm-dd HH:MM:ss'"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the tutorial of [pino-pretty](https://discordjs.guide/miscellaneous/useful-packages.html#pino) example script, it sets the custom time format `yyyy-mm-dd HH:MM:ss`, but as the argument value contains space so the output will only shows the date.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/2935980/178178460-10d021bd-1c0f-450c-8225-1f77a7f5a329.png">

This PR adds quotes around the value to apply the expected format.

<img width="527" alt="image" src="https://user-images.githubusercontent.com/2935980/178178497-15ec86bc-dccb-4e9e-9bdf-b061e9356ec0.png">
