### PR TITLE
refactor: Standardise `ClientReady` event

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,8 +191,8 @@ When you want to highlight a piece of code to display either an addition or a di
 Here's our base code:
 
 ```js {2,6}
-client.once(Events.ClientReady, () => {
-	console.log('Ready.');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.MessageCreate, message => {
@@ -203,8 +203,8 @@ client.on(Events.MessageCreate, message => {
 To add this feature, use this code:
 
 ```js {2,6-8}
-client.once(Events.ClientReady, () => {
-	console.log(`${client.user.tag} ready.`);
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.MessageCreate, message => {

--- a/code-samples/additional-features/cooldowns/index.js
+++ b/code-samples/additional-features/cooldowns/index.js
@@ -24,8 +24,8 @@ for (const folder of commandFolders) {
 	}
 }
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/code-samples/additional-info/rest-api/14/index.js
+++ b/code-samples/additional-info/rest-api/14/index.js
@@ -5,8 +5,8 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 const trim = (str, max) => (str.length > max ? `${str.slice(0, max - 3)}...` : str);
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/code-samples/creating-your-bot/command-deployment/index.js
+++ b/code-samples/creating-your-bot/command-deployment/index.js
@@ -23,8 +23,8 @@ for (const folder of commandFolders) {
 	}
 }
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/code-samples/creating-your-bot/command-handling/index.js
+++ b/code-samples/creating-your-bot/command-handling/index.js
@@ -23,8 +23,8 @@ for (const folder of commandFolders) {
 	}
 }
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/code-samples/creating-your-bot/initial-files/index.js
+++ b/code-samples/creating-your-bot/initial-files/index.js
@@ -3,8 +3,8 @@ const { token } = require('./config.json');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.login(token);

