### PR TITLE
Add clarity to clearly state that the ‘first’ audit log is the newest

### DIFF
--- a/guide/popular-topics/audit-logs.md
+++ b/guide/popular-topics/audit-logs.md
@@ -32,7 +32,7 @@ const fetchedLogs = await guild.fetchAuditLogs({
 const firstEntry = fetchedLogs.entries.first();
 ```
 
-This will return the first entry where an invite was created. You used `limit: 1` here to specify only one entry.
+This will return the first entry where an invite was created - it's worth noting that 'first' entry is the newest, or most recent, one. You used `limit: 1` here to specify only one entry.
 
 ## Receiving Audit Logs
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a small bit of extra text to make it clear to readers that the ‘first’ audit log is the most recent. Readers may be confused without this addition as they might believe that the first log is the first created, and therefore the oldest, however this isn’t the case and should be made clear.