### PR TITLE
feat(voice): Add sodium-native encryption package

### DIFF
--- a/guide/voice/README.md
+++ b/guide/voice/README.md
@@ -42,6 +42,7 @@ This guide assumes you have installed at least one additional dependency – FFm
   - [`ffmpeg-static`](https://www.npmjs.com/package/ffmpeg-static) - to install FFmpeg via npm
 - Encryption packages
   - [`sodium`](https://www.npmjs.com/package/sodium) (best performance)
+  - [`sodium-native`](https://www.npmjs.com/package/sodium-native)
   - [`libsodium-wrappers`](https://www.npmjs.com/package/libsodium-wrappers)
   - [`tweetnacl`](https://www.npmjs.com/package/tweetnacl)
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the sodium-native encryption package as an option under extra dependencies for encryption libraries. This should be merged as sodium-native is a good and fast encryption library which is supported within @discordjs/voice and is easy to install.