### PR TITLE
fix(command-deployment): folder pathing variable fix

### DIFF
--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -51,7 +51,7 @@ const path = require('node:path');
 
 const commands = [];
 // Grab all the command files from the commands directory you created earlier
-const commandsPath = path.join(__dirname, 'commands');
+const foldersPath = path.join(__dirname, 'commands');
 const commandFolders = fs.readdirSync(foldersPath);
 
 for (const folder of commandFolders) {


### PR DESCRIPTION
Hi! I'm going through the examples from scratch and ran into a few issues above:

- `foldersPath` was undefined
- I moved the REST() into the async, otherwise I got `TypeError: (intermediate value).setToken(...) is not a function`

I'm using Node 18.15.0 on Windows 11. After the above changes, the tutorial works again

# Screenshots of deploy errors

![image](https://user-images.githubusercontent.com/130273371/231635988-be6a5c4e-c017-406a-bbbe-45e2db978076.png)


![image](https://user-images.githubusercontent.com/130273371/231635933-ae195cb5-457f-4975-b715-79c059e9c3ab.png)
