### PR TITLE
fix(es6-syntax): rearrange username and password for consistency

### DIFF
--- a/guide/additional-info/es6-syntax.md
+++ b/guide/additional-info/es6-syntax.md
@@ -106,8 +106,8 @@ console.log(
 
 ```js
 // template literals
-console.log(`Your password is: **${password}**.`);
 console.log(`Your username is: **${username}**.`);
+console.log(`Your password is: **${password}**.`);
 
 console.log(`1 + 1 = ${1 + 1}`);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I rearranged the username and password line in the ES6 example to match exactly the ES5 example. Then people won't get confused.

You can look at https://discordjs.guide/additional-info/es6-syntax.html#template-literals-vs-string-concatenation to see for yourself what it looks like currently.