### PR TITLE
fix: Update expired link

### DIFF
--- a/guide/slash-commands/deleting-commands.md
+++ b/guide/slash-commands/deleting-commands.md
@@ -1,7 +1,7 @@
 # Deleting commands
 
 ::: tip
-This page is a follow-up to [the previous page](./creating-commands.md). You need commands to delete them in the first place.
+This page is a follow-up to [Registering slash commands](../creating-your-bot/command-deployment.md). You need commands to delete them in the first place.
 :::
 
 You may have decided that you don't need a command anymore and don't want your users to be confused when they encounter a removed command. 


### PR DESCRIPTION
the old link to "the previous page" went to https://discordjs.guide/slash-commands/creating-commands.html 
that page does not exist (anymore).
This is the closest page that would make sense imo

