### PR TITLE
Mention Util change

### DIFF
--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -469,7 +469,7 @@ Usage is now as follows:
 
 `Util.resolveAutoArchiveMaxLimit()` has been removed. Discord has since allowed any guild to use any auto archive time which makes this method redundant.
 
-Other functions in `Util` have been moved to top level so you can directly import them from `discord.js`
+Other functions in `Util` have been moved to top-level exports so you can directly import them from `discord.js`.
 
 ```diff
 - import { Util } from 'discord.js';

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -469,6 +469,15 @@ Usage is now as follows:
 
 `Util.resolveAutoArchiveMaxLimit()` has been removed. Discord has since allowed any guild to use any auto archive time which makes this method redundant.
 
+Other functions in `Util` have been moved to top level so you can directly import them from `discord.js`
+
+```diff
+- import { Util } from 'discord.js';
+- Util.escapeMarkdown(message);
++ import { escapeMarkdown } from 'discord.js';
++ escapeMarkdown(message);
+```
+
 ### `.deleted` Field(s) have been removed
 
 You can no longer use the `deleted` property to check if a structure was deleted. See [this issue](https://github.com/discordjs/discord.js/issues/7091) for more information.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Following https://github.com/discordjs/discord.js/pull/8052, the migration guide does not mention that the functions in `Util` are now top level exports
