### PR TITLE
fix(changes-in-v14): Use Diagnostics Channel

### DIFF
--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -413,12 +413,24 @@ The following discord.js events have been removed from the `Client`:
 -   `invalidRequestWarning`
 -   `rateLimit`
 
-Instead you should access these events from `Client#rest`. In addition, the `apiRequest`, `apiResponse` and `rateLimit` events have been renamed:
+discord.js internally uses [Undici](https://github.com/nodejs/undici). Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
+
+```JavaScript
+import diagnosticsChannel from 'diagnostics_channel';
+
+diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
+	console.log(request.method); // Log the method
+	console.log(request.path); // Log the path
+	console.log(headers); // Log the headers
+	console.log(request); // Or just log everything!
+});
+```
+
+The full list of examples can be seen with the above Diagnostic Channels link.
+
+As for the three other events, you should access them from `Client#rest`. In addition, the `apiResponse` and `rateLimit` events have been renamed:
 
 ```diff
-- client.on('apiRequest', ...);
-+ client.rest.on('request', ...);
-
 - client.on('apiResponse', ...);
 + client.rest.on('response', ...);
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -406,12 +406,7 @@ Overwrites are now keyed by the `PascalCase` permission key rather than the `SCR
 
 ### REST Events
 
-The following discord.js events have been removed from the `Client`:
-
--   `apiRequest`
--   `apiResponse`
--   `invalidRequestWarning`
--   `rateLimit`
+#### apiRequest
 
 discord.js now uses [Undici](https://github.com/nodejs/undici) as the underlying request handler. Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
 
@@ -432,12 +427,29 @@ diagnosticsChannel.channel('undici:request:create').subscribe(data => {
 
 You can find further examples at the [Undici Diagnostics Channel documentation](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel).
 
-As for the three other events, you should access them from `Client#rest`. In addition, the `apiResponse` and `rateLimit` events have been renamed:
+#### apiResponse
+
+This REST event has been renamed to `response` and moved to `Client#rest`:
 
 ```diff
 - client.on('apiResponse', ...);
 + client.rest.on('response', ...);
+```
 
+#### invalidRequestWarning
+
+This REST event has been moved to `Client#rest`:
+
+```diff
+- client.on('invalidRequestWarning', ...);
++ client.rest.on('invalidRequestWarning', ...);
+```
+
+#### rateLimit
+
+This REST event has been renamed to `rateLimited` and moved to `Client#rest`:
+
+```diff
 - client.on('rateLimit', ...);
 + client.rest.on('rateLimited', ...);
 ```

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -418,7 +418,11 @@ discord.js internally uses [Undici](https://github.com/nodejs/undici). Thus, the
 ```js
 import diagnosticsChannel from 'node:diagnostics_channel';
 
-diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
+diagnosticsChannel.channel('undici:request:create').subscribe(data => {
+	// If you use TypeScript, `data` may be casted as
+	// `DiagnosticsChannel.RequestCreateMessage`
+	// from Undici to receive type definitions.
+	const { request } = data;
 	console.log(request.method); // Log the method
 	console.log(request.path); // Log the path
 	console.log(request.headers); // Log the headers

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -408,7 +408,7 @@ Overwrites are now keyed by the `PascalCase` permission key rather than the `SCR
 
 #### apiRequest
 
-discord.js now uses [Undici](https://github.com/nodejs/undici) as the underlying request handler. Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
+This REST event has been removed as discord.js now uses [Undici](https://github.com/nodejs/undici) as the underlying request handler. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
 
 ```js
 import diagnosticsChannel from 'node:diagnostics_channel';

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -430,7 +430,7 @@ diagnosticsChannel.channel('undici:request:create').subscribe(data => {
 });
 ```
 
-You can find further examples at the Undici Diagnostics Channel documentation link above.
+You can find further examples at the [Undici Diagnostics Channel documentation](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel).
 
 As for the three other events, you should access them from `Client#rest`. In addition, the `apiResponse` and `rateLimit` events have been renamed:
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -416,12 +416,12 @@ The following discord.js events have been removed from the `Client`:
 discord.js internally uses [Undici](https://github.com/nodejs/undici). Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
 
 ```js
-import diagnosticsChannel from 'diagnostics_channel';
+import diagnosticsChannel from 'node:diagnostics_channel';
 
 diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
 	console.log(request.method); // Log the method
 	console.log(request.path); // Log the path
-	console.log(headers); // Log the headers
+	console.log(request.headers); // Log the headers
 	console.log(request); // Or just log everything!
 });
 ```

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -413,7 +413,7 @@ The following discord.js events have been removed from the `Client`:
 -   `invalidRequestWarning`
 -   `rateLimit`
 
-discord.js internally uses [Undici](https://github.com/nodejs/undici). Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
+discord.js now uses [Undici](https://github.com/nodejs/undici) as the underlying request handler. Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
 
 ```js
 import diagnosticsChannel from 'node:diagnostics_channel';
@@ -430,7 +430,7 @@ diagnosticsChannel.channel('undici:request:create').subscribe(data => {
 });
 ```
 
-The full list of examples can be seen with the above Diagnostic Channels link.
+You can find further examples at the Undici Diagnostics Channel documentation link above.
 
 As for the three other events, you should access them from `Client#rest`. In addition, the `apiResponse` and `rateLimit` events have been renamed:
 

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -415,7 +415,7 @@ The following discord.js events have been removed from the `Client`:
 
 discord.js internally uses [Undici](https://github.com/nodejs/undici). Thus, the way you can monitor API requests has changed. You must now use a [Diagnostics Channel](https://undici.nodejs.org/#/docs/api/DiagnosticsChannel). Here is a simple example:
 
-```JavaScript
+```js
 import diagnosticsChannel from 'diagnostics_channel';
 
 diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Client#rest` had no `request` event. Instead, Diagnostic Channels should be used.