### PR TITLE
fix error ERR_INVALID_ARG_TYPE

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -235,14 +235,14 @@ app.get('/', async ({ query }, response) => {
 		try {
 			const tokenResponseData = await request('https://discord.com/api/oauth2/token', {
 				method: 'POST',
-				body: new URLSearchParams({
+				body: (new URLSearchParams({
 					client_id: clientId,
 					client_secret: clientSecret,
 					code,
 					grant_type: 'authorization_code',
 					redirect_uri: `http://localhost:${port}`,
 					scope: 'identify',
-				}),
+				}).toString(),
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},


### PR DESCRIPTION
node v16.17.0 
undici v5.10.0

have error 

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Array
    at new NodeError (node:internal/errors:387:5)
    at Function.byteLength (node:buffer:740:11)
    at AsyncWriter.write (/Users/gnomerock/Repositories/nomubot/node_modules/undici/lib/client.js:1613:24)
    at writeIterable (/Users/gnomerock/Repositories/nomubot/node_modules/undici/lib/client.js:1574:19) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

so I think it should be converted to string first
