### PR TITLE
fix(navbar): documentation pointing to stable in v14

### DIFF
--- a/guide/.vuepress/config.ts
+++ b/guide/.vuepress/config.ts
@@ -39,7 +39,7 @@ const config = defineUserConfig<DefaultThemeOptions, ViteBundlerOptions>({
 			},
 			{
 				text: 'Documentation',
-				link: 'https://discord.js.org/#/docs/main/stable/general/welcome',
+				link: 'https://discord.js.org/#/',
 			},
 		],
 		themePlugins: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
### The docs link on the top of the guide page of v14 goes to the v13 docs:
<https://discord.js.org/#/docs/main/stable/general/welcome> (Should be main, not stable)

> Jiralite suggested be changed to `https://discord.js.org/#/`