### PR TITLE
fix(mention-user-by-Id)

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -139,7 +139,7 @@ If you want to DM the user who sent the interaction, you can use `interaction.us
 ```js
 const user = interaction.options.getUser('target');
 await interaction.reply(`Hi, ${user}.`);
-await interaction.followUp('Hi, <@user id>.');
+await interaction.followUp(`Hi, <@{user.id}>.`);
 ```
 
 ::: tip


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I believe the guide is trying to convey that you can mention users by formatting their Ids in a certain way, currently this method is incomplete.

Interestingly, this typo dates back to the [v11](https://v12.discordjs.guide/popular-topics/faq.html#how-do-i-mention-a-specific-user-in-a-message) guide.
