### PR TITLE
Example code error with ChannelTypes.GuildText

### DIFF
--- a/guide/slash-commands/advanced-creation.md
+++ b/guide/slash-commands/advanced-creation.md
@@ -146,7 +146,7 @@ const data = new SlashCommandBuilder()
 		option.setName('channel')
 			.setDescription('The channel to echo into')
 			// Ensure the user can only select a TextChannel for output
-			.addChannelTypes(ChannelTypes.GuildText))
+			.addChannelTypes(ChannelType.GuildText))
 	.addBooleanOption(option =>
 		option.setName('embed')
 			.setDescription('Whether or not the echo should be embedded'));


### PR DESCRIPTION
Line 149:
The guide (https://discordjs.guide/slash-commands/advanced-creation.html#further-validation) says to use `ChannelTypes.GuildText` but my code only worked when I used `ChannelType.GuildText`  (No 's' after 'Type')

**Please describe the changes this PR makes and why it should be merged:**
People new to code (like me) will get confused lol - I only worked this out because I had someone helping and vscode is helpful with autocomplete