### PR TITLE
fix(cache-customization): Access `client` from callback parameter

### DIFF
--- a/guide/miscellaneous/cache-customization.md
+++ b/guide/miscellaneous/cache-customization.md
@@ -53,7 +53,7 @@ const client = new Client({
 		ReactionManager: 0,
 		GuildMemberManager: {
 			maxSize: 200,
-			keepOverLimit: member => member.id === client.user.id,
+			keepOverLimit: member => member.id === member.client.user.id,
 		},
 	}),
 });
@@ -81,11 +81,11 @@ const client = new Client({
 		...Options.DefaultSweeperSettings,
 		messages: {
 			interval: 3_600, // Every hour.
-			lifetime: 1_800,	// Remove messages older than 30 minutes.
+			lifetime: 1_800, // Remove messages older than 30 minutes.
 		},
 		users: {
 			interval: 3_600, // Every hour.
-			filter: () => user => user.bot && user.id !== client.user.id, // Remove all bots.
+			filter: () => user => user.bot && user.id !== user.client.user.id, // Remove all bots.
 		},
 	},
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Using client while constructing it leads to it being of type `any` instead of `Client<boolean>`. Accessing it from the callback parameter fixes this.