### PR TITLE
fix: forum example

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -127,7 +127,7 @@ Currently, the only way to get tag ids is programmatically through <DocsLink pat
 
 ```js
 const channel = client.channels.cache.get('id');
-channel.threads.create({ name: 'Post name', message: { content: 'Message content' }, tags: ['tagID', 'anotherTagID'] });
+channel.threads.create({ name: 'Post name', message: { content: 'Message content' }, appliedTags: ['tagID', 'anotherTagID'] });
 ```
 
 ### How do I DM a specific user?


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The forum example is using an invalid property, `tags`. It's called `appliedTags`.