### PR TITLE
fix: rename SelectMenu to StringSelect

### DIFF
--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -166,7 +166,7 @@ const filter = i => {
 	return i.user.id === interaction.user.id;
 };
 
-message.awaitMessageComponent({ filter, componentType: ComponentType.SelectMenu, time: 60000 })
+message.awaitMessageComponent({ filter, componentType: ComponentType.StringSelect, time: 60000 })
 	.then(interaction => interaction.editReply(`You selected ${interaction.values.join(', ')}!`))
 	.catch(err => console.log(`No interactions were collected.`));
 ```


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`ComponentType.SelectMenu` has been deprecated when Discord released new type of select menus.