--- a/code-samples/creating-your-bot/slash-commands/index.js
+++ b/code-samples/creating-your-bot/slash-commands/index.js
@@ -5,8 +5,8 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // When the client is ready, run this code (only once)
-client.once(Events.ClientReady, c => {
-	console.log(`Ready! Logged in as ${c.user.tag}`);
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 // Log in to Discord with your client's token

--- a/code-samples/keyv/index.js
+++ b/code-samples/keyv/index.js
@@ -5,8 +5,8 @@ const { globalPrefix, token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent] });
 const prefixes = new Keyv('sqlite://path/to.sqlite');
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.MessageCreate, async message => {

--- a/code-samples/popular-topics/canvas/14/index.js
+++ b/code-samples/popular-topics/canvas/14/index.js
@@ -5,8 +5,8 @@ const { request } = require('undici');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 const applyText = (canvas, text) => {

--- a/code-samples/popular-topics/permissions/14/index.js
+++ b/code-samples/popular-topics/permissions/14/index.js
@@ -3,8 +3,8 @@ const { ChannelType, Client, Events, Formatters, GatewayIntentBits, PermissionsB
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, interaction => {

--- a/code-samples/popular-topics/reactions/14/awaiting-reactions.js
+++ b/code-samples/popular-topics/reactions/14/awaiting-reactions.js
@@ -4,8 +4,8 @@ const client = new Client({
 	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessageReactions],
 });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/code-samples/popular-topics/reactions/14/basic-reacting.js
+++ b/code-samples/popular-topics/reactions/14/basic-reacting.js
@@ -4,8 +4,8 @@ const client = new Client({
 	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessageReactions],
 });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/code-samples/popular-topics/reactions/14/uncached-messages.js
+++ b/code-samples/popular-topics/reactions/14/uncached-messages.js
@@ -5,8 +5,8 @@ const client = new Client({
 	partials: [Partials.Message, Partials.Channel, Partials.Reaction],
 });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.MessageReactionAdd, async (reaction, user) => {

--- a/code-samples/sequelize/tags/sequelize.js
+++ b/code-samples/sequelize/tags/sequelize.js
@@ -30,7 +30,7 @@ const Tags = sequelize.define('tags', {
 	},
 });
 
-client.once(Events.ClientReady, () => {
+client.once(Events.ClientReady, readyClient => {
 	/*
 	 * equivalent to: CREATE TABLE tags(
 	 * name VARCHAR(255),
@@ -41,7 +41,7 @@ client.once(Events.ClientReady, () => {
 	 */
 	Tags.sync();
 
-	console.log(`Logged in as ${client.user.tag}!`);
+	console.log(`Logged in as ${readyClient.user.tag}!`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/guide/additional-info/rest-api.md
+++ b/guide/additional-info/rest-api.md
@@ -43,8 +43,8 @@ const { Client, EmbedBuilder, Events, GatewayIntentBits } = require('discord.js'
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/guide/creating-your-bot/event-handling.md
+++ b/guide/creating-your-bot/event-handling.md
@@ -11,8 +11,8 @@ At this point, your `index.js` file has listeners for two events: `ClientReady` 
 :::: code-group
 ::: code-group-item ClientReady
 ```js
-client.once(Events.ClientReady, c => {
-	console.log(`Ready! Logged in as ${c.user.tag}`);
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 ```
 :::

--- a/guide/creating-your-bot/main-file.md
+++ b/guide/creating-your-bot/main-file.md
@@ -17,7 +17,7 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // When the client is ready, run this code (only once).
-// The distinction between `client: Client<boolean>` and `readyClient: Client<true>` is important for TypeScript Developers.
+// The distinction between `client: Client<boolean>` and `readyClient: Client<true>` is important for TypeScript developers.
 // It makes some properties non-nullable.
 client.once(Events.ClientReady, readyClient => {
 	console.log(`Ready! Logged in as ${readyClient.user.tag}`);

--- a/guide/creating-your-bot/main-file.md
+++ b/guide/creating-your-bot/main-file.md
@@ -16,7 +16,7 @@ const { token } = require('./config.json');
 // Create a new client instance
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-// When the client is ready, run this code (only once)
+// When the client is ready, run this code (only once).
 // The distinction between `client: Client<boolean>` and `readyClient: Client<true>` is important for TypeScript Developers.
 // It makes some properties non-nullable.
 client.once(Events.ClientReady, readyClient => {

--- a/guide/creating-your-bot/main-file.md
+++ b/guide/creating-your-bot/main-file.md
@@ -17,9 +17,8 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // When the client is ready, run this code (only once)
-// We use 'readyClient' for the event parameter to keep it separate from the already defined 'client'
-// This is important for TypeScript developers as the parameter will be a client that is ready
-// with some properties being non-nullable
+// The distinction between `client: Client<boolean>` and `readyClient: Client<true>` is important for TypeScript Developers.
+// It makes some properties non-nullable.
 client.once(Events.ClientReady, readyClient => {
 	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });

--- a/guide/creating-your-bot/main-file.md
+++ b/guide/creating-your-bot/main-file.md
@@ -17,9 +17,11 @@ const { token } = require('./config.json');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // When the client is ready, run this code (only once)
-// We use 'c' for the event parameter to keep it separate from the already defined 'client'
-client.once(Events.ClientReady, c => {
-	console.log(`Ready! Logged in as ${c.user.tag}`);
+// We use 'readyClient' for the event parameter to keep it separate from the already defined 'client'
+// This is important for TypeScript developers as the parameter will be a client that is ready
+// with some properties being non-nullable
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 // Log in to Discord with your client's token

--- a/guide/popular-topics/canvas.md
+++ b/guide/popular-topics/canvas.md
@@ -44,8 +44,8 @@ const Canvas = require('@napi-rs/canvas');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, interaction => {

--- a/guide/popular-topics/reactions.md
+++ b/guide/popular-topics/reactions.md
@@ -25,8 +25,8 @@ const client = new Client({
 	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMessageReactions],
 });
 
-client.once(Events.ClientReady, () => {
-	console.log('Ready!');
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, interaction => {

--- a/guide/sequelize/README.md
+++ b/guide/sequelize/README.md
@@ -50,8 +50,8 @@ const { Client, Events, GatewayIntentBits } = require('discord.js');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // When the client is ready, run this code (only once)
-client.once(Events.ClientReady, () => {
-	console.log(`Logged in as ${client.user.tag}!`);
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.InteractionCreate, async interaction => {
@@ -139,9 +139,9 @@ The model mirrors very closely what the database defines. There will be a table 
 Now that your structure is defined, you need to make sure the model exists in the database. To make sure the bot is ready and all the data you might need has arrived, add this line in your code.
 
 ```js {3}
-client.once(Events.ClientReady, () => {
+client.once(Events.ClientReady, readyClient => {
 	Tags.sync();
-	console.log(`Logged in as ${client.user.tag}!`);
+	console.log(`Logged in as ${readyClient.user.tag}!`);
 });
 ```
 

--- a/guide/sequelize/currency.md
+++ b/guide/sequelize/currency.md
@@ -207,8 +207,8 @@ const { Users, CurrencyShop } = require('./dbObjects.js');
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 const currency = new Collection();
 
-client.once(Events.ClientReady, async () => {
-	console.log(`Logged in as ${client.user.tag}!`);
+client.once(Events.ClientReady, readyClient => {
+	console.log(`Ready! Logged in as ${readyClient.user.tag}`);
 });
 
 client.on(Events.MessageCreate, async message => {
@@ -259,11 +259,11 @@ This defines the `addBalance()` helper function, since it'll be used quite frequ
 ### Ready event data sync
 
 ```js {2-3}
-client.once(Events.ClientReady, async () => {
+client.once(Events.ClientReady, async readyClient => {
 	const storedBalances = await Users.findAll();
 	storedBalances.forEach(b => currency.set(b.user_id, b));
 
-	console.log(`Logged in as ${client.user.tag}!`);
+	console.log(`Logged in as ${readyClient.user.tag}!`);
 });
 ```
 


### PR DESCRIPTION
Per https://github.com/discordjs/guide/pull/1525#pullrequestreview-1747094664, this event has been standardised everywhere it should be in the guide.

The first instance of this when following the guide is at guide/creating-your-bot/main-file.md. There were some code comments already, so I appended why this is useful for TypeScript users.