### PR TITLE
fix(Embeds): Use raw embed timestamp

### DIFF
--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -150,7 +150,7 @@ const exampleEmbed = {
 	image: {
 		url: 'https://i.imgur.com/AfFp7pu.png',
 	},
-	timestamp: new Date(),
+	timestamp: new Date().toISOString(),
 	footer: {
 		text: 'Some footer text here',
 		icon_url: 'https://i.imgur.com/AfFp7pu.png',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
On https://discordjs.guide/popular-topics/embeds.html#using-an-embed-object, the raw API data for the embed is not in an ISO 8601 format. This pull request modifies that.