### PR TITLE
fix: add vite@2.5.0 as a devDependency to resolve build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "eslint-config-sora": "^3.1.0",
                 "eslint-plugin-markdown": "^1.0.0",
                 "eslint-plugin-vue": "^7.5.0",
+                "vite": "^2.5.0",
                 "vuepress-vite": "^2.0.0-beta.24"
             }
         },
@@ -771,22 +772,6 @@
                 "@types/react": ">= 16.8.0 < 18.0.0",
                 "react": ">= 16.8.0 < 18.0.0",
                 "react-dom": ">= 16.8.0 < 18.0.0"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-            "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -2546,326 +2531,6 @@
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
-            }
-        },
-        "node_modules/esbuild-android-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-            "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-android-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-            "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-darwin-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-            "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-darwin-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-            "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-freebsd-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-            "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-freebsd-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-            "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-32": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-            "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-            "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-arm": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-            "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-            "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-mips64le": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-            "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-ppc64le": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-            "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-riscv64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-            "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-s390x": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-            "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-netbsd-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-            "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-openbsd-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-            "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-sunos-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-            "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-windows-32": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-            "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-windows-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-            "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-windows-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-            "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/escalade": {
@@ -5619,15 +5284,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "2.9.18",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
-            "integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.0.tgz",
+            "integrity": "sha512-Dn4B+g54PJsMG5WCc4QeFy1ygMXRdTtFrUPegqfk4+vzVQcbF/DqqmI/1bxezArzbujBJg/67QeT5wz8edfJVQ==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.14.27",
-                "postcss": "^8.4.13",
-                "resolve": "^1.22.0",
-                "rollup": ">=2.59.0 <2.78.0"
+                "esbuild": "^0.12.17",
+                "postcss": "^8.3.6",
+                "resolve": "^1.20.0",
+                "rollup": "^2.38.5"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -5637,58 +5302,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            },
-            "peerDependencies": {
-                "less": "*",
-                "sass": "*",
-                "stylus": "*"
-            },
-            "peerDependenciesMeta": {
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite/node_modules/esbuild": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-            "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/linux-loong64": "0.14.54",
-                "esbuild-android-64": "0.14.54",
-                "esbuild-android-arm64": "0.14.54",
-                "esbuild-darwin-64": "0.14.54",
-                "esbuild-darwin-arm64": "0.14.54",
-                "esbuild-freebsd-64": "0.14.54",
-                "esbuild-freebsd-arm64": "0.14.54",
-                "esbuild-linux-32": "0.14.54",
-                "esbuild-linux-64": "0.14.54",
-                "esbuild-linux-arm": "0.14.54",
-                "esbuild-linux-arm64": "0.14.54",
-                "esbuild-linux-mips64le": "0.14.54",
-                "esbuild-linux-ppc64le": "0.14.54",
-                "esbuild-linux-riscv64": "0.14.54",
-                "esbuild-linux-s390x": "0.14.54",
-                "esbuild-netbsd-64": "0.14.54",
-                "esbuild-openbsd-64": "0.14.54",
-                "esbuild-sunos-64": "0.14.54",
-                "esbuild-windows-32": "0.14.54",
-                "esbuild-windows-64": "0.14.54",
-                "esbuild-windows-arm64": "0.14.54"
             }
         },
         "node_modules/vue": {
@@ -6570,13 +6183,6 @@
                 "@docsearch/css": "3.0.0-alpha.34",
                 "algoliasearch": "^4.0.0"
             }
