### PR TITLE
chore(slash-commands): replace `setDMPermission` with `setContexts`

### DIFF
--- a/guide/slash-commands/parsing-options.md
+++ b/guide/slash-commands/parsing-options.md
@@ -5,7 +5,7 @@
 In this section, we'll cover how to access the values of a command's options. Consider the following `ban` command example with two options:
 
 ```js {7-15}
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -21,7 +21,7 @@ module.exports = {
 				.setName('reason')
 				.setDescription('The reason for banning'))
 		.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
-		.setDMPermission(false),
+		.setContexts(InteractionContextType.Guild),
 };
 ```
 

--- a/guide/slash-commands/permissions.md
+++ b/guide/slash-commands/permissions.md
@@ -53,14 +53,14 @@ const data = new SlashCommandBuilder()
 
 In reality, you'll probably want to have an additional confirmation step before a ban actually executes. Check out the [button components section](/message-components/buttons) of the guide to see how to add confirmation buttons to your command responses, and listen to button clicks.
 
-## DM permission
+## Contexts
 
-By default, globally-deployed commands are also available for use in DMs. You can use <DocsLink section="builders" path="SlashCommandBuilder:Class#setDMPermission" type="method" /> to disable this behaviour. Commands deployed to specific guilds are not available in DMs.
+By default, globally-deployed commands are also available for use in DMs. You can pass in [InteractionContextType](https://discord-api-types.dev/api/discord-api-types-v10/enum/InteractionContextType) to the `setContexts` method of the builder to restrict the command to only be available in guilds or DMs.
 
-It doesn't make much sense for your `ban` command to be available in DMs, so you can add `setDMPermission(false)` to the builder to remove it:
+It doesn't make much sense for your `ban` command to be available in DMs, so you can add `setContexts(InteractionContextType.Guild)` to the builder so that it is only available in guilds:
 
 ```js {11-12}
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } = require('discord.js');
 
 const data = new SlashCommandBuilder()
 	.setName('ban')
@@ -71,7 +71,7 @@ const data = new SlashCommandBuilder()
 			.setDescription('The member to ban')
 			.setRequired(true))
 	.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
-	.setDMPermission(false);
+	.setContexts(InteractionContextType.Guild);
 ```
 
-And that's all you need to know on slash command permissions!
+And that's all you need to know on slash command permissions and contexts!


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaces information about deprecated `SlashCommandBuilder#setDMPermission` with `SlashCommandBuilder#setContexts`