### PR TITLE
fix: remove `dynamic: true` in code samples

### DIFF
--- a/code-samples/additional-features/cooldowns/commands/utility/avatar.js
+++ b/code-samples/additional-features/cooldowns/commands/utility/avatar.js
@@ -8,7 +8,7 @@ module.exports = {
 		.addUserOption(option => option.setName('target').setDescription('The user\'s avatar to show')),
 	async execute(interaction) {
 		const user = interaction.options.getUser('target');
-		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);
+		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL()}`);
 		return interaction.reply(`Your avatar: ${interaction.user.displayAvatarURL()}`);
 	},
 };

--- a/code-samples/additional-features/reloading-commands/commands/utility/avatar.js
+++ b/code-samples/additional-features/reloading-commands/commands/utility/avatar.js
@@ -8,7 +8,7 @@ module.exports = {
 	category: 'utility',
 	async execute(interaction) {
 		const user = interaction.options.getUser('target');
-		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);
+		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL()}`);
 		return interaction.reply(`Your avatar: ${interaction.user.displayAvatarURL()}`);
 	},
 };

--- a/code-samples/creating-your-bot/command-handling/commands/utility/avatar.js
+++ b/code-samples/creating-your-bot/command-handling/commands/utility/avatar.js
@@ -7,7 +7,7 @@ module.exports = {
 		.addUserOption(option => option.setName('target').setDescription('The user\'s avatar to show')),
 	async execute(interaction) {
 		const user = interaction.options.getUser('target');
-		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL({ dynamic: true })}`);
+		if (user) return interaction.reply(`${user.username}'s avatar: ${user.displayAvatarURL()}`);
 		return interaction.reply(`Your avatar: ${interaction.user.displayAvatarURL()}`);
 	},
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This property doesn't exist in v14 and having it in the code sample that's referenced in the guide may lead to some confusion.
