### PR TITLE
Fixing a Typo

### DIFF
--- a/guide/oauth2/README.md
+++ b/guide/oauth2/README.md
@@ -168,7 +168,7 @@ if (localStorage.getItem('oauth-state') !== atob(decodeURIComponent(state))) {
 ```
 
 ::: tip
-Don't forgo security for a tiny bit of convenience!
+Don't forget security for a tiny bit of convenience!
 :::
 
 ### Authorization code grant flow


### PR DESCRIPTION
In this commit, a typo has been fixed.

**Please describe the changes this PR makes and why it should be merged:**
A typo has been corrected.
`forgo -> forget`
