### PR TITLE
Numbers: Numerical vs written representation

### DIFF
--- a/guide/popular-topics/embeds.md
+++ b/guide/popular-topics/embeds.md
@@ -270,6 +270,6 @@ There are a few limits to be aware of while planning your embeds due to the API'
 - The footer text is limited to 2048 characters
 - The author name is limited to 256 characters
 - The sum of all characters from all embed structures in a message must not exceed 6000 characters
-- Ten embeds can be sent per message
+- 10 embeds can be sent per message
 
 Source: [Discord API documentation](https://discord.com/developers/docs/resources/channel#embed-object-embed-limits)


### PR DESCRIPTION
Description: The word "ten" should be spelled out in the last bullet of the "Embed Limits" page section since the section uses numbers frequently in the other bullet points.

Explanation: I believe that the original writer was following the rule where whole numbers from one to ten, but there's another rule that consistency is more important and overrides all other rules[^1]. This rule should only be applied to this specific case because the other numbers in the "Embed Limits" section are written using numerical representation, making the "ten" stand out awkwardly.

[^1]: https://www.scribendi.com/academy/articles/when_to_spell_out_numbers_in_writing.en.html