### PR TITLE
Add Aforementioned Second Option to 'Handling multiple autocomplete o…

### DIFF
--- a/guide/slash-commands/autocomplete.md
+++ b/guide/slash-commands/autocomplete.md
@@ -131,6 +131,10 @@ module.exports = {
 		.addStringOption(option =>
 			option.setName('query')
 				.setDescription('Phrase to search for')
+				.setAutocomplete(true))
+		.addStringOption(option =>
+			option.setName('version')
+				.setDescription('Version to search in')
 				.setAutocomplete(true)),
 	async autocomplete(interaction) {
 		const focusedOption = interaction.options.getFocused(true);


### PR DESCRIPTION
Add Aforementioned Second Option to 'Handling multiple autocomplete options' Section

This section describes how to handle autocomplete interactions for commands with more than one option. The snippet currently only shows one option in the command builder. This PR adds the second option.
