### PR TITLE
fix(popular-topics): replace deprecated `underscore` with `underline`

### DIFF
--- a/guide/popular-topics/formatters.md
+++ b/guide/popular-topics/formatters.md
@@ -7,13 +7,13 @@ discord.js provides the <PackageLink name="formatters" /> package which contains
 These functions format strings into all the different Markdown styles supported by Discord.
 
 ```js
-const { bold, italic, strikethrough, underscore, spoiler, quote, blockQuote } = require('discord.js');
+const { blockQuote, bold, italic, quote, spoiler, strikethrough, underline } = require('discord.js');
 const string = 'Hello!';
 
 const boldString = bold(string);
 const italicString = italic(string);
 const strikethroughString = strikethrough(string);
-const underscoreString = underscore(string);
+const underlineString = underline(string);
 const spoilerString = spoiler(string);
 const quoteString = quote(string);
 const blockquoteString = blockQuote(string);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaced the deprecated `underscore` formatter with `underline`