### PR TITLE
Update intents.md

### DIFF
--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -20,7 +20,7 @@ To specify which events you want your bot to receive, first think about which ev
 
 All gateway intents, and the events belonging to each, are listed on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#list-of-intents).
 
-To see their discord.js-specific names, see them listed on the [Discord API Types](https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits).
+The library equivalent of which are listed on the [Discord API Types](https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits).
 
 - If you need your bot to receive messages (`MESSAGE_CREATE` - `"messageCreate"` in discord.js), you need the `Guilds` and `GuildMessages` intent, plus the `MessageContent` privileged intent to receive the `content`, `attachments`, `embeds` and `components` fields of the message.
 - If you want your bot to post welcome messages for new members (`GUILD_MEMBER_ADD` - `"guildMemberAdd"` in discord.js), you need the `GuildMembers` privileged intent, and so on.

--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -18,7 +18,9 @@ Should you receive an error prefixed with `[DisallowedIntents]`, please review y
 
 To specify which events you want your bot to receive, first think about which events your bot needs to operate. Then select the required intents and add them to your client constructor, as shown below.
 
-All gateway intents, and the events belonging to each, are listed on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#list-of-intents). 
+All gateway intents, and the events belonging to each, are listed on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#list-of-intents).
+
+To see their discord.js-specific names, see them listed on the [Discord API Types](https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits).
 
 - If you need your bot to receive messages (`MESSAGE_CREATE` - `"messageCreate"` in discord.js), you need the `Guilds` and `GuildMessages` intent, plus the `MessageContent` privileged intent to receive the `content`, `attachments`, `embeds` and `components` fields of the message.
 - If you want your bot to post welcome messages for new members (`GUILD_MEMBER_ADD` - `"guildMemberAdd"` in discord.js), you need the `GuildMembers` privileged intent, and so on.

--- a/guide/popular-topics/intents.md
+++ b/guide/popular-topics/intents.md
@@ -18,9 +18,7 @@ Should you receive an error prefixed with `[DisallowedIntents]`, please review y
 
 To specify which events you want your bot to receive, first think about which events your bot needs to operate. Then select the required intents and add them to your client constructor, as shown below.
 
-All gateway intents, and the events belonging to each, are listed on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#list-of-intents).
-
-The library equivalent of which are listed on the [Discord API Types](https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits).
+You can find the list of all current gateway intents and the events belonging to each on the [Discord API documentation](https://discord.com/developers/docs/topics/gateway#list-of-intents) and the enum values used in discord.js on the [Discord API types documentation](https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits).
 
 - If you need your bot to receive messages (`MESSAGE_CREATE` - `"messageCreate"` in discord.js), you need the `Guilds` and `GuildMessages` intent, plus the `MessageContent` privileged intent to receive the `content`, `attachments`, `embeds` and `components` fields of the message.
 - If you want your bot to post welcome messages for new members (`GUILD_MEMBER_ADD` - `"guildMemberAdd"` in discord.js), you need the `GuildMembers` privileged intent, and so on.


### PR DESCRIPTION
# Changes:
Added a single line that points to https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits
This link provides the names of the available intents compared to the current link to the discord API which did not list the discord.js names, just the API names.

# Purpose
The change is to provide additional, easy-to-access information for users.
