### PR TITLE
Fixed Typo advanced-creation.md

### DIFF
--- a/guide/slash-commands/advanced-creation.md
+++ b/guide/slash-commands/advanced-creation.md
@@ -87,7 +87,7 @@ const data = new SlashCommandBuilder()
 	.addStringOption(option =>
 		option.setName('input')
 			.setDescription('The input to echo back')
-			.setRequired(true));
+			.setRequired(true);
 ```
 
 ## Choices


### PR DESCRIPTION
fixed a typo on the .setRequired() method.