### PR TITLE
Removal of Number Intent Example

### DIFF
--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -44,7 +44,7 @@ myIntents.add(Intents.FLAGS.GUILD_PRESENCES, Intents.FLAGS.GUILD_MEMBERS);
 
 const client = new Client({ intents: myIntents });
 
-// other examples:
+// other example:
 
 const otherIntents = new Intents([Intents.FLAGS.GUILDS, Intents.FLAGS.DIRECT_MESSAGES]);
 otherIntents.remove([Intents.FLAGS.DIRECT_MESSAGES]);

--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -48,9 +48,6 @@ const client = new Client({ intents: myIntents });
 
 const otherIntents = new Intents([Intents.FLAGS.GUILDS, Intents.FLAGS.DIRECT_MESSAGES]);
 otherIntents.remove([Intents.FLAGS.DIRECT_MESSAGES]);
-
-const otherIntents2 = new Intents(32509);
-otherIntents2.remove(4096, 512);
 ```
 
 If you want to view the built flags you can utilize the `.toArray()`, `.serialize()` methods. The first returns an array of flags represented in this bitfield, the second an object mapping all possible flag values to a boolean, based on their representation in this bitfield.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It is often advised that users do not use a number for intents. This is because users often use a number to represent "all intents", not realizing the number gets outdated with the introduction of other intents. The majority of people who are reading the guide at this point would benefit from listing out all their intents as strings/enums not only for readability, but for debugging purposes as well. This would help people figure out why they aren't collecting certain data, things they are missing, etc. I feel the blurb about bitfields directly under this code example is more than sufficient. The problem with having a code example is blind copy pastes, and there is no good reason to include it.

tldr: intent number bad coding practice