### PR TITLE
Mention `restWsBridgeTimeout` in the v14 upgrade documentation

### DIFF
--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -234,6 +234,10 @@ The following type guards have been removed:
 
 Refer to [this section](#channels) for more context.
 
+### Client
+
+The `restWsBridgeTimeout` client option has been removed.
+
 ### CommandInteractionOptionResolver
 
 `CommandInteractionOptionResolver#getMember()` no longer has a parameter for `required`. See [this pull request](https://github.com/discordjs/discord.js/pull/7188) for more information.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
https://github.com/discordjs/discord.js/pull/7076 removed ClientOptions#restWsBridgeTimeout, but this was previously not mentioned in the v13->v14 upgrade guide. This PR adds it.