### PR TITLE
refactor(commands): do not specify the version option for REST

### DIFF
--- a/code-samples/creating-your-bot/command-deployment/deploy-commands.js
+++ b/code-samples/creating-your-bot/command-deployment/deploy-commands.js
@@ -21,7 +21,7 @@ for (const folder of commandFolders) {
 }
 
 // Construct and prepare an instance of the REST module
-const rest = new REST({ version: '10' }).setToken(token);
+const rest = new REST().setToken(token);
 
 // and deploy your commands!
 (async () => {

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -57,7 +57,7 @@ for (const file of commandFiles) {
 }
 
 // Construct and prepare an instance of the REST module
-const rest = new REST({ version: '10' }).setToken(token);
+const rest = new REST().setToken(token);
 
 // and deploy your commands!
 (async () => {

--- a/guide/slash-commands/deleting-commands.md
+++ b/guide/slash-commands/deleting-commands.md
@@ -24,7 +24,7 @@ Edit your `deploy-commands.js` as shown below, or put it into its own file to cl
 const { REST, Routes } = require('discord.js');
 const { clientId, guildId, token } = require('./config.json');
 
-const rest = new REST({ version: '10' }).setToken(token);
+const rest = new REST().setToken(token);
 
 // ...
 
@@ -49,7 +49,7 @@ To delete all commands in the respective scope (one guild, all global commands) 
 const { REST, Routes } = require('discord.js');
 const { clientId, guildId, token } = require('./config.json');
 
-const rest = new REST({ version: '10' }).setToken(token);
+const rest = new REST().setToken(token);
 
 // ...
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

We should keep the default version set by the lib instead of setting it by ourselves.
Also, when upgrading to a major version, people often don't update the version too.