### PR TITLE
fix: define `Events` in code examples

### DIFF
--- a/guide/interactions/buttons.md
+++ b/guide/interactions/buttons.md
@@ -17,7 +17,7 @@ You can have a maximum of five `ActionRow`s per message, and five buttons within
 To create your buttons, use the <DocsLink path="class/ActionRowBuilder"/> and <DocsLink path="class/ButtonBuilder"/> classes. Then, pass the resulting row object to <DocsLink path="class/ChatInputCommandInteraction?scrollTo=reply" /> in the `components` array of <DocsLink path="typedef/InteractionReplyOptions" />:
 
 ```js {1,7-13,15}
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, Events } = require('discord.js');
 
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;
@@ -59,7 +59,7 @@ Restart your bot and then send the command to a channel your bot has access to. 
 You can also send message components within an ephemeral response or alongside message embeds.
 
 ```js {1,12-16,18}
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, Events } = require('discord.js');
 
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;

--- a/guide/interactions/modals.md
+++ b/guide/interactions/modals.md
@@ -17,7 +17,7 @@ You can have a maximum of five <DocsLink path="class/ActionRowBuilder" />s per m
 To create a modal you construct a new <DocsLink path="class/ModalBuilder" />. You can then use the setters to add the custom id and title.
 
 ```js {1,7-13}
-const { ModalBuilder } = require('discord.js');
+const { ModalBuilder, Events } = require('discord.js');
 
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;
@@ -49,7 +49,7 @@ If you're using typescript you'll need to specify the type of components your ac
 :::
 
 ```js {1,12-34}
-const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, Events } = require('discord.js');
 
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;

--- a/guide/interactions/modals.md
+++ b/guide/interactions/modals.md
@@ -17,7 +17,7 @@ You can have a maximum of five <DocsLink path="class/ActionRowBuilder" />s per m
 To create a modal you construct a new <DocsLink path="class/ModalBuilder" />. You can then use the setters to add the custom id and title.
 
 ```js {1,7-13}
-const { ModalBuilder, Events } = require('discord.js');
+const { Events, ModalBuilder } = require('discord.js');
 
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;
@@ -49,7 +49,7 @@ If you're using typescript you'll need to specify the type of components your ac
 :::
 
 ```js {1,12-34}
-const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, Events } = require('discord.js');
+const { ActionRowBuilder, Events, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
 
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add the definition for `Events` in code examples