### PR TITLE
Add autocomplete choice limit (25) to documentation

### DIFF
--- a/guide/interactions/autocomplete.md
+++ b/guide/interactions/autocomplete.md
@@ -91,3 +91,4 @@ client.on('interactionCreate', async interaction => {
 - You have to respond to the request within 3 seconds, as with other application command interactions.
 - You cannot defer the response to an autocomplete interaction.
 - After the user selects a value and sends the command, it will be received as a <DocsLink path="class/ChatInputCommandInteraction"/> with the chosen value.
+- You can only respond with a maximum of 25 choices at a time.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Change autocomplete documentation to inform readers that the maximum number of choices they can respond with is 25. 
As a user myself, I faced issues with the implementation of my bot because I assumed the limit would be higher.

I could not find this limit detailed in the discord documentation, but discord.js replies with an detailed error when you send more than 25 options:

```
DiscordAPIError[50035]: Invalid Form Body
data.choices[BASE_TYPE_MAX_LENGTH]: Must be 25 or fewer in length.
```


Please feel free to suggest grammar/wording improvements, as I am not a native English speaker.