### PR TITLE
fix(Oauth2): set request body to string

### DIFF
--- a/code-samples/oauth/simple-oauth-webserver/index.js
+++ b/code-samples/oauth/simple-oauth-webserver/index.js
@@ -27,7 +27,7 @@ app.get('/', async ({ query }, response) => {
 					grant_type: 'authorization_code',
 					redirect_uri: `http://localhost:${port}`,
 					scope: 'identify',
-				}),
+				}).toString(),
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},

--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -242,7 +242,7 @@ app.get('/', async ({ query }, response) => {
 					grant_type: 'authorization_code',
 					redirect_uri: `http://localhost:${port}`,
 					scope: 'identify',
-				}),
+				}).toString(),
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves issue [#1172](https://github.com/discordjs/guide/issues/1172#issue-1306814581) in which the OAuth2 guide has a request body that is neither a string or buffer object