### PR TITLE
chore: use the same syntax as node-fetch

### DIFF
--- a/code-samples/additional-info/rest-api/14/index.js
+++ b/code-samples/additional-info/rest-api/14/index.js
@@ -16,15 +16,13 @@ client.on(Events.InteractionCreate, async interaction => {
 	await interaction.deferReply();
 
 	if (commandName === 'cat') {
-		const catResult = await request('https://aws.random.cat/meow');
-		const { file } = await catResult.body.json();
+		const { file } = await request('https://aws.random.cat/meow').then(response => response.body.json());
 		interaction.reply({ files: [{ attachment: file, name: 'cat.png' }] });
 	} else if (commandName === 'urban') {
 		const term = interaction.options.getString('term');
 		const query = new URLSearchParams({ term });
 
-		const dictResult = await request(`https://api.urbandictionary.com/v0/define?${query}`);
-		const { list } = await dictResult.body.json();
+		const { list } = await request(`https://api.urbandictionary.com/v0/define?${query}`).then(response => response.body.json());
 
 		if (!list.length) {
 			return interaction.editReply(`No results found for **${term}**.`);

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -83,8 +83,7 @@ To get the data from within the response object, you can define the following he
 Random cat's API is available at [https://aws.random.cat/meow](https://aws.random.cat/meow) and returns a [JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) response. To actually fetch data from the API, you're going to do the following:
 
 ```js
-const catResult = await request('https://aws.random.cat/meow');
-const { file } = await catResult.body.json();
+const { file } = await request('https://aws.random.cat/meow').then(response => response.body.json());
 ```
 
 If you just add this code, it will seem like nothing happens. What you do not see, is that you are launching a request to the random.cat server, which responds some JSON data. The helper function parses the response data to a JavaScript object you can work with. The object will have a `file` property with the value of a link to a random cat image.
@@ -95,8 +94,7 @@ Next, you will implement this approach into an application command:
 client.on(Events.InteractionCreate, async interaction => {
 	// ...
 	if (commandName === 'cat') {
-		const catResult = await request('https://aws.random.cat/meow');
-		const { file } = await catResult.body.json();
+		const { file } = await request('https://aws.random.cat/meow');
 		interaction.editReply({ files: [file] });
 	}
 });
@@ -124,8 +122,7 @@ client.on(Events.InteractionCreate, async interaction => {
 		const term = interaction.options.getString('term');
 		const query = new URLSearchParams({ term });
 
-		const dictResult = await request(`https://api.urbandictionary.com/v0/define?${query}`);
-		const { list } = await dictResult.body.json();
+		const { list } = await request(`https://api.urbandictionary.com/v0/define?${query}`).then(response => response.body.json());
 	}
 });
 ```

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -94,7 +94,7 @@ Next, you will implement this approach into an application command:
 client.on(Events.InteractionCreate, async interaction => {
 	// ...
 	if (commandName === 'cat') {
-		const { file } = await request('https://aws.random.cat/meow');
+		const { file } = await request('https://aws.random.cat/meow').then(response => response.body.json());
 		interaction.editReply({ files: [file] });
 	}
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I think it'll be better if the guide keeps the same syntax syntax as before when `node-fetch` was used.
Like: `const { file } = await fetch('https://aws.random.cat/meow').then(response => response.json())`