### PR TITLE
Implementing directory-import for command and event handling

### DIFF
--- a/guide/creating-your-bot/command-deployment.md
+++ b/guide/creating-your-bot/command-deployment.md
@@ -46,29 +46,17 @@ With these defined, you can use the deployment script below:
 ```js
 const { REST, Routes } = require('discord.js');
 const { clientId, guildId, token } = require('./config.json');
-const fs = require('node:fs');
-const path = require('node:path');
+const { directoryImport } = require('directory-import')
 
 const commands = [];
 // Grab all the command files from the commands directory you created earlier
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
-
-for (const folder of commandFolders) {
-	// Grab all the command files from the commands directory you created earlier
-	const commandsPath = path.join(foldersPath, folder);
-	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
-	// Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
-	for (const file of commandFiles) {
-		const filePath = path.join(commandsPath, file);
-		const command = require(filePath);
-		if ('data' in command && 'execute' in command) {
-			commands.push(command.data.toJSON());
-		} else {
-			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
-		}
-	}
-}
+directoryImport('./commands', (_, commandPath, command) => {
+  if ('data' in command && 'execute' in command) {
+    commands.push(command.data.toJSON());
+  } else {
+    console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`)
+  }
+})
 
 // Construct and prepare an instance of the REST module
 const rest = new REST().setToken(token);

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -22,7 +22,7 @@ In your `index.js` file, make these additions to the base template:
 
 ```js {1-3,8}
 const path = require('node:path');
-const { directoryImport } = require('directory-import')
+const { directoryImport } = require('directory-import');
 const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
@@ -45,12 +45,12 @@ Next, using the modules imported above, dynamically retrieve your command files 
 client.commands = new Collection();
 
 directoryImport('./commands', (_, commandPath, command) => {
-  if ('data' in command && 'execute' in command) {
-    client.commands.set(command.data.name, command);
-  } else {
-    console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`)
-  }
-})
+	if ('data' in command && 'execute' in command) {
+		client.commands.set(command.data.name, command);
+	} else {
+		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`);
+	}
+});
 ```
 
 First, [`directoryImport`](https://www.npmjs.com/package/directory-import) helps to import all command files in the `commands` directory. The callback function then checks that each command has at least the `data` and `execute` properties. This helps to prevent errors resulting from loading empty, unfinished or otherwise incorrect command files while you're still developing.

--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -20,7 +20,7 @@ Now that your command files have been created, your bot needs to load these file
 
 In your `index.js` file, make these additions to the base template:
 
-```js {1-3,8}
+```js {1-4,8}
 const path = require('node:path');
 const { directoryImport } = require('directory-import');
 const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
@@ -41,7 +41,7 @@ We recommend attaching a `.commands` property to your client instance so that yo
 
 Next, using the modules imported above, dynamically retrieve your command files with a few more additions to the `index.js` file:
 
-```js {3-15}
+```js {3-9}
 client.commands = new Collection();
 
 directoryImport('./commands', (_, commandPath, command) => {

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -131,7 +131,7 @@ The `name` property states which event this file is for, and the `once` property
 
 Next, let's write the code for dynamically retrieving all the event files in the `events` folder. We'll be taking a similar approach to our [command handler](/creating-your-bot/command-handling.md). Place the new code highlighted below in your `index.js`.
 
-```js {26-37}
+```js {19-25}
 const { directoryImport } = require('directory-import');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -104,30 +104,21 @@ module.exports = {
 :::
 ::: code-group-item index.js (after)
 ```js
-const fs = require('node:fs');
-const path = require('node:path');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
+const { directoryImport } = require('directory-import')
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.commands = new Collection();
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
 
-for (const folder of commandFolders) {
-	const commandsPath = path.join(foldersPath, folder);
-	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
-	for (const file of commandFiles) {
-		const filePath = path.join(commandsPath, file);
-		const command = require(filePath);
-		if ('data' in command && 'execute' in command) {
-			client.commands.set(command.data.name, command);
-		} else {
-			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
-		}
+directoryImport('./commands', (_, commandPath, command) => {
+	if ('data' in command && 'execute' in command) {
+		client.commands.set(command.data.name, command);
+	} else {
+		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`)
 	}
-}
+})
 
 client.login(token);
 ```
@@ -140,46 +131,32 @@ The `name` property states which event this file is for, and the `once` property
 
 Next, let's write the code for dynamically retrieving all the event files in the `events` folder. We'll be taking a similar approach to our [command handler](/creating-your-bot/command-handling.md). Place the new code highlighted below in your `index.js`.
 
-`fs.readdirSync().filter()` returns an array of all the file names in the given directory and filters for only `.js` files, i.e. `['ready.js', 'interactionCreate.js']`.
-
 ```js {26-37}
