### PR TITLE
Moved warning for better visibility.

### DIFF
--- a/guide/interactions/buttons.md
+++ b/guide/interactions/buttons.md
@@ -12,6 +12,13 @@ Buttons are one of the `MessageComponent` classes, which can be sent via message
 
 ::: warning
 You can have a maximum of five `ActionRow`s per message, and five buttons within an `ActionRow`.
+
+If you're using TypeScript you'll need to specify the type of components your action row holds. This can be done by specifying the component builder you will add to it using a generic parameter in <DocsLink path="class/ActionRowBuilder"/>.
+
+```diff
+- new ActionRowBuilder()
++ new ActionRowBuilder<ButtonBuilder>()
+```
 :::
 
 To create your buttons, use the <DocsLink path="class/ActionRowBuilder"/> and <DocsLink path="class/ButtonBuilder"/> classes. Then, pass the resulting row object to <DocsLink path="class/ChatInputCommandInteraction?scrollTo=reply" /> in the `components` array of <DocsLink path="typedef/InteractionReplyOptions" />:
@@ -107,15 +114,6 @@ client.on(Events.InteractionCreate, async interaction => {
 		</template>
 	</DiscordMessage>
 </DiscordMessages>
-
-::: warning
-If you're using TypeScript you'll need to specify the type of components your action row holds. This can be done by specifying the component builder you will add to it using a generic parameter in <DocsLink path="class/ActionRowBuilder"/>.
-
-```diff
-- new ActionRowBuilder()
-+ new ActionRowBuilder<ButtonBuilder>()
-```
-:::
 
 ### Disabled buttons
 


### PR DESCRIPTION
This page is mis-leading because it shows you the syntax but this does not work for typescript and you have to scroll down two monitors worth of the page to get a little warning at the end that you need something for typescript.

This has thrown me and others off because it is unclear, moving this to the top will stop confusion.

*You can stretch the page over two monitors and barely see the warning!*
![Uploading image.png…]()