### PR TITLE
refactor(faq): use consistent examples

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -21,12 +21,12 @@ guild.members.ban(user);
 ### How do I unban a user?
 
 ```js
-const id = interaction.options.get('target')?.value;
-guild.members.unban(id);
+const user = interaction.options.getUser('target');
+guild.members.unban(user);
 ```
 
 ::: tip
-Because you cannot ping a user who isn't in the server, you have to pass in the user id. To do this, we use a <DocsLink path="typedef/CommandInteractionOption" />. See [here](/interactions/slash-commands.html#parsing-options) for more information on this topic.
+The <DocsLink path="class/CommandInteractionOptionResolver?scrollTo=getUser" /> method parses user ids into <DocsLink path="class/User" /> instances even if the target is not in the server where the command is used.
 :::
 
 ### How do I kick a guild member?

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -26,7 +26,7 @@ guild.members.unban(user);
 ```
 
 ::: tip
-The <DocsLink path="class/CommandInteractionOptionResolver?scrollTo=getUser" /> method parses user ids into <DocsLink path="class/User" /> instances even if the target is not in the server where the command is used.
+Discord validates and resolves user ids for users not on the server in user slash command options. To retrieve and use the full structure from the resulting interaction, you can use the <DocsLink path="class/CommandInteractionOptionResolver?scrollTo=getUser" /> method.
 :::
 
 ### How do I kick a guild member?


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The original section for "How do I unban a user?" uses `<CommandInteractionOptionResolver>.get(...).value` instead of `<CommandInteractionOptionResolver>.getUser(...)` which is inconsistent with the nearby section regarding banning users.  This corrects that, and it rewrites the tip that was originally based on message commands instead of slash commands.