### PR TITLE
fix(Permissions): use correct name for constructor

### DIFF
--- a/guide/popular-topics/permissions.md
+++ b/guide/popular-topics/permissions.md
@@ -330,7 +330,7 @@ The Permissions object enables you to easily add or remove individual permission
 ```js
 const { PermissionsBitField } = require('discord.js');
 
-const permissions = new Permissions([
+const permissions = new PermissionsBitField([
 	PermissionsBitField.Flags.ViewChannel,
 	PermissionsBitField.Flags.EmbedLinks,
 	PermissionsBitField.Flags.AttachFiles,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Rename `Permissions` to `PermissionsBitField` 
