### PR TITLE
refactor(permissions): Note hiding of commands when setting default member permissions

### DIFF
--- a/guide/slash-commands/permissions.md
+++ b/guide/slash-commands/permissions.md
@@ -10,7 +10,7 @@ It is not possible to prevent users with Administrator permissions from using an
 
 ## Member permissions
 
-You can use <DocsLink section="builders" path="SlashCommandBuilder:Class#setDefaultMemberPermissions" type="method" /> to set the default permissions required for a member to run the command. Setting it to `0` will prohibit anyone in a guild from using the command unless a specific overwrite is configured or the user has the Administrator permission flag. This also controls the command's visibility, ensuring that only users with the required permissions can access it.
+You can use <DocsLink section="builders" path="SlashCommandBuilder:Class#setDefaultMemberPermissions" type="method" /> to set the default permissions required for a member to run the command. Setting it to `0` will hide and prohibit anyone in a guild from using the command unless a specific overwrite is configured or the user has the Administrator permission flag.
 
 For this, we'll introduce two common and simple moderation commands: `ban` and `kick`. For a ban command, a sensible default is to ensure that users already have the Discord permission `BanMembers` in order to use it.
 

--- a/guide/slash-commands/permissions.md
+++ b/guide/slash-commands/permissions.md
@@ -10,7 +10,7 @@ It is not possible to prevent users with Administrator permissions from using an
 
 ## Member permissions
 
-You can use <DocsLink section="builders" path="SlashCommandBuilder:Class#setDefaultMemberPermissions" type="method" /> to set the default permissions required for a member to run the command. Setting it to `0` will prohibit anyone in a guild from using the command unless a specific overwrite is configured or the user has the Administrator permission flag.
+You can use <DocsLink section="builders" path="SlashCommandBuilder:Class#setDefaultMemberPermissions" type="method" /> to set the default permissions required for a member to run the command. Setting it to `0` will prohibit anyone in a guild from using the command unless a specific overwrite is configured or the user has the Administrator permission flag. This also controls the command's visibility, ensuring that only users with the required permissions can access it.
 
 For this, we'll introduce two common and simple moderation commands: `ban` and `kick`. For a ban command, a sensible default is to ensure that users already have the Discord permission `BanMembers` in order to use it.
 


### PR DESCRIPTION
### updated `slash-commands/permissions.md`
Added a note regarding command visibility when using `setDefaultMemberPermissions` as adding permissions to a slash command will *hide* the command from users when looking for commands.