### PR TITLE
refactor(collectors): rename the filter variable

### DIFF
--- a/code-samples/popular-topics/reactions/14/awaiting-reactions.js
+++ b/code-samples/popular-topics/reactions/14/awaiting-reactions.js
@@ -15,11 +15,11 @@ client.on(Events.InteractionCreate, async interaction => {
 		const message = await interaction.reply({ content: 'Awaiting emojis...', fetchReply: true });
 		message.react('👍').then(() => message.react('👎'));
 
-		const filter = (reaction, user) => {
+		const collectorFilter = (reaction, user) => {
 			return ['👍', '👎'].includes(reaction.emoji.name) && user.id === interaction.user.id;
 		};
 
-		message.awaitReactions({ filter, max: 1, time: 60000, errors: ['time'] })
+		message.awaitReactions({ filter: collectorFilter, max: 1, time: 60000, errors: ['time'] })
 			.then(collected => {
 				const reaction = collected.first();
 

--- a/guide/additional-info/changes-in-v13.md
+++ b/guide/additional-info/changes-in-v13.md
@@ -216,11 +216,11 @@ const { prefix } = message.client.guildSettings.get(message.guild.id);
 All Collector related classes and methods (both `.create*()` and `.await*()`) now take a single object parameter which also includes the filter.
 
 ```diff
-- const collector = message.createReactionCollector(filter, { time: 15000 });
-+ const collector = message.createReactionCollector({ filter, time: 15000 });
+- const collector = message.createReactionCollector(collectorFilter, { time: 15000 });
++ const collector = message.createReactionCollector({ filter: collectorFilter, time: 15000 });
 
-- const reactions = await message.awaitReactions(filter, { time: 15000 });
-+ const reactions = await message.awaitReactions({ filter, time: 15000 });
+- const reactions = await message.awaitReactions(collectorFilter, { time: 15000 });
++ const reactions = await message.awaitReactions({ filter: collectorFilter, time: 15000 });
 ```
 
 ### Naming conventions

--- a/guide/additional-info/changes-in-v14.md
+++ b/guide/additional-info/changes-in-v14.md
@@ -566,7 +566,7 @@ Component collector options now use the `ComponentType` enum values:
 + const { ComponentType } = require('discord.js');
 
 const collector = interaction.channel.createMessageComponentCollector({
-	filter,
+	filter: collectorFilter,
 -	componentType: 'BUTTON',
 +	componentType: ComponentType.Button,
 	time: 20000

--- a/guide/additional-info/es6-syntax.md
+++ b/guide/additional-info/es6-syntax.md
@@ -152,11 +152,11 @@ var doubleAge = function(age) {
 };
 
 // inside a message collector command
-var filter = function(m) {
+var collectorFilter = function(m) {
 	return m.content === 'I agree' && !m.author.bot;
 };
 
-var collector = message.createMessageCollector({ filter, time: 15000 });
+var collector = message.createMessageCollector({ filter: collectorFilter, time: 15000 });
 ```
 
 ```js
@@ -170,8 +170,8 @@ client.on(Events.MessageCreate, message => console.log(`${message.author.tag} se
 const doubleAge = age => `Your age doubled is: ${age * 2}`;
 
 // inside a message collector command
-const filter = m => m.content === 'I agree' && !m.author.bot;
-const collector = message.createMessageCollector({ filter, time: 15000 });
+const collectorFilter = m => m.content === 'I agree' && !m.author.bot;
+const collector = message.createMessageCollector({ filter: collectorFilter, time: 15000 });
 ```
 
 There are a few important things you should note here:

--- a/guide/message-components/interactions.md
+++ b/guide/message-components/interactions.md
@@ -42,9 +42,10 @@ const response = await interaction.reply({
 	components: [row],
 });
 
-const filter = i => i.user.id === interaction.user.id;
+const collectorFilter = i => i.user.id === interaction.user.id;
+
 try {
-	const confirmation = await response.awaitMessageComponent({ filter, time: 60000 });
+	const confirmation = await response.awaitMessageComponent({ filter: collectorFilter, time: 60000 });
 } catch (e) {
 	await response.editReply({ content: 'Confirmation not received within 1 minute, cancelling', components: [] });
 }
@@ -62,9 +63,9 @@ const response = await interaction.reply({
 	components: [row],
 });
 
-const filter = i => i.user.id === interaction.user.id;
+const collectorFilter = i => i.user.id === interaction.user.id;
 try {
-	const confirmation = await response.awaitMessageComponent({ filter, time: 60_000 });
+	const confirmation = await response.awaitMessageComponent({ filter: collectorFilter, time: 60_000 });
 
 	if (confirmation.customId === 'confirm') {
 		await interaction.guild.members.ban(target);

--- a/guide/popular-topics/collectors.md
+++ b/guide/popular-topics/collectors.md
@@ -10,8 +10,8 @@ For now, let's take the example that they have provided us:
 
 ```js
 // `m` is a message object that will be passed through the filter function
-const filter = m => m.content.includes('discord');
-const collector = interaction.channel.createMessageCollector({ filter, time: 15000 });
+const collectorFilter = m => m.content.includes('discord');
+const collector = interaction.channel.createMessageCollector({ filter: collectorFilter, time: 15000 });
 
 collector.on('collect', m => {
 	console.log(`Collected ${m.content}`);
@@ -62,13 +62,13 @@ The provided set allows for responder error with an array of answers permitted. 
 const quiz = require('./quiz.json');
 // ...
 const item = quiz[Math.floor(Math.random() * quiz.length)];
-const filter = response => {
+const collectorFilter = response => {
 	return item.answers.some(answer => answer.toLowerCase() === response.content.toLowerCase());
 };
 
 interaction.reply({ content: item.question, fetchReply: true })
 	.then(() => {
-		interaction.channel.awaitMessages({ filter, max: 1, time: 30000, errors: ['time'] })
+		interaction.channel.awaitMessages({ filter: collectorFilter, max: 1, time: 30000, errors: ['time'] })
 			.then(collected => {
 				interaction.followUp(`${collected.first().author} got the correct answer!`);
 			})
@@ -93,11 +93,11 @@ The filter looks for messages that match one of the answers in the array of poss
 These work quite similarly to message collectors, except that you apply them on a message rather than a channel. This example uses the <DocsLink path="class/Message?scrollTo=createReactionCollector" type="method" /> method. The filter will check for the 👍 emoji–in the default skin tone specifically, so be wary of that. It will also check that the person who reacted shares the same id as the author of the original message that the collector was assigned to.
 
 ```js
-const filter = (reaction, user) => {
+const collectorFilter = (reaction, user) => {
 	return reaction.emoji.name === '👍' && user.id === message.author.id;
 };
 
-const collector = message.createReactionCollector({ filter, time: 15000 });
+const collector = message.createReactionCollector({ filter: collectorFilter, time: 15000 });
 
 collector.on('collect', (reaction, user) => {
 	console.log(`Collected ${reaction.emoji.name} from ${user.tag}`);
@@ -113,11 +113,11 @@ collector.on('end', collected => {
 <p><DocsLink path="class/Message?scrollTo=awaitReactions" type="method" /> works almost the same as a reaction collector, except it is Promise-based. The same differences apply as with channel collectors.</p>
 
 ```js
-const filter = (reaction, user) => {
+const collectorFilter = (reaction, user) => {
 	return reaction.emoji.name === '👍' && user.id === message.author.id;
 };
 
-message.awaitReactions({ filter, max: 4, time: 60000, errors: ['time'] })
+message.awaitReactions({ filter: collectorFilter, max: 4, time: 60000, errors: ['time'] })
 	.then(collected => console.log(collected.size))
 	.catch(collected => {
 		console.log(`After a minute, only ${collected.size} out of 4 reacted.`);
@@ -161,12 +161,12 @@ Unlike other Promise-based collectors, this method will only ever collect one in
 ```js
 const { ComponentType } = require('discord.js');
 
-const filter = i => {
+const collectorFilter = i => {
 	i.deferUpdate();
 	return i.user.id === interaction.user.id;
 };
 
-message.awaitMessageComponent({ filter, componentType: ComponentType.StringSelect, time: 60000 })
+message.awaitMessageComponent({ filter: collectorFilter, componentType: ComponentType.StringSelect, time: 60000 })
 	.then(interaction => interaction.editReply(`You selected ${interaction.values.join(', ')}!`))
 	.catch(err => console.log('No interactions were collected.'));
 ```

--- a/guide/popular-topics/faq.md
+++ b/guide/popular-topics/faq.md
@@ -188,9 +188,9 @@ channel.send({
 
 ```js
 interaction.reply('Please enter more input.').then(() => {
-	const filter = m => interaction.user.id === m.author.id;
+	const collectorFilter = m => interaction.user.id === m.author.id;
 
-	interaction.channel.awaitMessages({ filter, time: 60000, max: 1, errors: ['time'] })
+	interaction.channel.awaitMessages({ filter: collectorFilter, time: 60000, max: 1, errors: ['time'] })
 		.then(messages => {
 			interaction.followUp(`You've entered: ${messages.first().content}`);
 		})

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -427,11 +427,11 @@ A common use case for reactions in commands is having a user confirm or deny an 
 ```js
 message.react('👍').then(() => message.react('👎'));
 
-const filter = (reaction, user) => {
+const collectorFilter = (reaction, user) => {
 	return ['👍', '👎'].includes(reaction.emoji.name) && user.id === interaction.user.id;
 };
 
-message.awaitReactions({ filter, max: 1, time: 60000, errors: ['time'] })
+message.awaitReactions({ filter: collectorFilter, max: 1, time: 60000, errors: ['time'] })
 	.then(collected => {
 		const reaction = collected.first();
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I think it's better to name the `filter` variable differently than the `filter` option because people are often thinking that they could name the variable however they want and pass it as a key in the method.