### PR TITLE
chore: add util section

### DIFF
--- a/guide/.vuepress/components/DocsLink.vue
+++ b/guide/.vuepress/components/DocsLink.vue
@@ -10,7 +10,7 @@ import { defaultDjsBranch } from '../constants';
 
 const legacyBaseURL = 'https://discord.js.org/#/docs';
 const baseURL = 'https://discordjs.dev/docs/packages';
-const sections = ['discord.js', 'brokers', 'builders', 'collection', 'core', 'formatters', 'proxy', 'rest', 'voice', 'ws'];
+const sections = ['discord.js', 'brokers', 'builders', 'collection', 'core', 'formatters', 'proxy', 'rest', 'util', 'voice', 'ws'];
 const legacyPathRegex = /\w+\/(\w+)(?:\?scrollTo=(.+))?/;
 const pathRegex = /(\w+):(\w+)(?:#(.+))?/i;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Recently merged PR #1435 added sections for [discordjs.dev/docs/packages](https://discordjs.dev/docs/packages). This PR adds the `util` section since that was left out.