### PR TITLE
Update Command Error Handling

### DIFF
--- a/code-samples/creating-your-bot/command-deployment/index.js
+++ b/code-samples/creating-your-bot/command-deployment/index.js
@@ -30,7 +30,11 @@ client.on(Events.InteractionCreate, async interaction => {
 		await command.execute(interaction);
 	} catch (error) {
 		console.error(error);
-		await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		if(interaction.replied || interaction.deferred){
+			await interaction.editReply({ content: 'There was an error while executing this command!', ephemeral: true });
+		} else {
+			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		}
 	}
 });
 

--- a/code-samples/creating-your-bot/command-deployment/index.js
+++ b/code-samples/creating-your-bot/command-deployment/index.js
@@ -31,7 +31,7 @@ client.on(Events.InteractionCreate, async interaction => {
 	} catch (error) {
 		console.error(error);
 		if(interaction.replied || interaction.deferred){
-			await interaction.editReply({ content: 'There was an error while executing this command!', ephemeral: true });
+			await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
 		} else {
 			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
 		}

--- a/code-samples/creating-your-bot/command-handling/index.js
+++ b/code-samples/creating-your-bot/command-handling/index.js
@@ -30,7 +30,11 @@ client.on(Events.InteractionCreate, async interaction => {
 		await command.execute(interaction);
 	} catch (error) {
 		console.error(error);
-		await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		if(interaction.replied || interaction.deferred){
+			await interaction.editReply({ content: 'There was an error while executing this command!', ephemeral: true });
+		} else {
+			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		}
 	}
 });
 

--- a/code-samples/creating-your-bot/command-handling/index.js
+++ b/code-samples/creating-your-bot/command-handling/index.js
@@ -31,7 +31,7 @@ client.on(Events.InteractionCreate, async interaction => {
 	} catch (error) {
 		console.error(error);
 		if(interaction.replied || interaction.deferred){
-			await interaction.editReply({ content: 'There was an error while executing this command!', ephemeral: true });
+			await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
 		} else {
 			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
 		}

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -107,7 +107,7 @@ client.on(Events.InteractionCreate, async interaction => {
 	} catch (error) {
 		console.error(error);
 		if(interaction.replied || interaction.deferred){
-			await interaction.editReply({ content: 'There was an error while executing this command!', ephemeral: true });
+			await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
 		} else {
 			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
 		}

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -106,7 +106,11 @@ client.on(Events.InteractionCreate, async interaction => {
 		await command.execute(interaction);
 	} catch (error) {
 		console.error(error);
-		await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		if(interaction.replied || interaction.deferred){
+			await interaction.editReply({ content: 'There was an error while executing this command!', ephemeral: true });
+		} else {
+			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+		}
 	}
 });
 ```

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -164,7 +164,7 @@ await interaction.followUp(`Hi, <@${user.id}>.`);
 ```
 
 ::: tip
-Mentions in embeds may resolve correctly in embed descriptions and field values but will never notify the user. Other areas do not support mentions at all.
+Mentions in embeds may resolve correctly in embed titles, descriptions and field values but will never notify the user. Other areas do not support mentions at all.
 :::
 
 ### How do I control which users and/or roles are mentioned in a message?

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -164,7 +164,7 @@ await interaction.followUp(`Hi, <@${user.id}>.`);
 ```
 
 ::: tip
-Mentions in embeds may resolve correctly in embed titles, descriptions and field values but will never notify the user. Other areas do not support mentions at all.
+Mentions in embeds may resolve correctly in embed descriptions and field values but will never notify the user. Other areas do not support mentions at all.
 :::
 
 ### How do I control which users and/or roles are mentioned in a message?


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR simply updates the way errors are displayed following the command handler guide. In cases where one has already replied to the interaction and an individual command file code errors after the reply, this error reply does not work. This can be solved with a simple check to see if the interaction is deferred or replied.
