### PR TITLE
fix (DocsLink): use `discord.js` instead of `main` section

### DIFF
--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -8,13 +8,13 @@
 import { computed } from 'vue';
 
 const baseURL = 'https://discord.js.org/#/docs';
-const docsSections = ['main', 'collection', 'rpc', 'builders', 'proxy', 'rest', 'voice', 'ws'];
+const docsSections = ['discord.js', 'collection', 'rpc', 'builders', 'proxy', 'rest', 'voice', 'ws'];
 const docsPathRegex = /\w+\/(\w+)(?:\?scrollTo=(.+))?/;
 
 const props = defineProps({
 	section: {
 		type: String,
-		'default': 'main',
+		'default': 'discord.js',
 	},
 	branch: String,
 	path: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
should fix #1389 issue