### PR TITLE
feat: further improvements to the Creating your bot section

### DIFF
--- a/code-samples/creating-your-bot/command-deployment/deploy-commands.js
+++ b/code-samples/creating-your-bot/command-deployment/deploy-commands.js
@@ -16,7 +16,11 @@ for (const folder of commandFolders) {
 	for (const file of commandFiles) {
 		const filePath = path.join(commandsPath, file);
 		const command = require(filePath);
-		commands.push(command.data.toJSON());
+		if ('data' in command && 'execute' in command) {
+			commands.push(command.data.toJSON());
+		} else {
+			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+		}
 	}
 }
 

--- a/code-samples/creating-your-bot/event-handling/index.js
+++ b/code-samples/creating-your-bot/event-handling/index.js
@@ -6,13 +6,21 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.commands = new Collection();
-const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+const foldersPath = path.join(__dirname, 'commands');
+const commandFolders = fs.readdirSync(foldersPath);
 
-for (const file of commandFiles) {
-	const filePath = path.join(commandsPath, file);
-	const command = require(filePath);
-	client.commands.set(command.data.name, command);
+for (const folder of commandFolders) {
+	const commandsPath = path.join(foldersPath, folder);
+	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+	for (const file of commandFiles) {
+		const filePath = path.join(commandsPath, file);
+		const command = require(filePath);
+		if ('data' in command && 'execute' in command) {
+			client.commands.set(command.data.name, command);
+		} else {
+			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+		}
+	}
 }
 
 const eventsPath = path.join(__dirname, 'events');

--- a/code-samples/creating-your-bot/event-handling/index.js
+++ b/code-samples/creating-your-bot/event-handling/index.js
@@ -1,6 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
+const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });

--- a/code-samples/creating-your-bot/event-handling/index.js
+++ b/code-samples/creating-your-bot/event-handling/index.js
@@ -1,9 +1,19 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const { Client, GatewayIntentBits } = require('discord.js');
+const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.commands = new Collection();
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+
+for (const file of commandFiles) {
+	const filePath = path.join(commandsPath, file);
+	const command = require(filePath);
+	client.commands.set(command.data.name, command);
+}
 
 const eventsPath = path.join(__dirname, 'events');
 const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'));

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -3,8 +3,8 @@
 ::: tip
 For fully functional slash commands, you need three important pieces of code:
 
-1. The [individual command files](slash-commands.html), containing their definitions and functionality.
-2. The [command handler](command-handling.html), which dynamically reads the files and executes the commands.
+1. The [individual command files](slash-commands), containing their definitions and functionality.
+2. The [command handler](command-handling), which dynamically reads the files and executes the commands.
 3. The command deployment script, to register your slash commands with Discord so they appear in the interface.
 
 These steps can be done in any order, but **all are required** before the commands are fully functional.
@@ -52,12 +52,18 @@ const path = require('node:path');
 const commands = [];
 // Grab all the command files from the commands directory you created earlier
 const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+const commandFolders = fs.readdirSync(foldersPath);
 
-// Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
-for (const file of commandFiles) {
-	const command = require(`./commands/${file}`);
-	commands.push(command.data.toJSON());
+for (const folder of commandFolders) {
+	// Grab all the command files from the commands directory you created earlier
+	const commandsPath = path.join(foldersPath, folder);
+	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+	// Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
+	for (const file of commandFiles) {
+		const filePath = path.join(commandsPath, file);
+		const command = require(filePath);
+		commands.push(command.data.toJSON());
+	}
 }
 
 // Construct and prepare an instance of the REST module

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -1,12 +1,16 @@
 # Registering slash commands
 
 ::: tip
-This page assumes you use the same file structure as our [Slash commands](./slash-commands.md) section, and the provided are made to function with that setup. Please carefully read that section first so that you can understand the methods used in this section.
+For fully functional slash commands, there are three important pieces of code that need to be written. They are:
 
-If you already have slash commands set up and deployed for your application and want to learn how to respond to them, refer to the following section on [Command Response Methods](/slash-commands/response-methods.md).
+1. The [individual command files](slash-commands.html), containing their definitions and functionality.
+2. The [command handler](command-handling.html), which dynamically reads the files and executes the commands.
+3. The command deployment script, to register your slash commands with Discord so they appear in the interface.
+
+These steps can be done in any order, but **all are required** before the commands are fully functional.
+
+This page details how to complete **Step 3**. Make sure to also complete the other pages linked above!
 :::
-
-In this section, we'll cover how to register your commands to Discord using discord.js!
 
 ## Command registration
 

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -62,7 +62,11 @@ for (const folder of commandFolders) {
 	for (const file of commandFiles) {
 		const filePath = path.join(commandsPath, file);
 		const command = require(filePath);
-		commands.push(command.data.toJSON());
+		if ('data' in command && 'execute' in command) {
+			commands.push(command.data.toJSON());
+		} else {
+			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+		}
 	}
 }
 

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -1,7 +1,7 @@
 # Registering slash commands
 
 ::: tip
-For fully functional slash commands, there are three important pieces of code that need to be written. They are:
+For fully functional slash commands, you need three important pieces of code:
 
 1. The [individual command files](slash-commands.html), containing their definitions and functionality.
 2. The [command handler](command-handling.html), which dynamically reads the files and executes the commands.

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -5,9 +5,9 @@ Unless your bot project is small, it's not a very good idea to have a single fil
 ::: tip
 For fully functional slash commands, there are three important pieces of code that need to be written. They are:
 
-1. The [individual command files](slash-commands.html), containing their definitions and functionality.
+1. The [individual command files](slash-commands), containing their definitions and functionality.
 2. The command handler, which dynamically reads the files and executes the commands.
-3. The [command deployment script](command-deployment.html), to register your slash commands with Discord so they appear in the interface.
+3. The [command deployment script](command-deployment), to register your slash commands with Discord so they appear in the interface.
 
 These steps can be done in any order, but **all are required** before the commands are fully functional.
 

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -2,6 +2,18 @@
 
 Unless your bot project is small, it's not a very good idea to have a single file with a giant `if`/`else if` chain for commands. If you want to implement features into your bot and make your development process a lot less painful, you'll want to implement a command handler. Let's get started on that!
 
+::: tip
+For fully functional slash commands, there are three important pieces of code that need to be written. They are:
+
+1. The [individual command files](slash-commands.html), containing their definitions and functionality.
+2. The command handler, which dynamically reads the files and executes the commands.
+3. The [command deployment script](command-deployment.html), to register your slash commands with Discord so they appear in the interface.
+
+These steps can be done in any order, but **all are required** before the commands are fully functional.
+
+This page details how to complete **Step 2**. Make sure to also complete the other pages linked above!
+:::
+
 ## Loading command files
 
 Now that your command files have been created, your bot needs to load these files on startup. 

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -60,7 +60,7 @@ discord-bot/
 └── package.json
 ```
 
-Create an `events` folder in the same directory. You can then move the code from your event listeners in `index.js` to separate files; `events/ready.js` and `events/interactionCreate.js` files.
+Create an `events` folder in the same directory. You can then move the code from your event listeners in `index.js` to separate files: `events/ready.js` and `events/interactionCreate.js`.
 
 :::: code-group
 ::: code-group-item events/ready.js
@@ -106,7 +106,7 @@ module.exports = {
 ```js
 const fs = require('node:fs');
 const path = require('node:path');
-const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
+const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
@@ -137,7 +137,7 @@ Next, let's write the code for dynamically retrieving all the event files in the
 ```js {18-29}
 const fs = require('node:fs');
 const path = require('node:path');
-const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
+const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
@@ -177,7 +177,7 @@ The callback function passed takes argument(s) returned by its respective event,
 After this, listening for other events is as easy as creating a new file in the `events` folder. The event handler will automatically retrieve and register it whenever you restart your bot.
 
 ::: tip
-In most cases, you can access your `client` instance in other files by obtaining it from one of the other discord.js structures, e.g. `interaction.client` in the `interactionCreate` event. It doesn't need to manually passed to your events.
+In most cases, you can access your `client` instance in other files by obtaining it from one of the other discord.js structures, e.g. `interaction.client` in the `interactionCreate` event. It doesn't need to be manually passed to your events.
 :::
 
 ## Resulting code

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -112,13 +112,21 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.commands = new Collection();
-const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+const foldersPath = path.join(__dirname, 'commands');
+const commandFolders = fs.readdirSync(foldersPath);
 
-for (const file of commandFiles) {
-	const filePath = path.join(commandsPath, file);
-	const command = require(filePath);
-	client.commands.set(command.data.name, command);
+for (const folder of commandFolders) {
+	const commandsPath = path.join(foldersPath, folder);
+	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+	for (const file of commandFiles) {
+		const filePath = path.join(commandsPath, file);
+		const command = require(filePath);
+		if ('data' in command && 'execute' in command) {
+			client.commands.set(command.data.name, command);
+		} else {
+			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+		}
+	}
 }
 
 client.login(token);
@@ -134,7 +142,7 @@ Next, let's write the code for dynamically retrieving all the event files in the
 
 `fs.readdirSync().filter()` returns an array of all the file names in the given directory and filters for only `.js` files, i.e. `['ready.js', 'interactionCreate.js']`.
 
-```js {18-29}
+```js {26-37}
 const fs = require('node:fs');
 const path = require('node:path');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
@@ -143,13 +151,21 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.commands = new Collection();
-const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+const foldersPath = path.join(__dirname, 'commands');
+const commandFolders = fs.readdirSync(foldersPath);
 
-for (const file of commandFiles) {
-	const filePath = path.join(commandsPath, file);
-	const command = require(filePath);
-	client.commands.set(command.data.name, command);
+for (const folder of commandFolders) {
+	const commandsPath = path.join(foldersPath, folder);
+	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+	for (const file of commandFiles) {
+		const filePath = path.join(commandsPath, file);
+		const command = require(filePath);
+		if ('data' in command && 'execute' in command) {
+			client.commands.set(command.data.name, command);
+		} else {
+			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+		}
+	}
 }
 
 const eventsPath = path.join(__dirname, 'events');

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -170,14 +170,14 @@ client.login(token);
 
 You'll notice the code looks very similar to the command loading above it - read the files in the events folder and load each one individually.
 
-The <DocsLink path="class/Client" /> class in discord.js extends the [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) class. Therefore, the `client` object exposes the [`.on()`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) and [`.once()`](https://nodejs.org/api/events.html#events_emitter_once_eventname_listener) methods that you can use to register event listeners. These methods take two arguments: the event name and a callback function. These are defined in our separate event files as `name` and `execute`.
+The <DocsLink path="class/Client" /> class in discord.js extends the [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) class. Therefore, the `client` object exposes the [`.on()`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) and [`.once()`](https://nodejs.org/api/events.html#events_emitter_once_eventname_listener) methods that you can use to register event listeners. These methods take two arguments: the event name and a callback function. These are defined in your separate event files as `name` and `execute`.
 
 The callback function passed takes argument(s) returned by its respective event, collects them in an `args` array using the `...` [rest parameter syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters), then calls `event.execute()` while passing in the `args` array using the `...` [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). They are used here because different events in discord.js have different numbers of arguments. The rest parameter collects these variable number of arguments into a single array, and the spread syntax then takes these elements and passes them to the `execute` function.
 
 After this, listening for other events is as easy as creating a new file in the `events` folder. The event handler will automatically retrieve and register it whenever you restart your bot.
 
 ::: tip
-In most cases, you can access your `client` instance in other files by obtaining it from one of the other discord.js structures, e.g. `interaction.client` in the `interactionCreate` event. It doesn't need to be manually passed to your events.
+In most cases, you can access your `client` instance in other files by obtaining it from one of the other discord.js structures, e.g. `interaction.client` in the `interactionCreate` event. You do not need to manually pass it to your events.
 :::
 
 ## Resulting code

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -2,18 +2,22 @@
 
 Node.js uses an event-driven architecture, making it possible to execute code when a specific event occurs. The discord.js library takes full advantage of this. You can visit the <DocsLink path="class/Client" /> documentation to see the full list of events.
 
-If you've followed the guide up to this point, your `index.js` file will have listeners for two events: `ClientReady` and `InteractionCreate`.
+::: tip
+This page assumes you've followed the guide up to this point, and created your `index.js` and individual slash commands according to those pages.
+:::
 
+At this point, your `index.js` file has listeners for two events: `ClientReady` and `InteractionCreate`.
+
+:::: code-group
+::: code-group-item ClientReady
 ```js
-const { Client, Events, GatewayIntentBits } = require('discord.js');
-const { token } = require('./config.json');
-
-const client = new Client({ intents: [GatewayIntentBits.Guilds] });
-
 client.once(Events.ClientReady, c => {
 	console.log(`Ready! Logged in as ${c.user.tag}`);
 });
-
+```
+:::
+::: code-group-item InteractionCreate
+```js
 client.on(Events.InteractionCreate, async interaction => {
 	if (!interaction.isChatInputCommand()) return;
 
@@ -31,11 +35,15 @@ client.on(Events.InteractionCreate, async interaction => {
 		console.error(error);
 	}
 });
-
-client.login(token);
 ```
+:::
+::::
 
 Currently, the event listeners are in the `index.js` file. <DocsLink path="class/Client?scrollTo=e-ready" /> emits once when the `Client` becomes ready for use, and <DocsLink path="class/Client?scrollTo=e-interactionCreate" /> emits whenever an interaction is received. Moving the event listener code into individual files is simple, and we'll be taking a similar approach to the [command handler](/creating-your-bot/command-handling.md).
+
+::: warning
+You're only going to move these two events from `index.js`. The code for [loading command files](/creating-your-bot/command-handling.html#loading-command-files) will stay here!
+:::
 
 ## Individual event files
 
@@ -43,8 +51,8 @@ Your project directory should look something like this:
 
 ```:no-line-numbers
 discord-bot/
-├── commands
-├── node_modules
+├── commands/
+├── node_modules/
 ├── config.json
 ├── deploy-commands.js
 ├── index.js
@@ -52,7 +60,7 @@ discord-bot/
 └── package.json
 ```
 
-Create an `events` folder in the same directory. You can then take your existing events code in `index.js` and move them to `events/ready.js` and `events/interactionCreate.js` files.
+Create an `events` folder in the same directory. You can then move the code from your event listeners in `index.js` to separate files; `events/ready.js` and `events/interactionCreate.js` files.
 
 :::: code-group
 ::: code-group-item events/ready.js
@@ -94,18 +102,55 @@ module.exports = {
 };
 ```
 :::
+::: code-group-item index.js (after)
+```js
+const fs = require('node:fs');
+const path = require('node:path');
+const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
+const { token } = require('./config.json');
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.commands = new Collection();
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+
+for (const file of commandFiles) {
+	const filePath = path.join(commandsPath, file);
+	const command = require(filePath);
+	client.commands.set(command.data.name, command);
+}
+
+client.login(token);
+```
+:::
 ::::
 
 The `name` property states which event this file is for, and the `once` property holds a boolean value that specifies if the event should run only once. You don't need to specify this in `interactionCreate.js` as the default behavior will be to run on every event instance. The `execute` function holds your event logic, which will be called by the event handler whenever the event emits.
 
 ## Reading event files
 
-Next, let's write the code for dynamically retrieving all the event files in the `events` folder. We'll be taking a similar approach to our [command handler](/creating-your-bot/command-handling.md). Place the code below in your `index.js`.
+Next, let's write the code for dynamically retrieving all the event files in the `events` folder. We'll be taking a similar approach to our [command handler](/creating-your-bot/command-handling.md). Place the new code highlighted below in your `index.js`.
 
 `fs.readdirSync().filter()` returns an array of all the file names in the given directory and filters for only `.js` files, i.e. `['ready.js', 'interactionCreate.js']`.
 
-```js {3,5-12}
+```js {18-29}
+const fs = require('node:fs');
+const path = require('node:path');
+const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
+const { token } = require('./config.json');
+
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.commands = new Collection();
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+
+for (const file of commandFiles) {
+	const filePath = path.join(commandsPath, file);
+	const command = require(filePath);
+	client.commands.set(command.data.name, command);
+}
 
 const eventsPath = path.join(__dirname, 'events');
 const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'));
@@ -119,16 +164,20 @@ for (const file of eventFiles) {
 		client.on(event.name, (...args) => event.execute(...args));
 	}
 }
+
+client.login(token);
 ```
 
-The <DocsLink path="class/Client" /> class in discord.js extends the [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) class. Therefore, the `client` object exposes the [`.on()`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) and [`.once()`](https://nodejs.org/api/events.html#events_emitter_once_eventname_listener) methods that you can use to register event listeners. These methods take two arguments: the event name and a callback function.
+You'll notice the code looks very similar to the command loading above it - read the files in the events folder and load each one individually.
+
+The <DocsLink path="class/Client" /> class in discord.js extends the [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) class. Therefore, the `client` object exposes the [`.on()`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) and [`.once()`](https://nodejs.org/api/events.html#events_emitter_once_eventname_listener) methods that you can use to register event listeners. These methods take two arguments: the event name and a callback function. These are defined in our separate event files as `name` and `execute`.
 
 The callback function passed takes argument(s) returned by its respective event, collects them in an `args` array using the `...` [rest parameter syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters), then calls `event.execute()` while passing in the `args` array using the `...` [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). They are used here because different events in discord.js have different numbers of arguments. The rest parameter collects these variable number of arguments into a single array, and the spread syntax then takes these elements and passes them to the `execute` function.
 
 After this, listening for other events is as easy as creating a new file in the `events` folder. The event handler will automatically retrieve and register it whenever you restart your bot.
 
 ::: tip
-In most cases, you can access your `client` instance in other files by obtaining it from one of the other discord.js structures, e.g. `interaction.client` in the `interactionCreate` event.
+In most cases, you can access your `client` instance in other files by obtaining it from one of the other discord.js structures, e.g. `interaction.client` in the `interactionCreate` event. It doesn't need to manually passed to your events.
 :::
 
 ## Resulting code

--- a/guide/creating-your-bot/slash-commands.md
+++ b/guide/creating-your-bot/slash-commands.md
@@ -35,13 +35,17 @@ discord-bot/
 └── package.json
 ```
 
-To go from this starter code to fully functional slash commands, there are three key pieces of code that need to be written. They are:
+::: tip
+For fully functional slash commands, there are three important pieces of code that need to be written. They are:
 
 1. The individual command files, containing their definitions and functionality.
-2. The command handler, which dynamically reads the files and executes the commands.
-3. The command deployment script, to register your slash commands with Discord so they appear in the interface.
+2. The [command handler](command-handling.html), which dynamically reads the files and executes the commands.
+3. The [command deployment script](command-deployment.html), to register your slash commands with Discord so they appear in the interface.
 
-These steps can be done in any order, but all are required before the commands are fully functional. This section of the guide will use the order listed above. So let's get started!
+These steps can be done in any order, but **all are required** before the commands are fully functional.
+
+On this page, you'll complete Step 1. Make sure to also complete the other pages linked above!
+:::
 
 ## Individual command files
 

--- a/guide/slash-commands/response-methods.md
+++ b/guide/slash-commands/response-methods.md
@@ -83,7 +83,7 @@ client.on(Events.InteractionCreate, async interaction => {
 });
 ```
 
-In fact, editing your interaction response is necessary to [calculate the ping](/popular-topics/faq.html#how-do-i-check-the-bot-s-ping) properly for this command.
+In fact, editing your interaction response is necessary to [calculate the ping](/popular-topics/faq#how-do-i-check-the-bot-s-ping) properly for this command.
 
 ## Deferred responses
 


### PR DESCRIPTION
This is an attempt to address some common errors seen in support from people who are following the guide (or not following it fully as the case usually is).

This adds an identical tip box to each of the slash command pages that need to be completed in conjunction with each other before the commands will be fully functional (write the commands + load/handle the commands + deploy the commands). People often miss one or more of these steps.

This also makes some changes to the event handling guide to attempt to improve the transition from the other pages. I noticed that our code sample for event handling didn't include the code for command loading. As people don't read and just copy and paste code snippets, it's been added back to the samples to reduce the support load of having to explain it.
