### PR TITLE
change unsafe builders to disable/enableValidators

### DIFF
--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -142,6 +142,8 @@ Similarly to channels, some interaction type guards have been removed, and repla
 
 Builders are no longer returned by the API like they were previously. For example you send the API an `EmbedBuilder` but you receive an `Embed` of the same data from the API. This may affect how your code handles received structures such as components. Refer to [message component changes section](#messagecomponent) for more details.
 
+Added `disableValidators()` and `enableValidators()` as top-level exports which disable or enable validation (enabled by default).
+
 ### Consolidation of `create()` & `edit()` parameters
 
 Various `create()` and `edit()` methods on managers and objects have had their parameters consolidated. The changes are below:
@@ -480,10 +482,6 @@ Many of the analogous enums can be found in the discord-api-types docs. [discord
 ### AutocompleteInteraction
 
 `AutocompleteInteraction#commandGuildId` has been added which is the id of the guild the invoked application command is registered to.
-
-### Builders
-
-Added `disableValidators()` and `enableValidators()` as top-level exports which disable or enable validation (enabled by default).
 
 ### Channel
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -483,7 +483,7 @@ Many of the analogous enums can be found in the discord-api-types docs. [discord
 
 ### Builders
 
-Added `disableValidators()` and `enableValidators()` which disables or enables validation (enabled by default).
+Added `disableValidators()` and `enableValidators()` as top-level exports which disable or enable validation (enabled by default).
 
 ### Channel
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -481,6 +481,10 @@ Many of the analogous enums can be found in the discord-api-types docs. [discord
 
 `AutocompleteInteraction#commandGuildId` has been added which is the id of the guild the invoked application command is registered to.
 
+### Builders
+
+Added `disableValidators()` and `enableValidators()` which disables or enables validation (enabled by default).
+
 ### Channel
 
 Store channels have been removed as they are no longer part of the API.
@@ -529,10 +533,6 @@ Added `Interaction#isRepliable()` to check whether a given interaction can be re
 ### MessageReaction
 
 Added `MessageReaction#react()` to make the client user react with the reaction the class belongs to.
-
-### Unsafe Builders
-
-Unsafe builders operate exactly like regular builders except they perform no validation on input. Unsafe builders are named by adding an `Unsafe` prefix to a regular builder.
 
 ### Webhook
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Unsafe builders got removed a while ago
- discordjs/discord.js#8074