### PR TITLE
fix(interactions): use correct interaction

### DIFF
--- a/guide/message-components/interactions.md
+++ b/guide/message-components/interactions.md
@@ -68,9 +68,9 @@ try {
 
 	if (confirmation.customId === 'confirm') {
 		await interaction.guild.members.ban(target);
-		await i.update({ content: `${target.username} has been banned for reason: ${reason}`, components: [] });
+		await confirmation.update({ content: `${target.username} has been banned for reason: ${reason}`, components: [] });
 	} else if (confirmation.customId === 'cancel') {
-		await i.update({ content: 'Action cancelled', components: [] });
+		await confirmation.update({ content: 'Action cancelled', components: [] });
 	}
 } catch (e) {
 	await response.editReply({ content: 'Confirmation not received within 1 minute, cancelling', components: [] });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Originally, the collector acknowledged `i`, the interaction instance only defined in the scope of the filter function.  Now, it acknowledges `confirmation`, the interaction instance that was actually collected.