### PR TITLE
update voice guide encryption dependencies

### DIFF
--- a/guide/voice/README.md
+++ b/guide/voice/README.md
@@ -6,7 +6,11 @@
 
 ### Barebones
 
-To add voice functionality to your discord.js bot, you will need the `@discordjs/voice` package, as well as one of the encryption packages listed below. For example: 
+To add voice functionality to your discord.js bot, you will need the `@discordjs/voice` package. If your system does not support aes-256-gcm you also need one of the encryption packages listed below. For example:
+
+::: tip
+You can verify aes-256-gcm support by running `require('node:crypto').getCiphers().includes('aes-256-gcm')`.
+:::
 
 :::: code-group
 ::: code-group-item npm

--- a/guide/voice/README.md
+++ b/guide/voice/README.md
@@ -50,6 +50,8 @@ This guide assumes you have installed at least one additional dependency – FFm
   - [`sodium-native`](https://www.npmjs.com/package/sodium-native)
   - [`libsodium-wrappers`](https://www.npmjs.com/package/libsodium-wrappers)
   - [`tweetnacl`](https://www.npmjs.com/package/tweetnacl)
+- DAVE Protocol Support
+  - [`@snazzah/davey`](https://www.npmjs.com/package/@snazzah/davey) - to enable end-to-end encryption with the DAVE protocol.
 
 ::: tip
 Outside a development environment, it is recommended for you to use `@discordjs/opus` and `sodium` to improve performance and improve the stability of audio playback!
@@ -88,6 +90,10 @@ bun add --global --production --add-python-to-path windows-build-tools
 </CodeGroup>
 :::
 
+::: warning
+Some Discord clients already require the DAVE protocol for end-to-end encryption in voice chat. Ensure you have `@snazzah/davey` installed to avoid compatibility issues, as `@snazzah/davey` is only set as a dev-dependency for `@discordjs/voice` and may not install in production environments without explicit installation.
+:::
+
 ## Debugging Dependencies
 
 The library includes a helper function that helps you to find out which dependencies you've successfully installed. This information is also very helpful if you ever need to submit an issue on the `@discordjs/voice` issue tracker.
@@ -115,6 +121,9 @@ Encryption Libraries
 FFmpeg
 - version: 4.2.4-1ubuntu0.1
 - libopus: yes
+
+DAVE Protocol
+- @snazzah/davey: 0.1.6
 --------------------------------------------------
 */
 ```
@@ -128,3 +137,5 @@ FFmpeg
 - **FFmpeg**
   - If you want to play audio from many different file types, you will need to have FFmpeg installed.
   - If `libopus` is enabled, you will be able to benefit from increased performance if real-time volume alteration is disabled.
+- **DAVE Protocol**
+  - Required for enabling end-to-end encryption in voice channels.


### PR DESCRIPTION
Seems that we might need a few updates here for the voice guides.

- There is support for the DAVE protocol, some users might be interested and it should show as an option.
- Same goes for `generateDependencyReport` output in the guide.
- Added warning about `@snazzah/davey` being a dev dependency, this could confuse some devs.
- We now support `node:crypto`, updated the section about the requirement to install encryption library and a tip to verify the system support.

Support for DAVE protocol was added here https://github.com/discordjs/discord.js/issues/10735
Please note that I discovered this while I got repeated crashes due to discord not downgrading my connection to a non e2ee connection!
Discord mention this in a past blog post [here](https://discord.com/developers/docs/change-log#voice-endtoend-encryption-dave-protocol) and it seems like this is about to be a requirement.