### PR TITLE
fix: remove the usage of @discordjs/builders

### DIFF
--- a/guide/popular-topics/builders.md
+++ b/guide/popular-topics/builders.md
@@ -1,6 +1,6 @@
 # Builders
 
-discord.js provides the [`@discordjs/builders`](https://github.com/discordjs/builders) package which contains a variety of utilities you can use when writing your Discord bot.
+discord.js provides Builders, which contain a variety of utilities you can use when making your Discord bot.
 
 ## Basic Markdown
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes the usage of `@discordjs/builders` in `builders.md`