-const fs = require('node:fs');
-const path = require('node:path');
+const { directoryImport } = require('directory-import')
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.commands = new Collection();
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
 
-for (const folder of commandFolders) {
-	const commandsPath = path.join(foldersPath, folder);
-	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
-	for (const file of commandFiles) {
-		const filePath = path.join(commandsPath, file);
-		const command = require(filePath);
-		if ('data' in command && 'execute' in command) {
-			client.commands.set(command.data.name, command);
-		} else {
-			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
-		}
+// Load commands
+directoryImport('./commands', (_, commandPath, command) => {
+	if ('data' in command && 'execute' in command) {
+		client.commands.set(command.data.name, command);
+	} else {
+		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`)
 	}
-}
+})
 
-const eventsPath = path.join(__dirname, 'events');
-const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'));
-
-for (const file of eventFiles) {
-	const filePath = path.join(eventsPath, file);
-	const event = require(filePath);
+// Load events
+directoryImport('./events', (_, eventPath, event) => {
 	if (event.once) {
 		client.once(event.name, (...args) => event.execute(...args));
 	} else {
 		client.on(event.name, (...args) => event.execute(...args));
 	}
-}
+})
 
 client.login(token);
 ```

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -105,7 +105,7 @@ module.exports = {
 ::: code-group-item index.js (after)
 ```js
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
-const { directoryImport } = require('directory-import')
+const { directoryImport } = require('directory-import');
 const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
@@ -116,9 +116,9 @@ directoryImport('./commands', (_, commandPath, command) => {
 	if ('data' in command && 'execute' in command) {
 		client.commands.set(command.data.name, command);
 	} else {
-		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`)
+		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`);
 	}
-})
+});
 
 client.login(token);
 ```
@@ -132,7 +132,7 @@ The `name` property states which event this file is for, and the `once` property
 Next, let's write the code for dynamically retrieving all the event files in the `events` folder. We'll be taking a similar approach to our [command handler](/creating-your-bot/command-handling.md). Place the new code highlighted below in your `index.js`.
 
 ```js {26-37}
-const { directoryImport } = require('directory-import')
+const { directoryImport } = require('directory-import');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const { token } = require('./config.json');
 
@@ -145,9 +145,9 @@ directoryImport('./commands', (_, commandPath, command) => {
 	if ('data' in command && 'execute' in command) {
 		client.commands.set(command.data.name, command);
 	} else {
-		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`)
+		console.log(`[WARNING] The command at ${commandPath} is missing a required "data" or "execute" property.`);
 	}
-})
+});
 
 // Load events
 directoryImport('./events', (_, eventPath, event) => {
@@ -156,7 +156,7 @@ directoryImport('./events', (_, eventPath, event) => {
 	} else {
 		client.on(event.name, (...args) => event.execute(...args));
 	}
-})
+});
 
 client.login(token);
 ```


### PR DESCRIPTION
This pull request integrates the directory-import module into both command and event handling, aiming to streamline the import process.

Updates include:

Command Handling: The manual method of importing each command from the commands directory has been replaced with the directory-import module, simplifying command management.

Event Handling: Similarly, the module has been implemented for event handling. This should simplify and improve the current process which depends on manual work.

The usage of directory-import module should significantly improve the efficiency of managing commands and events in the Discord bot by automating imports.

I look forward to your feedback and I am open to making any further changes if required.

This change also validates the module for adaptability and can be a case for integrating into other areas of the project as necessary. I believe this will advance the quality and maintainability of the code overall.