### PR TITLE
fix(*): Update message component links to no longer 404

### DIFF
--- a/guide/additional-info/changes-in-v13.md
+++ b/guide/additional-info/changes-in-v13.md
@@ -75,7 +75,7 @@ In addition to the `interactionCreate` event covered in the above guide, this re
 discord.js now has support for message components!
 This introduces the `MessageActionRow`, `MessageButton`, and `MessageSelectMenu` classes, as well as associated interactions and collectors. 
 
-Refer to the [message components](/interactions/buttons.html) section of this guide to get started.
+Refer to the [message components](/message-components/buttons.md) section of this guide to get started.
 
 ## Threads
 
@@ -1136,7 +1136,7 @@ A Collection of Roles which are managed by the integration.
 
 Provides gateway support for slash command and message component interactions. 
 
-For more information refer to the [slash commands](/interactions/slash-commands.md#replying-to-slash-commands) and [message components](/interactions/buttons.html#responding-to-buttons.html) sections of the guide.
+For more information refer to the [slash commands](/interactions/slash-commands.md#replying-to-slash-commands) and [message components](/message-components/buttons) sections of the guide.
 
 ### InteractionCollector
 

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -134,7 +134,7 @@ You've successfully sent a response to a slash command! However, this is only th
 * utilising the different [Response methods](/slash-commands/response-methods.md) that can be used for slash commands.
 * expanding on these examples with additional validated option types in [Advanced command creation](/slash-commands/advanced-creation.md).
 * adding formatted [Embeds](/popular-topics/embeds.md) to your responses.
-* enhancing the command functionality with [Buttons](/interactions/buttons) and [Select Menus](/interactions/select-menus.md).
+* enhancing the command functionality with [Buttons](/message-components/buttons) and [Select Menus](/message-components/select-menus.md).
 * prompting the user for more information with [Modals](/interactions/modals.md).
 
 #### Resulting code

--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -134,7 +134,7 @@ You've successfully sent a response to a slash command! However, this is only th
 * utilising the different [Response methods](/slash-commands/response-methods.md) that can be used for slash commands.
 * expanding on these examples with additional validated option types in [Advanced command creation](/slash-commands/advanced-creation.md).
 * adding formatted [Embeds](/popular-topics/embeds.md) to your responses.
-* enhancing the command functionality with [Buttons](/message-components/buttons) and [Select Menus](/message-components/select-menus.md).
+* enhancing the command functionality with [Buttons](/message-components/buttons) and [Select Menus](/message-components/select-menus).
 * prompting the user for more information with [Modals](/interactions/modals.md).
 
 #### Resulting code

--- a/guide/slash-commands/permissions.md
+++ b/guide/slash-commands/permissions.md
@@ -51,7 +51,7 @@ const data = new SlashCommandBuilder()
 	.setDefaultMemberPermissions(PermissionFlagsBits.KickMembers);
 ```
 
-In reality, you'll probably want to have an additional confirmation step before a ban actually executes. Check out the [button components section](/interactions/buttons.html) of the guide to see how to add confirmation buttons to your command responses, and listen to button clicks.
+In reality, you'll probably want to have an additional confirmation step before a ban actually executes. Check out the [button components section](/message-components/buttons) of the guide to see how to add confirmation buttons to your command responses, and listen to button clicks.
 
 ## DM permission
 

--- a/guide/whats-new.md
+++ b/guide/whats-new.md
@@ -45,8 +45,8 @@ All content has been updated to use discord.js v14 syntax. The v13 version of th
 
 - [Updating from v13 to v14](/additional-info/changes-in-v14.md): A list of the changes from discord.js v13 to v14
 - [Slash commands](/slash-commands/advanced-creation.md): Registering, replying to slash commands and permissions
-- [Buttons](/interactions/buttons.md): Building, sending, and receiving buttons
-- [Select menus](/interactions/select-menus.md): Building, sending, and receiving select menus
+- [Buttons](/message-components/buttons): Building, sending, and receiving buttons
+- [Select menus](/message-components/select-menus): Building, sending, and receiving select menus
 - [Threads](/popular-topics/threads.md): Creating and managing threads
 - [Formatters](/popular-topics/formatters.md): A collection of formatters to use with your bot
 


### PR DESCRIPTION
Just a small change to prevent 404, I updated 2 links from `/interactions` to `/message-components`.