### PR TITLE
fix(faq): $ in template literal

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -139,7 +139,7 @@ If you want to DM the user who sent the interaction, you can use `interaction.us
 ```js
 const user = interaction.options.getUser('target');
 await interaction.reply(`Hi, ${user}.`);
-await interaction.followUp(`Hi, <@{user.id}>.`);
+await interaction.followUp(`Hi, <@${user.id}>.`);
 ```
 
 ::: tip


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Ironically, #1197 was incorrect too. I missed the `$` completing the template literal.
