### PR TITLE
fix invalid pnpm init command

### DIFF
--- a/guide/improving-dev-environment/package-json-scripts.md
+++ b/guide/improving-dev-environment/package-json-scripts.md
@@ -46,8 +46,8 @@ yarn init -y
   <CodeGroupItem title="pnpm">
 
 ```sh:no-line-numbers
-pnpm init -y
-```  
+pnpm init
+```
 
   </CodeGroupItem>
 </CodeGroup>

--- a/guide/preparations/README.md
+++ b/guide/preparations/README.md
@@ -87,7 +87,7 @@ yarn init -y
   <CodeGroupItem title="pnpm">
 
 ```sh:no-line-numbers
-pnpm init -y
+pnpm init
 ```
 
   </CodeGroupItem>


### PR DESCRIPTION
Fixes invalid command for `pnpm` initialization. Unlike `npm` and `yarn` that uses a `-y` flag to skip answering `package.json` config options, `pnpm` does that by default. Using a `-y` flag causes an error.