### PR TITLE
Fix ThreadMembersUpdate typo

### DIFF
--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -272,7 +272,7 @@ The `message` and `interaction` events are now removed. Use `messageCreate` and 
 
 `applicationCommandCreate`, `applicationCommandDelete` and `applicationCommandUpdate` have all been removed. See [this pull request](https://github.com/discordjs/discord.js/pull/6492) for more information.
 
-The `ThreadMembersUpdate` event now emits the users who were added, the users who were removed, and the thread respectively.
+The `threadMembersUpdate` event now emits the users who were added, the users who were removed, and the thread respectively.
 
 ### GuildBanManager
 


### PR DESCRIPTION
Fix minor typo; rename `ThreadMembersUpdate` event to `threadMembersUpdate`. Prevents any misunderstandings.