### PR TITLE
DocsLink use main branch as default

### DIFF
--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -29,7 +29,7 @@ const props = defineProps({
 
 const link = computed(() => {
 	const guideSection = docsSections.find(section => section === props.section) || docsSections[0];
-	const branch = guideSection === 'main' ? 'stable' : props.branch || 'main';
+	const branch = props.branch || 'main';
 	return `${baseURL}/${guideSection}/${branch}/${props.path}`;
 });
 


### PR DESCRIPTION
As guide is v14 but docs still use stable
> Example issue #1278