### PR TITLE
fix(updating-from-v14): "decoration" typo

### DIFF
--- a/guide/additional-info/updating-from-v14.md
+++ b/guide/additional-info/updating-from-v14.md
@@ -198,7 +198,7 @@ The reason parameter of `ThreadMemberManager#remove()` has been removed. Discord
 
 #### Avatar decoration
 
-Discord no longer sends avatar devoration data via `User#avatarDecoration`, so this property has been removed. `User#avatarDecorationData` is the replacement.
+Discord no longer sends avatar decoration data via `User#avatarDecoration`, so this property has been removed. `User#avatarDecorationData` is the replacement.
 
 #### Flags
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A typo has been fixed.
`devoration` -> `decoration`
