### PR TITLE
Mistake in embed mentions tip

### DIFF
--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -164,7 +164,7 @@ await interaction.followUp(`Hi, <@${user.id}>.`);
 ```
 
 ::: tip
-Mentions in embeds may resolve correctly in embed titles, descriptions and field values but will never notify the user. Other areas do not support mentions at all.
+Mentions in embeds may resolve correctly in embed descriptions and field values but will never notify the user. Other areas do not support mentions at all.
 :::
 
 ### How do I control which users and/or roles are mentioned in a message?


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Updates a mistake in a tip for mentions in embeds. Mentions only resolve in embed descriptions and field values, not titles.