-        },
-        "@esbuild/linux-loong64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-            "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-            "dev": true,
-            "optional": true
         },
         "@eslint/eslintrc": {
             "version": "0.4.3",
@@ -8021,146 +7627,6 @@
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.22.tgz",
             "integrity": "sha512-yWCr9RoFehpqoe/+MwZXJpYOEIt7KOEvNnjIeMZpMSyQt+KCBASM3y7yViiN5dJRphf1wGdUz1+M4rTtWd/ulA==",
             "dev": true
-        },
-        "esbuild-android-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-            "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-android-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-            "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-darwin-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-            "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-darwin-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-            "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-freebsd-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-            "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-freebsd-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-            "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-32": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-            "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-            "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-arm": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-            "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-            "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-mips64le": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-            "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-ppc64le": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-            "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-riscv64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-            "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-s390x": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-            "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-netbsd-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-            "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-openbsd-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-            "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-sunos-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-            "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-windows-32": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-            "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-windows-64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-            "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-windows-arm64": {
-            "version": "0.14.54",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-            "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-            "dev": true,
-            "optional": true
         },
         "escalade": {
             "version": "3.1.1",
@@ -10188,47 +9654,16 @@
             }
         },
         "vite": {
-            "version": "2.9.18",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
-            "integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.0.tgz",
+            "integrity": "sha512-Dn4B+g54PJsMG5WCc4QeFy1ygMXRdTtFrUPegqfk4+vzVQcbF/DqqmI/1bxezArzbujBJg/67QeT5wz8edfJVQ==",
             "dev": true,
             "requires": {
-                "esbuild": "^0.14.27",
+                "esbuild": "^0.12.17",
                 "fsevents": "~2.3.2",
-                "postcss": "^8.4.13",
-                "resolve": "^1.22.0",
-                "rollup": ">=2.59.0 <2.78.0"
-            },
-            "dependencies": {
-                "esbuild": {
-                    "version": "0.14.54",
-                    "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-                    "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-                    "dev": true,
-                    "requires": {
-                        "@esbuild/linux-loong64": "0.14.54",
-                        "esbuild-android-64": "0.14.54",
-                        "esbuild-android-arm64": "0.14.54",
-                        "esbuild-darwin-64": "0.14.54",
-                        "esbuild-darwin-arm64": "0.14.54",
-                        "esbuild-freebsd-64": "0.14.54",
-                        "esbuild-freebsd-arm64": "0.14.54",
-                        "esbuild-linux-32": "0.14.54",
-                        "esbuild-linux-64": "0.14.54",
-                        "esbuild-linux-arm": "0.14.54",
-                        "esbuild-linux-arm64": "0.14.54",
-                        "esbuild-linux-mips64le": "0.14.54",
-                        "esbuild-linux-ppc64le": "0.14.54",
-                        "esbuild-linux-riscv64": "0.14.54",
-                        "esbuild-linux-s390x": "0.14.54",
-                        "esbuild-netbsd-64": "0.14.54",
-                        "esbuild-openbsd-64": "0.14.54",
-                        "esbuild-sunos-64": "0.14.54",
-                        "esbuild-windows-32": "0.14.54",
-                        "esbuild-windows-64": "0.14.54",
-                        "esbuild-windows-arm64": "0.14.54"
-                    }
-                }
+                "postcss": "^8.3.6",
+                "resolve": "^1.20.0",
+                "rollup": "^2.38.5"
             }
         },
         "vue": {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
     },
     "homepage": "https://discordjs.guide",
     "devDependencies": {
+        "@babel/eslint-parser": "^7.17.0",
         "@vuepress/plugin-docsearch": "^2.0.0-beta.24",
         "@vuepress/plugin-google-analytics": "^2.0.0-beta.24",
         "eslint": "^7.18.0",
         "eslint-config-sora": "^3.1.0",
         "eslint-plugin-markdown": "^1.0.0",
         "eslint-plugin-vue": "^7.5.0",
-        "@babel/eslint-parser": "^7.17.0",
+        "vite": "^2.5.0",
         "vuepress-vite": "^2.0.0-beta.24"
     },
     "dependencies": {


### PR DESCRIPTION
# Pull Request Details

Fix build issues by adding vite@2.5.0 as a devDependency

## Description
- **Issue**:  Encountered an error when running the development server due to an undefined property in the Vite plugin for Vue.
- **Solution**: This commit adds vite@2.5.0 as a devDependency, which resolves the error and allows the development environment to start correctly.

## Steps to Reproduce:
- Clone the repository.
- Run `npm install.`
- Execute `npm run dev.`
Observe the error as [shown](https://discord.com/channels/222078108977594368/1297939200649199626/1297939200649199626) in the help channel of discord.js support server.
```ts
Cannot read properties of undefined (reading 'replace')
8:32:56 pm [vite] Internal server error: Cannot read properties of undefined (reading 'replace')
  Plugin: vite:vue
```
- Testing: After adding the dependency, I confirmed that the development server starts successfully on localhost:8080 without any errors.