### PR TITLE
typo(permissions): Fix Permission flag typo

### DIFF
--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -263,7 +263,7 @@ You can also use this approach for other <DocsLink path="typedef/PermissionResol
 const { PermissionsBitField } = require('discord.js');
 
 const flags = [
-	PermissionsBitField.Flags.ViewChannels,
+	PermissionsBitField.Flags.ViewChannel,
 	PermissionsBitField.Flags.EmbedLinks,
 	PermissionsBitField.Flags.AttachFiles,
 	PermissionsBitField.Flags.ReadMessageHistory,


### PR DESCRIPTION
This PR fixed a typo that's barely noticeable. As of the making of this PR, there is no permission flag named `ViewChannels`, as per what was previously stated in this section. It is most likely that the intended permission flag is `ViewChannel` (singular). This PR should be merged to avoid confusing readers with code that directly contradicts a previous statement made in the guide.