### PR TITLE
feat: Quality of life changes under the "Eval arguments" header of the Sharding section

### DIFF
--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -77,14 +77,22 @@ You can access them later as usual via `process.argv`, which contains an array o
 
 ## Eval arguments
 
-There may come the point where you will want to pass arguments from the outer scope into a `.broadcastEval()` call.
+There may come the point where you will want to pass arguments from the outer scope into a `.broadcastEval()` call. The `context` property is useful for this purpose:
 
 ```js
-function funcName(c, { arg }) {
-	// ...
+function funcName(client, context) {
+	console.log(context.arg);
 }
 
-client.shard.broadcastEval(funcName, { context: { arg: 'arg' } });
+//Eval on all shards
+client.shard.broadcastEval(funcName, { 
+	context: { arg: 'arg' } 
+});
+//Eval on a specific shard
+client.shard.broadcastEval(funcName, {
+	shard: 0,
+	context: { arg: 'some stuff' }
+});
 ```
 
 The `BroadcastEvalOptions` typedef was introduced in discord.js v13 as the second parameter in `.broadcastEval()`. It accepts two properties: `shard` and `context`. The `context` property will be sent as the second argument to your function.

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -84,11 +84,11 @@ function funcName(client, context) {
 	console.log(context.arg);
 }
 
-//Eval on all shards
-client.shard.broadcastEval(funcName, { 
-	context: { arg: 'arg' } 
+// Eval on all shards
+client.shard.broadcastEval(funcName, {
+	context: { arg: 'arg' }
 });
-//Eval on a specific shard
+// Eval on a specific shard
 client.shard.broadcastEval(funcName, {
 	shard: 0,
 	context: { arg: 'some stuff' }
@@ -103,4 +103,7 @@ The function will receive the arguments as an object as the second parameter.
 ::: warning
 The `context` option only accepts properties which are JSON-serializable. This means you cannot pass complex data types in the context directly.
 For example, if you sent a `User` instance, the function would receive the raw data object.
+:::
+::: tip
+The [next section](/sharding/extended.md) will go into more detail about various use cases of `.broadcastEval()`
 :::

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -104,6 +104,7 @@ The function will receive the arguments as an object as the second parameter.
 The `context` option only accepts properties which are JSON-serializable. This means you cannot pass complex data types in the context directly.
 For example, if you sent a `User` instance, the function would receive the raw data object.
 :::
+
 ::: tip
 The [next section](/sharding/extended.md) will go into more detail about various use cases of `.broadcastEval()`
 :::


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Reading the content about Sharding, I felt that it takes quite a while for a user who has just been redirected to the "Eval arguments" header from [this link](https://discordjs.guide/sharding/#broadcasteval) to pick up what is going on.

Therefore, the following changes were made to the Eval arguments section:
- changed the name of funcName parameters to make it more clear what is being passed
- Added some newlines to make the usage of .broadcastEval more clear
- Added another sentence to help with the logical flow of the section.
- Added an additional tip that points users to further usage of .broadcastEval

In my opinion it's ready for review. If there are any objections about the changes I've made I'm happy to fix them up.