### PR TITLE
chore: Mention deleteMessageSeconds instead of deleteMessageDays

### DIFF
--- a/guide/additional-info/changes-in-v13.md
+++ b/guide/additional-info/changes-in-v13.md
@@ -1032,6 +1032,17 @@ Now supports setting the parent of multiple channels, and locking their permissi
 
 Provides improved API support for handling and caching bans.
 
+Starting from 13.11, developers should utilise `deleteMessageSeconds` instead of `days`:
+
+```diff
+<GuildBanManager>.create('123456789', {
+-  days: 3
++  deleteMessageSeconds: 3 * 24 * 60 * 60
+});
+```
+
+`days` is deprecated and will be removed in the future.
+
 ### GuildChannel
 
 #### GuildChannel#clone

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -280,7 +280,7 @@ The `threadMembersUpdate` event now emits the users who were added, the users wh
 
 ### GuildBanManager
 
-The `days` option when banning a user has been removed. Use `deleteMessageSeconds` instead.
+The `days` option when banning a user has been removed. Use `deleteMessageSeconds` instead which, as named, takes seconds instead of the number of days.
 
 ### Guild
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -280,7 +280,7 @@ The `threadMembersUpdate` event now emits the users who were added, the users wh
 
 ### GuildBanManager
 
-Staring from 14.4.0, developers should utilise `deleteMessageSeconds` instead of `days` and `deleteMessageDays`:
+Starting from 14.4.0, developers should utilise `deleteMessageSeconds` instead of `days` and `deleteMessageDays`:
 
 ```diff
 <GuildBanManager>.create('123456789', {

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -280,7 +280,17 @@ The `threadMembersUpdate` event now emits the users who were added, the users wh
 
 ### GuildBanManager
 
-The `days` option when banning a user has been removed. Use `deleteMessageSeconds` instead which, as named, takes seconds instead of the number of days.
+Staring from 14.4.0, developers should utilise `deleteMessageSeconds` instead of `days` and `deleteMessageDays`:
+
+```diff
+<GuildBanManager>.create('123456789', {
+-  days: 3
+-  deleteMessageDays: 3
++  deleteMessageSeconds: 3 * 24 * 60 * 60
+});
+```
+
+`deleteMessageDays` (introduced with version 14) and `days` are both deprecated and will be removed in the future.
 
 ### Guild
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -280,7 +280,7 @@ The `threadMembersUpdate` event now emits the users who were added, the users wh
 
 ### GuildBanManager
 
-The `days` option when banning a user has been renamed to `deleteMessageDays` to be more aligned to the API name.
+The `days` option when banning a user has been removed. Use `deleteMessageSeconds` instead.
 
 ### Guild
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`deleteMessageDays` is deprecated. Users should be using `deleteMessageSeconds` instead: https://github.com/discordjs/discord.js/pull/8326.