### PR TITLE
fix(interactions): invalid link to event handling in component interactions

### DIFF
--- a/guide/message-components/interactions.md
+++ b/guide/message-components/interactions.md
@@ -104,7 +104,7 @@ collector.on('collect', async i => {
 
 Third and finally, you may wish to have a listener setup to respond to permanent button or select menu features of your guild. For this, returning to the <DocsLink path="class/Client?scrollTo=e-interactionCreate" /> event is the best approach.
 
-If you're event handling has been setup in multiple files as per our [event handling](creating-your-bot/event-handling) guide, you should already have an `events/interactionCreate.js` file that looks something like this.
+If you're event handling has been setup in multiple files as per our [event handling](/creating-your-bot/event-handling) guide, you should already have an `events/interactionCreate.js` file that looks something like this.
 
 ```js {6}
 const { Events } = require('discord.js');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes an invalid link which would take you to https://discordjs.guide/message-components/creating-your-bot/event-handling which doesn't exist, it should be https://discordjs.guide/creating-your-bot/event-handling