### PR TITLE
Warn users of change from component collector `"BUTTON"` to `ComponentType.Button`

### DIFF
--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -103,6 +103,17 @@ const button = {
 }
 ```
 
+```diff
++ const { ComopnentType } = require('discord.js');
+
+const collector = interaction.channel.createMessageComponentCollector({
+	filter,
+-	componentType: 'BUTTON',
++	componentType: ComponentType.Button,
+	time: 20000
+});
+```
+
 ### Removal of method-based type guards
 
 #### Channels

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -103,17 +103,6 @@ const button = {
 }
 ```
 
-```diff
-+ const { ComponentType } = require('discord.js');
-
-const collector = interaction.channel.createMessageComponentCollector({
-	filter,
--	componentType: 'BUTTON',
-+	componentType: ComponentType.Button,
-	time: 20000
-});
-```
-
 ### Removal of method-based type guards
 
 #### Channels
@@ -533,6 +522,19 @@ Additionally, new typeguards have been added:
 ### Collector
 
 A new `ignore` event has been added which is emitted whenever an element is not collected by the collector.
+
+Component collector options now use the `ComponentType` enum values:
+
+```diff
++ const { ComponentType } = require('discord.js');
+
+const collector = interaction.channel.createMessageComponentCollector({
+	filter,
+-	componentType: 'BUTTON',
++	componentType: ComponentType.Button,
+	time: 20000
+});
+```
 
 ### CommandInteraction
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -104,7 +104,7 @@ const button = {
 ```
 
 ```diff
-+ const { ComopnentType } = require('discord.js');
++ const { ComponentType } = require('discord.js');
 
 const collector = interaction.channel.createMessageComponentCollector({
 	filter,


### PR DESCRIPTION
This tripped me up for a few hours; the v14 discord API wasn't complaining that I was using `"BUTTON"` over `ComponentType.Button` like it would when I used `"PRIMARY"` over `ButtonStyle.Primary`. I feel like this could save others some time! Thanks.
