### PR TITLE
fix(reloading-commands): add categories to code samples

### DIFF
--- a/code-samples/additional-features/reloading-commands/commands/fun/ping.js
+++ b/code-samples/additional-features/reloading-commands/commands/fun/ping.js
@@ -4,7 +4,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('ping')
 		.setDescription('Replies with Pong!'),
-	category:"fun",
+	category: 'fun',
 	async execute(interaction) {
 		return interaction.reply('Pong!');
 	},

--- a/code-samples/additional-features/reloading-commands/commands/fun/ping.js
+++ b/code-samples/additional-features/reloading-commands/commands/fun/ping.js
@@ -4,6 +4,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('ping')
 		.setDescription('Replies with Pong!'),
+	category:"fun",
 	async execute(interaction) {
 		return interaction.reply('Pong!');
 	},

--- a/code-samples/additional-features/reloading-commands/commands/moderation/kick.js
+++ b/code-samples/additional-features/reloading-commands/commands/moderation/kick.js
@@ -5,7 +5,7 @@ module.exports = {
 		.setName('kick')
 		.setDescription('Select a member and kick them (but not really).')
 		.addUserOption(option => option.setName('target').setDescription('The member to kick').setRequired(true)),
-	category:"moderation",
+	category: 'moderation',
 	async execute(interaction) {
 		const member = interaction.options.getMember('target');
 		return interaction.reply({ content: `You wanted to kick: ${member.user.username}`, ephemeral: true });

--- a/code-samples/additional-features/reloading-commands/commands/moderation/kick.js
+++ b/code-samples/additional-features/reloading-commands/commands/moderation/kick.js
@@ -5,6 +5,7 @@ module.exports = {
 		.setName('kick')
 		.setDescription('Select a member and kick them (but not really).')
 		.addUserOption(option => option.setName('target').setDescription('The member to kick').setRequired(true)),
+	category:"moderation",
 	async execute(interaction) {
 		const member = interaction.options.getMember('target');
 		return interaction.reply({ content: `You wanted to kick: ${member.user.username}`, ephemeral: true });

--- a/code-samples/additional-features/reloading-commands/commands/moderation/prune.js
+++ b/code-samples/additional-features/reloading-commands/commands/moderation/prune.js
@@ -9,6 +9,7 @@ module.exports = {
 				.setDescription('Number of messages to prune')
 				.setMinValue(1)
 				.setMaxValue(100)),
+	category:"moderation",
 	async execute(interaction) {
 		const amount = interaction.options.getInteger('amount');
 

--- a/code-samples/additional-features/reloading-commands/commands/moderation/prune.js
+++ b/code-samples/additional-features/reloading-commands/commands/moderation/prune.js
@@ -9,7 +9,7 @@ module.exports = {
 				.setDescription('Number of messages to prune')
 				.setMinValue(1)
 				.setMaxValue(100)),
-	category:"moderation",
+	category: 'moderation',
 	async execute(interaction) {
 		const amount = interaction.options.getInteger('amount');
 

--- a/code-samples/additional-features/reloading-commands/commands/utility/avatar.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/avatar.js
@@ -5,7 +5,7 @@ module.exports = {
 		.setName('avatar')
 		.setDescription('Get the avatar URL of the selected user, or your own avatar.')
 		.addUserOption(option => option.setName('target').setDescription('The user\'s avatar to show')),
-	category: "utility",
+	category: 'utility',
 	async execute(interaction) {
 		const user = interaction.options.getUser('target');
 		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);

--- a/code-samples/additional-features/reloading-commands/commands/utility/avatar.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/avatar.js
@@ -5,6 +5,7 @@ module.exports = {
 		.setName('avatar')
 		.setDescription('Get the avatar URL of the selected user, or your own avatar.')
 		.addUserOption(option => option.setName('target').setDescription('The user\'s avatar to show')),
+	category: "utility",
 	async execute(interaction) {
 		const user = interaction.options.getUser('target');
 		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);

--- a/code-samples/additional-features/reloading-commands/commands/utility/reload.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/reload.js
@@ -16,11 +16,11 @@ module.exports = {
 			return interaction.reply(`There is no command with name \`${commandName}\`!`);
 		}
 
-		delete require.cache[require.resolve(`./${command.data.name}.js`)];
+		delete require.cache[require.resolve(`../${command.category}/${command.data.name}.js`)];
 
 		try {
 	        interaction.client.commands.delete(command.data.name);
-	        const newCommand = require(`./${command.data.name}.js`);
+	        const newCommand = require(`../${command.category}/${command.data.name}.js`);
 	        interaction.client.commands.set(newCommand.data.name, newCommand);
 	        await interaction.reply(`Command \`${newCommand.data.name}\` was reloaded!`);
 		} catch (error) {

--- a/code-samples/additional-features/reloading-commands/commands/utility/server.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/server.js
@@ -4,7 +4,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('server')
 		.setDescription('Display info about this server.'),
-	category:"utility",
+	category: 'utility',
 	async execute(interaction) {
 		return interaction.reply(`Server name: ${interaction.guild.name}\nTotal members: ${interaction.guild.memberCount}`);
 	},

--- a/code-samples/additional-features/reloading-commands/commands/utility/server.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/server.js
@@ -4,6 +4,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('server')
 		.setDescription('Display info about this server.'),
+	category:"utility",
 	async execute(interaction) {
 		return interaction.reply(`Server name: ${interaction.guild.name}\nTotal members: ${interaction.guild.memberCount}`);
 	},

--- a/code-samples/additional-features/reloading-commands/commands/utility/user.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/user.js
@@ -4,6 +4,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('user')
 		.setDescription('Provides information about the user.'),
+	category:"utility",
 	async execute(interaction) {
 		// interaction.user is the object representing the User who ran the command
 		// interaction.member is the GuildMember object, which represents the user in the specific guild

--- a/code-samples/additional-features/reloading-commands/commands/utility/user.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/user.js
@@ -4,7 +4,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('user')
 		.setDescription('Provides information about the user.'),
-	category:"utility",
+	category: 'utility',
 	async execute(interaction) {
 		// interaction.user is the object representing the User who ran the command
 		// interaction.member is the GuildMember object, which represents the user in the specific guild


### PR DESCRIPTION
For the reloading commands part of the code, it failed to run if the commands were in categories as suggested previously by the guide thus the code couldn't get the commands through require. I added a category key to the exports object and appropriate code in the reload.js file to properly.