### PR TITLE
Fixed broken link in "Registering slash commands"

### DIFF
--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -1,7 +1,7 @@
 # Registering slash commands
 
 ::: tip
-This page assumes you use the same file structure as our [Slash commands](/slash-commands/) section, and the provided are made to function with that setup. Please carefully read that section first so that you can understand the methods used in this section.
+This page assumes you use the same file structure as our [Creating slash commands](/creating-your-bot/slash-commands.html#before-you-continue/) section, and the provided are made to function with that setup. Please carefully read that section first so that you can understand the methods used in this section.
 
 If you already have slash commands set up and deployed for your application and want to learn how to respond to them, refer to the following section on [Command Response Methods](/slash-commands/response-methods.md).
 :::

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -1,7 +1,7 @@
 # Registering slash commands
 
 ::: tip
-This page assumes you use the same file structure as our [Creating slash commands](/creating-your-bot/slash-commands.html#before-you-continue/) section, and the provided are made to function with that setup. Please carefully read that section first so that you can understand the methods used in this section.
+This page assumes you use the same file structure as our [Creating slash commands](/creating-your-bot/slash-commands.html) section, and the provided are made to function with that setup. Please carefully read that section first so that you can understand the methods used in this section.
 
 If you already have slash commands set up and deployed for your application and want to learn how to respond to them, refer to the following section on [Command Response Methods](/slash-commands/response-methods.md).
 :::


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes issue #1378. The link used to redirect to `/slash-commands` but since that route doesn't exist, it resulted in a 404 page. So, I have changed the link to the Creating Slash Commands page which specifies the correct file structure mentioned in the tip
