### PR TITLE
Correct the response for "Ephemeral responses"

### DIFF
--- a/guide/slash-commands/response-methods.md
+++ b/guide/slash-commands/response-methods.md
@@ -55,7 +55,7 @@ Now when you run your command again, you should see something like this:
 				:ephemeral="true"
 			>ping</DiscordInteraction>
 		</template>
-		Pong!
+		Secret Pong!
 	</DiscordMessage>
 </DiscordMessages>
 


### PR DESCRIPTION
The Response message for "Ephemeral responses" is showing as "Pong!" when it should be showing as "Secret Pong!"
